### PR TITLE
 Update FlyleafLib v3.8.4

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -1345,7 +1345,7 @@ public class EngineConfig
     /// Main<br/>
     /// </summary>
     public LoadProfile
-                    FFmpegLoadProfile       { get; set; } = LoadProfile.All;
+                    FFmpegLoadProfile       { get; set; } = LoadProfile.Filters; // change default to disable devices
 
     /// <summary>
     /// Whether to allow HLS live seeking (this can cause segmentation faults in case of incompatible ffmpeg version with library's custom structures)

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FlyleafLib.Controls.WPF;
 using FlyleafLib.MediaFramework.MediaDecoder;
 using FlyleafLib.MediaFramework.MediaFrame;
@@ -22,6 +23,8 @@ namespace FlyleafLib;
 /// </summary>
 public class Config : NotifyPropertyChanged
 {
+    static JsonSerializerOptions jsonOpts = new() { WriteIndented = true };
+
     public Config()
     {
         // Parse default plugin options to Config.Plugins (Creates instances until fix with statics in interfaces)
@@ -68,6 +71,9 @@ public class Config : NotifyPropertyChanged
         Config config       = JsonSerializer.Deserialize<Config>(File.ReadAllText(path), jsonOptions);
         config.Loaded       = true;
         config.LoadedPath   = path;
+
+        if (config.Audio.FiltersEnabled && Engine.Config.FFmpegLoadProfile == LoadProfile.Main)
+            config.Audio.FiltersEnabled = false;
 
         // TODO: L: refactor
         config.Player.config = config;
@@ -131,7 +137,7 @@ public class Config : NotifyPropertyChanged
             path = LoadedPath;
         }
 
-        jsonOptions ??= new JsonSerializerOptions { WriteIndented = true };
+        jsonOptions ??= jsonOpts;
 
         File.WriteAllText(path, JsonSerializer.Serialize(this, jsonOptions));
     }
@@ -876,7 +882,7 @@ public class Config : NotifyPropertyChanged
         /// 1. Requires FFmpeg avfilter lib<br/>
         /// 2. Currently SWR performs better if you dont need filters<br/>
         /// </summary>
-        public bool             FiltersEnabled      { get => _FiltersEnabled; set { if (Set(ref _FiltersEnabled, value && Engine.FFmpeg.FiltersLoaded)) player?.AudioDecoder.SetupFiltersOrSwr(); } }
+        public bool             FiltersEnabled      { get => _FiltersEnabled; set { if (Set(ref _FiltersEnabled, value && Engine.Config.FFmpegLoadProfile != LoadProfile.Main)) player?.AudioDecoder.SetupFiltersOrSwr(); } }
         bool _FiltersEnabled = false;
 
         /// <summary>
@@ -1333,14 +1339,13 @@ public class EngineConfig
     public string   FFmpegPath              { get; set; } = "FFmpeg";
 
     /// <summary>
-    /// <para>Whether to register av devices or not (gdigrab/dshow/etc.)</para>
-    /// <para>When enabled you can pass urls in this format device://[device_name]?[FFmpeg_Url]</para>
-    /// <para>device://gdigrab?desktop</para>
-    /// <para>device://gdigrab?title=Command Prompt</para>
-    /// <para>device://dshow?video=Lenovo Camera</para>
-    /// <para>device://dshow?audio=Microphone (Relatek):video=Lenovo Camera</para>
+    /// <para>Can be used to choose which FFmpeg libs to load</para>
+    /// All (Devices &amp; Filters)<br/>
+    /// Filters<br/>
+    /// Main<br/>
     /// </summary>
-    public bool     FFmpegDevices           { get; set; }
+    public LoadProfile
+                    FFmpegLoadProfile       { get; set; } = LoadProfile.All;
 
     /// <summary>
     /// Whether to allow HLS live seeking (this can cause segmentation faults in case of incompatible ffmpeg version with library's custom structures)

--- a/FlyleafLib/Engine/Engine.FFmpeg.cs
+++ b/FlyleafLib/Engine/Engine.FFmpeg.cs
@@ -5,9 +5,6 @@ public class FFmpegEngine
     public string   Folder          { get; private set; }
     public string   Version         { get; private set; }
 
