### PR TITLE
Taskbar UI enhancements

### DIFF
--- a/LLPlayer/Controls/FlyleafBar.xaml
+++ b/LLPlayer/Controls/FlyleafBar.xaml
@@ -159,7 +159,7 @@
                     </Button.Style>
                 </Button>
 
-                <Button Click="ButtonBase_OnClick" Grid.Column="3" Foreground="{DynamicResource MaterialDesignBody}" Content="{materialDesign:PackIcon Kind=VolumeMedium}" ToolTip="Audio Streams">
+                <Button Click="ButtonBase_OnClick" Grid.Column="3" Foreground="{DynamicResource MaterialDesignBody}" Content="{materialDesign:PackIcon Kind=MusicBoxOutline}" ToolTip="Audio Streams">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource IconButton}">
                             <Setter Property="ContextMenu">

--- a/LLPlayer/Controls/FlyleafBar.xaml
+++ b/LLPlayer/Controls/FlyleafBar.xaml
@@ -288,7 +288,18 @@ Right Click: Open Context Menu</ToolTip>
                 <Button Grid.Column="9" Style="{StaticResource IconButton}" Content="{materialDesign:PackIcon Kind=SettingsOutline}" Command="{Binding FL.Action.CmdOpenWindowSettings}" ToolTip="Open Settings"/>
 
                 <!-- Toggle Sub Sidebar -->
-                <Button Grid.Column="10" Style="{StaticResource IconButton}" Content="{materialDesign:PackIcon Kind=DockRight}" Command="{Binding FL.Action.CmdToggleSidebar}" ToolTip="Toggle Sub Sidebar"/>
+                <Button Grid.Column="10" Command="{Binding FL.Action.CmdToggleSidebar}" ToolTip="Toggle Sub Sidebar">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource IconButton}">
+                            <Setter Property="Content" Value="{materialDesign:PackIcon Kind=DockRight}"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding FL.Config.SidebarLeft}" Value="True">
+                                    <Setter Property="Content" Value="{materialDesign:PackIcon Kind=DockLeft}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
 
                 <!-- Toggle Fullscreen Button -->
                 <ToggleButton Grid.Column="11" Style="{StaticResource MaterialDesignActionToggleButton}" Foreground="{DynamicResource MaterialDesign.Brush.Primary}" Background="Transparent" Focusable="False" IsChecked="{Binding FL.Player.Host.IsFullScreen}" Content="{materialDesign:PackIcon Kind=Fullscreen, Size=28}" materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon Kind=FullscreenExit, Size=28}" ToolTip="Toggle Fullscreen"/>

--- a/LLPlayer/Resources/PopupMenu.xaml
+++ b/LLPlayer/Resources/PopupMenu.xaml
@@ -336,7 +336,7 @@ AncestorType={x:Type MenuItem}}}">
 
         <Separator />
 
-        <MenuItem Header="Audio" Icon="{materialDesign:PackIcon Kind=VolumeMedium}">
+        <MenuItem Header="Audio" Icon="{materialDesign:PackIcon Kind=MusicBoxOutline}">
             <MenuItem Header="Enabled" IsCheckable="True" IsChecked="{Binding FL.PlayerConfig.Audio.Enabled}"/>
             <MenuItem Header="{Binding FL.PlayerConfig.Audio.Delay, Converter={StaticResource TicksToMilliSecondsConv}}" HeaderStringFormat="Delay ({0})">
                 <MenuItem Header="Reset..." CommandParameter="0" Command="{Binding FL.Player.Commands.AudioDelaySet}"/>


### PR DESCRIPTION
**1. Changed icon for "Audio Streams" button both in taskbar and popup menu. The new icon removes ambiguity and better matches the style of adjacent buttons.**

![MBYziGExOc](https://github.com/user-attachments/assets/6c89e6a3-e969-41dc-8e0e-33b85f24781d)

**2. "Toggle Sidebar" button changes it's icon according to chosen position**

![image](https://github.com/user-attachments/assets/b798e200-d716-4817-84a9-44b215da0530)
![image](https://github.com/user-attachments/assets/9fb60808-146d-460f-9944-57e9f95bfba7)

Also, there are some possible improvements I'd like to discuss first

**1. Set original margin values for title element**
I've discovered that in newer version extra top margin for title element was added.
https://github.com/umlx5h/LLPlayer/blob/e8b8e48126e2fae49f9a0568cadcb8c43ca27793/LLPlayer/Controls/FlyleafBar.xaml#L216

So it doesn't look vertically centered.

![image](https://github.com/user-attachments/assets/7cfd94ba-1826-4a8c-9329-0e1c35c8ce25)

In my opinion, top margin set to 0 looks better.

![image](https://github.com/user-attachments/assets/1d910184-8146-4d76-8049-5600214cc3e1)

If there were some technical reasons for setting such a value, then fine.

**2. Move "Open Next" and "Open Prev" buttons from Context Menu to taskbar**
I suggest to place it right after "Play/Pause" button. Although, there is caveat. In original Flyleaf layout there are buttons for "Next/Prev Playlist Item" which appears only when playlist opened.

![image](https://github.com/user-attachments/assets/cd629860-b911-4f76-99b5-9bcd224cf252)

So I think would be ok, if original buttons would have outlined icons unlike "Open Next/Prev" to reduce ambiguity. Also, "Open Next/Prev" buttons could be hidden when playlist opened.

![image](https://github.com/user-attachments/assets/fe95fd99-cab8-4942-becd-556c523de371)