-    public bool     FiltersLoaded   { get; set; }
-    public bool     DevicesLoaded   { get; set; }
-
     const int           AV_LOG_BUFFER_SIZE = 5 * 1024;
     internal AVRational AV_TIMEBASE_Q;
 
@@ -17,17 +14,14 @@ public class FFmpegEngine
         {
             Engine.Log.Info($"Loading FFmpeg libraries from '{Engine.Config.FFmpegPath}'");
             Folder = Utils.GetFolderPath(Engine.Config.FFmpegPath);
-            LoadLibraries(Folder, Engine.Config.FFmpegDevices ? LoadProfile.All : LoadProfile.Filters);
-
-            FiltersLoaded = true; // Possible allow only main profile?
-            DevicesLoaded = Engine.Config.FFmpegDevices;
+            LoadLibraries(Folder, Engine.Config.FFmpegLoadProfile);
 
             uint ver = avformat_version();
             Version = $"{ver >> 16}.{(ver >> 8) & 255}.{ver & 255}";
 
             SetLogLevel();
             AV_TIMEBASE_Q   = av_get_time_base_q();
-            Engine.Log.Info($"FFmpeg Loaded (Location: {Folder}, Ver: {Version}) [Devices: {(DevicesLoaded ? "yes" : "no")}, Filters: {(FiltersLoaded ? "yes" : "no")}]");
+            Engine.Log.Info($"FFmpeg Loaded (Profile: {Engine.Config.FFmpegLoadProfile}, Location: {Folder}, FmtVer: {Version})");
         } catch (Exception e)
         {
             Engine.Log.Error($"Loading FFmpeg libraries '{Engine.Config.FFmpegPath}' failed\r\n{e.Message}\r\n{e.StackTrace}");

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -144,7 +144,7 @@ public static class Engine
         Log = new LogHandler("[FlyleafEngine] ");
 
         Audio = new AudioEngine();
-        if (Config.FFmpegDevices)
+        if (Config.FFmpegLoadProfile == LoadProfile.All)
             AudioDevice.RefreshDevices();
     }
 
@@ -155,7 +155,7 @@ public static class Engine
 
         FFmpeg  = new FFmpegEngine();
         Video   = new VideoEngine();
-        if (Config.FFmpegDevices)
+        if (Config.FFmpegLoadProfile == LoadProfile.All)
             VideoDevice.RefreshDevices();
         Plugins = new PluginsEngine();
         Players = new List<Player>();

--- a/FlyleafLib/Engine/Language.cs
+++ b/FlyleafLib/Engine/Language.cs
@@ -2,7 +2,6 @@
 using System.Globalization;
 using System.Linq;
 using System.Text.Json.Serialization;
-using System.Windows;
 
 namespace FlyleafLib;
 

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.3</Version>
+    <Version>3.8.4</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
@@ -207,7 +207,7 @@ public unsafe partial class AudioDecoder
             if (Disposed)
                 return ret;
 
-            if (Config.Audio.FiltersEnabled && Engine.FFmpeg.FiltersLoaded)
+            if (Config.Audio.FiltersEnabled)
             {
                 ret = SetupFilters();
 
@@ -236,9 +236,12 @@ public unsafe partial class AudioDecoder
     }
     public int ReloadFilters()
     {
+        if (!Config.Audio.FiltersEnabled)
+            return -1;
+
         lock (lockActions)
             lock (lockCodecCtx)
-                return !Engine.FFmpeg.FiltersLoaded || Config.Audio.FiltersEnabled ? -1 : SetupFilters();
+                return SetupFilters();
     }
 
     private void ProcessFilters()

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -625,7 +625,7 @@ public unsafe class VideoDecoder : DecoderBase
 
             avcodec_parameters_from_context(Stream.AVStream->codecpar, codecCtx);
             VideoStream.AVStream->time_base = codecCtx->pkt_timebase;
-            VideoStream.Refresh(codecCtx->sw_pix_fmt != AVPixelFormat.None ? codecCtx->sw_pix_fmt : codecCtx->pix_fmt, frame);
+            VideoStream.Refresh(VideoAccelerated && codecCtx->sw_pix_fmt != AVPixelFormat.None ? codecCtx->sw_pix_fmt : codecCtx->pix_fmt, frame);
 
             if (!(VideoStream.FPS > 0)) // NaN
             {

--- a/FlyleafLib/MediaFramework/MediaPlaylist/PlaylistItem.cs
+++ b/FlyleafLib/MediaFramework/MediaPlaylist/PlaylistItem.cs
@@ -15,37 +15,31 @@ public class PlaylistItem : DemuxerInput
     /// </summary>
     public string   DirectUrl               { get; set; }
 
-    //public IOpen    OpenPlugin      { get; set; }
-
     /// <summary>
     /// Relative folder to playlist's folder base (can be empty, not null)
     /// Use Path.Combine(Playlist.FolderBase, Folder) to get absolute path for saving related files with the current selection item (such as subtitles)
     /// </summary>
     public string   Folder                  { get; set; } = "";
 
-
-    //public long     StoppedAt               { get; set; }
-    //public long     SubtitlesDelay          { get; set; }
-    //public long     AudioDelay              { get; set; }
-
-    /// <summary>
-    /// Item's file size
-    /// </summary>
     public long     FileSize                { get; set; }
 
     /// <summary>
-    /// Item's title
-    /// (can be updated from scrapers)
+    /// Usually just the filename part of the provided Url
     /// </summary>
-    public string   Title                   { get => _Title; set { if (_Title == "") OriginalTitle = value; SetUI(ref _Title, value ?? "", false);} }
-    string _Title = "";
+    public string   OriginalTitle           { get => _OriginalTitle;set => SetUI(ref _OriginalTitle, value ?? "", false); }
+    string _OriginalTitle = "";
 
     /// <summary>
-    /// Item's original title
-    /// (setted by opened plugin)
+    /// Movie/TVShow Title
     /// </summary>
-    public string   OriginalTitle           { get => _OriginalTitle; set => SetUI(ref _OriginalTitle, value ?? "", false); }
-    string _OriginalTitle = "";
+    public string   MediaTitle              { get => _MediaTitle;   set => SetUI(ref _MediaTitle, value ?? "", false); }
+    string _MediaTitle = "";
+
+    /// <summary>
+    /// Movie/TVShow Title including Movie's Year or TVShow's Season/Episode
+    /// </summary>
+    public string   Title                   { get => _Title;        set { if (_Title == "") OriginalTitle = value; SetUI(ref _Title, value ?? "", false);} }
+    string _Title = "";
 
     public List<Demuxer.Chapter>
                     Chapters                { get; set; } = new();
@@ -55,17 +49,15 @@ public class PlaylistItem : DemuxerInput
     public int      Year                    { get; set; }
 
     public Dictionary<string, object>
-                    Tag                     { get; set; } = new Dictionary<string, object>();
+                    Tag                     { get; set; } = [];
     public void AddTag(object tag, string pluginName)
     {
-        if (Tag.ContainsKey(pluginName))
+        if (!Tag.TryAdd(pluginName, tag))
             Tag[pluginName] = tag;
-        else
-            Tag.Add(pluginName, tag);
     }
 
     public object GetTag(string pluginName)
-        => Tag.ContainsKey(pluginName) ? Tag[pluginName] : null;
+        => Tag.TryGetValue(pluginName, out object value) ? value : null;
 
     public bool     SearchedLocal           { get; set; }
     public bool     SearchedOnline          { get; set; }
@@ -86,33 +78,60 @@ public class PlaylistItem : DemuxerInput
                                             { get; set; } = new ExternalSubtitlesStream[2];
 
     public ObservableCollection<ExternalVideoStream>
-                    ExternalVideoStreams    { get; set; } = new ObservableCollection<ExternalVideoStream>();
+                    ExternalVideoStreams    { get; set; } = [];
     public ObservableCollection<ExternalAudioStream>
-                    ExternalAudioStreams    { get; set; } = new ObservableCollection<ExternalAudioStream>();
+                    ExternalAudioStreams    { get; set; } = [];
     public ObservableCollection<ExternalSubtitlesStream>
-                    ExternalSubtitlesStreamsAll{ get; set; } = new ObservableCollection<ExternalSubtitlesStream>();
+                    ExternalSubtitlesStreamsAll
+                                            { get; set; } = [];
     internal object lockExternalStreams = new();
 
-    public void AddExternalStream(ExternalStream extStream, PlaylistItem item, string pluginName, object tag = null)
+    bool filled;
+    public void FillMediaParts() // Called during OpenScrape (if file) & Open/Search Subtitles (to be able to search online and compare tvshow/movie properly)
+    {
+        if (filled)
+            return;
+
+        filled      = true;
+        var mp      = Utils.GetMediaParts(OriginalTitle);
+        Year        = mp.Year;
+        Season      = mp.Season;
+        Episode     = mp.Episode;
+        MediaTitle  = mp.Title; // safe title to check with online subs
+
+        if (mp.Season > 0 && mp.Episode > 0) // tvshow
+        {
+            var title = "S";
+            title += Season > 9 ? Season : $"0{Season}";
+            title += "E";
+            title += Episode > 9 ? Episode : $"0{Episode}";
+
+            Title = mp.Title == "" ? title : mp.Title + " (" + title + ")";
+        }
+        else if (mp.Year > 0) // movie
+            Title = mp.Title + " (" + mp.Year + ")";
+    }
+
+    public static void AddExternalStream(ExternalStream extStream, PlaylistItem item, string pluginName, object tag = null)
     {
         lock (item.lockExternalStreams)
         {
             extStream.PlaylistItem = item;
             extStream.PluginName = pluginName;
 
-            if (extStream is ExternalAudioStream)
+            if (extStream is ExternalAudioStream astream)
             {
-                item.ExternalAudioStreams.Add((ExternalAudioStream)extStream);
+                item.ExternalAudioStreams.Add(astream);
                 extStream.Index = item.ExternalAudioStreams.Count - 1;
             }
-            else if (extStream is ExternalVideoStream)
+            else if (extStream is ExternalVideoStream vstream)
             {
-                item.ExternalVideoStreams.Add((ExternalVideoStream)extStream);
+                item.ExternalVideoStreams.Add(vstream);
                 extStream.Index = item.ExternalVideoStreams.Count - 1;
             }
-            else if (extStream is ExternalSubtitlesStream)
+            else if (extStream is ExternalSubtitlesStream sstream)
             {
-                item.ExternalSubtitlesStreamsAll.Add((ExternalSubtitlesStream)extStream);
+                item.ExternalSubtitlesStreamsAll.Add(sstream);
                 extStream.Index = item.ExternalSubtitlesStreamsAll.Count - 1;
             }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
 using System.Text.Json.Serialization;
-
 using Vortice.DXGI;
 using Vortice.Direct3D11;
 

--- a/FlyleafLib/Plugins/PluginBase.cs
+++ b/FlyleafLib/Plugins/PluginBase.cs
@@ -47,7 +47,8 @@ public abstract class PluginBase : PluginType, IPlugin
     {
         item ??= Playlist.Selected;
 
-        item?.AddExternalStream(extStream, item, Name, tag);
+        if (item != null)
+            PlaylistItem.AddExternalStream(extStream, item, Name, tag);
     }
 
     public void AddPlaylistItem(PlaylistItem item, object tag = null)

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -254,7 +254,13 @@ public static partial class Utils
         return dump;
     }
     public static string GetUrlExtention(string url)
-        => url.LastIndexOf(".") > 0 ? url[(url.LastIndexOf(".") + 1)..].ToLower() : "";
+    {
+        int index;
+        if ((index = url.LastIndexOf('.')) > 0)
+            return url[(index + 1)..].ToLower();
+
+        return "";
+    }
 
     public static List<Language> GetSystemLanguages()
     {
@@ -281,27 +287,25 @@ public static partial class Utils
 
     public class MediaParts
     {
-        public int Season { get; set; }
-        public int Episode { get; set; }
-        public string Title { get; set; }
-        public int Year { get; set; }
+        public string   Title       { get; set; } = "";
+        public string   Extension   { get; set; } = "";
+        public int      Season      { get; set; }
+        public int      Episode     { get; set; }
+        public int      Year        { get; set; }
     }
-    public static MediaParts GetMediaParts(string title, bool movieOnly = false)
+    public static MediaParts GetMediaParts(string title, bool checkSeasonEpisodeOnly = false)
     {
         Match res;
         MediaParts mp = new();
-        List<int> indices = new();
+        int index = int.MaxValue; // title end pos
 
-        // s|season 01 ... e|episode|part 01
-        res = Regex.Match(title, @"(^|[^a-z0-9])(s|season)[^a-z0-9]*(?<season>[0-9]{1,2})[^a-z0-9]*(e|episode|part)[^a-z0-9]*(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase);
+        res = RxSeasonEpisode1().Match(title);
         if (!res.Success)
         {
-            // 01x01
-            res = Regex.Match(title, @"(^|[^a-z0-9])(?<season>[0-9]{1,2})x(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase);
+            res = RxSeasonEpisode2().Match(title);
 
-            // TODO: in case of single season should check only for e|episode|part 01
             if (!res.Success)
-                res = Regex.Match(title, @"(^|[^a-z0-9])(episode|part)[^a-z0-9]*(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase);
+                res = RxEpisodePart().Match(title);
         }
 
         if (res.Groups.Count > 1)
@@ -312,37 +316,44 @@ public static partial class Utils
             if (res.Groups["episode"].Value != "")
                 mp.Episode = int.Parse(res.Groups["episode"].Value);
 
-            if (movieOnly)
+            if (checkSeasonEpisodeOnly || res.Index == 0) // 0: No title just season/episode
                 return mp;
 
-            indices.Add(res.Index);
+            index = res.Index;
         }
+
+        mp.Extension = GetUrlExtention(title);
+        if (mp.Extension.Length > 0 && mp.Extension.Length < 5)
+            title = title[..(title.Length - mp.Extension.Length - 1)];
 
         // non-movie words, 1080p, 2015
-        indices.Add(Regex.Match(title, "[^a-z0-9]extended", RegexOptions.IgnoreCase).Index);
-        indices.Add(Regex.Match(title, "[^a-z0-9]directors.cut", RegexOptions.IgnoreCase).Index);
-        indices.Add(Regex.Match(title, "[^a-z0-9]brrip", RegexOptions.IgnoreCase).Index);
-        indices.Add(Regex.Match(title, "[^a-z0-9][0-9]{3,4}p", RegexOptions.IgnoreCase).Index);
+        if ((res = RxExtended().Match(title)).Index > 0 && res.Index < index)
+            index = res.Index;
 
-        res = Regex.Match(title, @"[^a-z0-9](?<year>(19|20)[0-9][0-9])($|[^a-z0-9])", RegexOptions.IgnoreCase);
-        if (res.Success)
+        if ((res = RxDirectorsCut().Match(title)).Index > 0 && res.Index < index)
+            index = res.Index;
+
+        if ((res = RxBrrip().Match(title)).Index > 0 && res.Index < index)
+            index = res.Index;
+
+        if ((res = RxResolution().Match(title)).Index > 0 && res.Index < index)
+            index = res.Index;
+
+        res = RxYear().Match(title);
+        Group gc;
+        if (res.Success && (gc = res.Groups["year"]).Index > 2)
         {
-            indices.Add(res.Index);
-            mp.Year = int.Parse(res.Groups["year"].Value);
+            mp.Year = int.Parse(gc.Value);
+            if (res.Index < index)
+                index = res.Index;
         }
 
-        var sorted = indices.OrderBy(x => x);
-
-        foreach (int index in sorted)
-            if (index > 0)
-            {
-                title = title[..index];
-                break;
-            }
+        if (index != int.MaxValue)
+            title = title[..index];
 
         title = title.Replace(".", " ").Replace("_", " ");
-        title = Regex.Replace(title, @"\s{2,}", " ");
-        title = Regex.Replace(title, @"[^a-z0-9]$", "", RegexOptions.IgnoreCase);
+        title = RxSpaces().Replace(title, " ");
+        title = RxNonAlphaNumeric().Replace(title, "");
 
         mp.Title = title.Trim();
 
@@ -651,6 +662,32 @@ public static partial class Utils
     public static int GCD(int a, int b) => b == 0 ? a : GCD(b, a % b);
     public static string TicksToTime(long ticks) => new TimeSpan(ticks).ToString();
     public static void Log(string msg) { try { Debug.WriteLine($"[{DateTime.Now:hh.mm.ss.fff}] {msg}"); } catch (Exception) { Debug.WriteLine($"[............] [MediaFramework] {msg}"); } }
+
+    [GeneratedRegex("[^a-z0-9]extended", RegexOptions.IgnoreCase)]
+    private static partial Regex RxExtended();
+    [GeneratedRegex("[^a-z0-9]directors.cut", RegexOptions.IgnoreCase)]
+    private static partial Regex RxDirectorsCut();
+    [GeneratedRegex(@"(^|[^a-z0-9])(s|season)[^a-z0-9]*(?<season>[0-9]{1,2})[^a-z0-9]*(e|episode|part)[^a-z0-9]*(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase)]
+
+    // s|season 01 ... e|episode|part 01
+    private static partial Regex RxSeasonEpisode1();
+    [GeneratedRegex(@"(^|[^a-z0-9])(?<season>[0-9]{1,2})x(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase)]
+    // 01x01
+    private static partial Regex RxSeasonEpisode2();
+    // TODO: in case of single season should check only for e|episode|part 01
+    [GeneratedRegex(@"(^|[^a-z0-9])(episode|part)[^a-z0-9]*(?<episode>[0-9]{1,2})($|[^a-z0-9])", RegexOptions.IgnoreCase)]
+    private static partial Regex RxEpisodePart();
+    [GeneratedRegex("[^a-z0-9]brrip", RegexOptions.IgnoreCase)]
+    private static partial Regex RxBrrip();
+
+    [GeneratedRegex("[^a-z0-9][0-9]{3,4}p", RegexOptions.IgnoreCase)]
+    private static partial Regex RxResolution();
+    [GeneratedRegex(@"[^a-z0-9](?<year>(19|20)[0-9][0-9])($|[^a-z0-9])", RegexOptions.IgnoreCase)]
+    private static partial Regex RxYear();
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex RxSpaces();
+    [GeneratedRegex(@"[^a-z0-9]$", RegexOptions.IgnoreCase)]
+    private static partial Regex RxNonAlphaNumeric();
 
     public static string TruncateString(string str, int maxLength, string suffix = "...")
     {

--- a/LLPlayer/Controls/Settings/SettingsPlayer.xaml
+++ b/LLPlayer/Controls/Settings/SettingsPlayer.xaml
@@ -27,6 +27,12 @@
                 <x:Type TypeName="ffmpeg:LogLevel"/>
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+
+        <ObjectDataProvider x:Key="FFmpegLoadProfileEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="ffmpeg:LoadProfile"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
     </UserControl.Resources>
     <ScrollViewer>
         <StackPanel>
@@ -212,18 +218,6 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Header="FFmpeg">
-                <StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Width="180"
-                            Text="Enable FFmpeg devices" />
-                        <ToggleButton
-                            IsChecked="{Binding FL.ConfigEngine.FFmpegDevices}" />
-                    </StackPanel>
-                </StackPanel>
-            </GroupBox>
-
             <GroupBox Header="Seek">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal">
@@ -295,6 +289,20 @@
                             Width="100"
                             Text="{Binding FL.ConfigEngine.LogCachedLines}"
                             helpers:TextBoxHelper.OnlyNumeric="Uint" />
+                    </StackPanel>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="FFmpeg">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock
+                            Width="180"
+                            Text="FFmpeg Load Profile" />
+                        <ComboBox
+                            Width="100"
+                            ItemsSource="{Binding Source={StaticResource FFmpegLoadProfileEnum}}"
+                            SelectedItem="{Binding FL.ConfigEngine.FFmpegLoadProfile}" />
                     </StackPanel>
                 </StackPanel>
             </GroupBox>

--- a/LLPlayer/Services/FlyleafLoader.cs
+++ b/LLPlayer/Services/FlyleafLoader.cs
@@ -107,6 +107,7 @@ public static class FlyleafLoader
             FFmpegPath = ":FFmpeg",
             FFmpegHLSLiveSeek = true,
             UIRefresh = true,
+            FFmpegLoadProfile = Flyleaf.FFmpeg.LoadProfile.All,
 #if DEBUG
             LogOutput = ":debug",
             LogLevel = LogLevel.Debug,

--- a/LLPlayer/Services/FlyleafLoader.cs
+++ b/LLPlayer/Services/FlyleafLoader.cs
@@ -107,7 +107,7 @@ public static class FlyleafLoader
             FFmpegPath = ":FFmpeg",
             FFmpegHLSLiveSeek = true,
             UIRefresh = true,
-            FFmpegLoadProfile = Flyleaf.FFmpeg.LoadProfile.All,
+            FFmpegLoadProfile = Flyleaf.FFmpeg.LoadProfile.Filters,
 #if DEBUG
             LogOutput = ":debug",
             LogLevel = LogLevel.Debug,

--- a/Plugins/YoutubeDL/YoutubeDL.cs
+++ b/Plugins/YoutubeDL/YoutubeDL.cs
@@ -458,13 +458,13 @@ namespace FlyleafLib.Plugins
                 if (Playlist.IOStream != null)
                     return false;
 
-                Uri uri = new Uri(Playlist.Url);
+                Uri uri = new(Playlist.Url);
                 string scheme = uri.Scheme.ToLower();
 
                 if (scheme != "http" && scheme != "https")
                     return false;
 
-                string ext = Utils.GetUrlExtention(uri.AbsolutePath);
+                string ext = GetUrlExtention(uri.AbsolutePath);
 
                 if (ext == "m3u8" || ext == "mp3" || ext == "m3u" || ext == "pls")
                     return false;
@@ -593,9 +593,9 @@ namespace FlyleafLib.Plugins
                     return Open();
                 }
             }
-            catch (Exception e) { Log.Error($"Open ({e.Message})"); return new OpenResults(e.Message); }
+            catch (Exception e) { Log.Error($"Open ({e.Message})"); return new(e.Message); }
 
-            return new OpenResults();
+            return new();
         }
 
         public OpenResults OpenItem()
@@ -603,25 +603,31 @@ namespace FlyleafLib.Plugins
 
         public ExternalAudioStream SuggestExternalAudio()
         {
-            if (Handler.OpenedPlugin == null || Handler.OpenedPlugin.Name != Name) return null;
+            if (Handler.OpenedPlugin == null || Handler.OpenedPlugin.Name != Name)
+                return null;
 
             var fmt = GetAudioOnly((YoutubeDLJson)GetTag(Selected));
-            if (fmt == null) return null;
+            if (fmt == null)
+                return null;
 
             foreach (var extStream in Selected.ExternalAudioStreams)
-                if (fmt.url == extStream.Url) return extStream;
+                if (fmt.url == extStream.Url)
+                    return extStream;
 
             return null;
         }
         public ExternalVideoStream SuggestExternalVideo()
         {
-            if (Handler.OpenedPlugin == null || Handler.OpenedPlugin.Name != Name) return null;
+            if (Handler.OpenedPlugin == null || Handler.OpenedPlugin.Name != Name)
+                return null;
 
             Format fmt = GetBestMatch((YoutubeDLJson)GetTag(Selected));
-            if (fmt == null) return null;
+            if (fmt == null)
+                return null;
 
             foreach (var extStream in Selected.ExternalVideoStreams)
-                if (fmt.url == extStream.Url) return extStream;
+                if (fmt.url == extStream.Url)
+                    return extStream;
 
             return null;
         }


### PR DESCRIPTION
Update FlyleafLib v3.8.4 from v3.8.3

## Changelog

- AudioDecoder: Fixes an issue with ReloadFilters()
- VideoDecoder: Fixes an issue with PixelFormat (while software decoding and codec wrongly sets sw_pix_fmt, use pix_fmt instead)
- Demuxer: Fixes an issue with BitmapSubtitles auto-increase of analyseduration/probesize [Fixes #502]
- Engine.Config: Replaces FFmpegDevices with FFmpegLoadProfile (which by default requires/loads all FFmpeg libs) [Fixes #581]

- PlaylistItem: Introduces MediaTitle for Movies/TVShows
- Plugins.OpenDefault: Sets PlaylistItem's OrignalTitle/Title to filename (without removing any parts) in case of non-Movie/TVShow
- Plugins.OpenSubtitles: Sets ExternalSubtitlesStream's Title to filename (without removing any parts)

- Solution: Few code clean-ups and performance improvements

[Breaking Changes]
- Engine.Config: Deprecates FFmpegDevices
- Engine.FFmpeg: Deprecates DevicesLoaded/FiltersLoaded


New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/c0e719f2df02f87c1316942d8a11f423f904e3de...68387759e656e3acdcecb0cd9eca3a2441ae69f7