### PR TITLE
Update FlyleafLib v3.8.6

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -1,16 +1,16 @@
 ﻿using System.ComponentModel;
-using System.Windows.Controls;
 using System.Windows;
-using System.Windows.Media;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 
-using FlyleafLib.MediaPlayer;
+using Brushes = System.Windows.Media.Brushes;
 
 using static FlyleafLib.Utils;
 using static FlyleafLib.Utils.NativeMethods;
 
-using Brushes = System.Windows.Media.Brushes;
+using FlyleafLib.MediaPlayer;
 
 namespace FlyleafLib.Controls.WPF;
 
@@ -98,39 +98,61 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     public int          UniqueId        { get; private set; }
     public bool         Disposed        { get; private set; }
 
+    public double       DpiX            { get; private set
+        {
+            field = value;
+            // copy to global variable
+            NativeMethods.DpiX = value;
+        }
+    } = 1;
+    public double       DpiY            { get; private set
+        {
+            field = value;
+            NativeMethods.DpiY = value;
+        }
+    } = 1;
+    public double       DpiXSource      { get; private set
+        {
+            field = value;
+            NativeMethods.DpiXSource = value;
+        }
+    } = 96;
+    public double       DpiYSource      { get; private set
+        {
+            field = value;
+            NativeMethods.DpiYSource = value;
+        }
+    } = 96;
 
-    public event EventHandler SurfaceCreated;
-    public event EventHandler OverlayCreated;
-    public event DragEventHandler OnSurfaceDrop;
-    public event DragEventHandler OnOverlayDrop;
+    public event EventHandler       SurfaceCreated;
+    public event EventHandler       OverlayCreated;
+    public event DragEventHandler   OnSurfaceDrop;
+    public event DragEventHandler   OnOverlayDrop;
 
     static bool isDesignMode;
     static int  idGenerator = 1;
     static nint NONE_STYLE = (nint) (WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE); // WS_MINIMIZEBOX required for swapchain
-    static Rect rectRandom = new(1, 2, 3, 4);
 
-    float curResizeRatio;
-    float curResizeRatioIfEnabled;
-    bool surfaceClosed, surfaceClosing, overlayClosed;
-    int panPrevX, panPrevY;
-    bool isMouseBindingsSubscribedSurface;
-    bool isMouseBindingsSubscribedOverlay;
-    Window standAloneOverlay;
+    float   curResizeRatio;
+    float   curResizeRatioIfEnabled;
+    bool    surfaceClosed, surfaceClosing, overlayClosed;
+    int     panPrevX, panPrevY;
+    bool    isMouseBindingsSubscribedSurface;
+    bool    isMouseBindingsSubscribedOverlay;
+    Window  standAloneOverlay;
 
     CornerRadius zeroCornerRadius = new(0);
-    Point zeroPoint = new(0, 0);
-    Point mouseLeftDownPoint = new(0, 0);
-    Point mouseMoveLastPoint = new(0, 0);
-    Point ownerZeroPointPos = new();
+    Point   zeroPoint = new(0, 0);
+    Point   mouseLeftDownPoint = new(0, 0);
+    Point   mouseMoveLastPoint = new(0, 0);
+    Point   ownerZeroPointPos = new();
 
-    Rect zeroRect = new(0, 0, 0, 0);
-    Rect rectDetachedLast = Rect.Empty;
-    Rect rectInit;
-    Rect rectInitLast = rectRandom;
-    Rect rectIntersect;
-    Rect rectIntersectLast = rectRandom;
-    RECT beforeResizeRect = new();
-    RECT curRect = new();
+    Rect    zeroRect = new(0, 0, 0, 0);
+    Rect    rectDetachedLast = Rect.Empty;
+    Rect    rectInit;
+    Rect    rectIntersect;
+    RECT    beforeResizeRect = new();
+    RECT    curRect = new();
 
     private class FlyleafHostDropWrap { public FlyleafHost FlyleafHost; } // To allow non FlyleafHosts to drag & drop
     protected readonly LogHandler Log;
@@ -915,7 +937,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             if (!IsAttached || OwnerHandle == ownerHandle)
                 return; // Check OwnerHandle changed (NOTE: Owner can be the same class/window but the handle can be different)
 
-            Owner.SizeChanged -= Owner_SizeChanged;
+            Owner.DpiChanged    -= Owner_DpiChanged;
 
             Surface.Hide();
             Overlay?.Hide();
@@ -926,7 +948,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             Surface.Title   = Owner.Title;
             Surface.Icon    = Owner.Icon;
 
-            Owner.SizeChanged += Owner_SizeChanged;
+            Owner.DpiChanged    += Owner_DpiChanged;
+
             Attach();
             rectDetachedLast = Rect.Empty; // Attach will set it wrong first time
             Host_IsVisibleChanged(null, new());
@@ -943,7 +966,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         Surface.Title   = Owner.Title;
         Surface.Icon    = Owner.Icon;
 
-        Owner.SizeChanged   += Owner_SizeChanged;
+        Owner.DpiChanged    += Owner_DpiChanged;
         DataContextChanged  += Host_DataContextChanged;
         LayoutUpdated       += Host_LayoutUpdated;
         IsVisibleChanged    += Host_IsVisibleChanged;
@@ -973,9 +996,16 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         }
     }
 
-    // WindowChrome Issue #410: It will not properly move child windows when resized from top or left
-    private void Owner_SizeChanged(object sender, SizeChangedEventArgs e)
-        => rectInitLast = Rect.Empty;
+    private void Owner_DpiChanged(object sender, DpiChangedEventArgs e)
+    {
+        if (IsAttached)
+        {
+            DpiX = e.NewDpi.DpiScaleX;
+            DpiY = e.NewDpi.DpiScaleY;
+            DpiXSource = e.NewDpi.PixelsPerInchX;
+            DpiYSource = e.NewDpi.PixelsPerInchY;
+        }
+    }
 
     private void Host_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e) =>
         // TBR
@@ -1060,30 +1090,14 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
                     rectIntersect.Intersect(new Rect(parent.TransformToAncestor(Owner).Transform(zeroPoint), parent.RenderSize));
             }
 
-            if (rectInit != rectInitLast)
-            {
-                SetRect(ref rectInit);
-                rectInitLast = rectInit;
-            }
+            SetRect(ref rectInit);
 
             if (rectIntersect == Rect.Empty)
-            {
-                if (rectIntersect == rectIntersectLast)
-                    return;
-
-                rectIntersectLast = rectIntersect;
                 SetVisibleRect(ref zeroRect);
-            }
             else
             {
                 rectIntersect.X -= rectInit.X;
                 rectIntersect.Y -= rectInit.Y;
-
-                if (rectIntersect == rectIntersectLast)
-                    return;
-
-                rectIntersectLast = rectIntersect;
-
                 SetVisibleRect(ref rectIntersect);
             }
         }
@@ -1875,6 +1889,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         Surface.DragEnter   += Surface_DragEnter;
         Surface.StateChanged+= Surface_StateChanged;
         Surface.SizeChanged += SetRectOverlay;
+        Surface.DpiChanged  += Surface_DpiChanged;
 
         SetMouseSurface();
 
@@ -1887,6 +1902,18 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
         SurfaceCreated?.Invoke(this, new());
     }
+
+    private void Surface_DpiChanged(object sender, DpiChangedEventArgs e)
+    {
+        if (!IsAttached)
+        {
+            DpiX = e.NewDpi.DpiScaleX;
+            DpiY = e.NewDpi.DpiScaleY;
+            DpiXSource = e.NewDpi.PixelsPerInchX;
+            DpiYSource = e.NewDpi.PixelsPerInchY;
+        }
+    }
+
     public virtual void SetOverlay()
     {
         if (Overlay == null)
@@ -2086,11 +2113,21 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     {
         Window wasFocus = Overlay != null && Overlay.IsKeyboardFocusWithin ? Overlay : Surface;
 
+        var source = PresentationSource.FromVisual(Owner);
+        if (source != null)
+        {
+            DpiX = source.CompositionTarget.TransformToDevice.M11;
+            DpiY = source.CompositionTarget.TransformToDevice.M22;
+            DpiXSource = DpiX * 96;
+            DpiYSource = DpiY * 96;
+        }
+
         if (IsFullScreen)
         {
             IsFullScreen = false;
             return;
         }
+
         if (!ignoreRestoreRect)
             rectDetachedLast= new(Surface.Left, Surface.Top, Surface.Width, Surface.Height);
 
@@ -2104,7 +2141,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         Surface.Owner = Owner;
         SetParent(SurfaceHandle, OwnerHandle);
 
-        rectInitLast = rectIntersectLast = rectRandom;
         Host_LayoutUpdated(null, null);
         Owner.Activate();
         wasFocus.Focus();
@@ -2136,51 +2172,20 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             newSize.Width   *= DpiX;
             newSize.Height  *= DpiY;
 
-            switch (DetachedPosition)
+            newPos = DetachedPosition switch
             {
-                case DetachedPositionOptions.TopLeft:
-                    newPos = new Point(screen.Left, screen.Top);
-                    break;
-                case DetachedPositionOptions.TopCenter:
-                    newPos = new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top);
-                    break;
-
-                case DetachedPositionOptions.TopRight:
-                    newPos = new Point(screen.Left + screen.Width - newSize.Width, screen.Top);
-                    break;
-
-                case DetachedPositionOptions.CenterLeft:
-                    newPos = new Point(screen.Left, screen.Top + (screen.Height / 2) - (newSize.Height / 2));
-                    break;
-
-                case DetachedPositionOptions.CenterCenter:
-                    newPos = new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top + (screen.Height / 2) - (newSize.Height / 2));
-                    break;
-
-                case DetachedPositionOptions.CenterRight:
-                    newPos = new Point(screen.Left + screen.Width - newSize.Width, screen.Top + (screen.Height / 2) - (newSize.Height / 2));
-                    break;
-
-                case DetachedPositionOptions.BottomLeft:
-                    newPos = new Point(screen.Left, screen.Top + screen.Height - newSize.Height);
-                    break;
-
-                case DetachedPositionOptions.BottomCenter:
-                    newPos = new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top + screen.Height - newSize.Height);
-                    break;
-
-                case DetachedPositionOptions.BottomRight:
-                    newPos = new Point(screen.Left + screen.Width - newSize.Width, screen.Top + screen.Height - newSize.Height);
-                    break;
-
-                case DetachedPositionOptions.Custom:
-                    newPos = DetachedFixedPosition;
-                    break;
-
-                default:
-                    newPos = new(); //satisfy the compiler
-                    break;
-            }
+                DetachedPositionOptions.TopLeft     => new Point(screen.Left, screen.Top),
+                DetachedPositionOptions.TopCenter   => new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top),
+                DetachedPositionOptions.TopRight    => new Point(screen.Left + screen.Width - newSize.Width, screen.Top),
+                DetachedPositionOptions.CenterLeft  => new Point(screen.Left, screen.Top + (screen.Height / 2) - (newSize.Height / 2)),
+                DetachedPositionOptions.CenterCenter=> new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top + (screen.Height / 2) - (newSize.Height / 2)),
+                DetachedPositionOptions.CenterRight => new Point(screen.Left + screen.Width - newSize.Width, screen.Top + (screen.Height / 2) - (newSize.Height / 2)),
+                DetachedPositionOptions.BottomLeft  => new Point(screen.Left, screen.Top + screen.Height - newSize.Height),
+                DetachedPositionOptions.BottomCenter=> new Point(screen.Left + (screen.Width / 2) - (newSize.Width / 2), screen.Top + screen.Height - newSize.Height),
+                DetachedPositionOptions.BottomRight => new Point(screen.Left + screen.Width - newSize.Width, screen.Top + screen.Height - newSize.Height),
+                DetachedPositionOptions.Custom      => DetachedFixedPosition,
+                _ => new(),//satisfy the compiler
+            };
 
             // SetRect will drop DPI so we add it
             newPos.X /= DpiX;
@@ -2354,8 +2359,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             }
 
             if (Owner != null)
-                Owner.SizeChanged -= Owner_SizeChanged;
-
+                Owner.DpiChanged -= Owner_DpiChanged;
             Surface = null;
             Overlay = null;
             Owner   = null;

--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -1911,6 +1911,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             DpiY = e.NewDpi.DpiScaleY;
             DpiXSource = e.NewDpi.PixelsPerInchX;
             DpiYSource = e.NewDpi.PixelsPerInchY;
+            SetRectOverlay(null, null);
         }
     }
 
@@ -2147,6 +2148,10 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     }
     public virtual void Detach()
     {
+        /* TODO
+         * Restoring to rectDetachedLast does not take count the DPI changes (also needs to calculate/check the DPI at that point before detaching)
+         */
+
         if (IsFullScreen)
             IsFullScreen = false;
 
@@ -2344,6 +2349,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
                 Surface.DragEnter   -= Surface_DragEnter;
                 Surface.StateChanged-= Surface_StateChanged;
                 Surface.SizeChanged -= SetRectOverlay;
+                Surface.DpiChanged  -= Surface_DpiChanged;
 
                 // If not shown yet app will not close properly
                 if (!surfaceClosed)
@@ -2360,6 +2366,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
             if (Owner != null)
                 Owner.DpiChanged -= Owner_DpiChanged;
+
             Surface = null;
             Overlay = null;
             Owner   = null;

--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -998,7 +998,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
     private void Owner_DpiChanged(object sender, DpiChangedEventArgs e)
     {
-        if (IsAttached)
+        if (e.OriginalSource == Owner && IsAttached)
         {
             DpiX = e.NewDpi.DpiScaleX;
             DpiY = e.NewDpi.DpiScaleY;

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -838,6 +838,24 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public bool             SwapForceR8G8B8A8           { get; set; }
 
+        /// <summary>
+        /// Enables custom Direct2D drawing over playback frames
+        /// </summary>
+        public bool             Use2DGraphics               { get; set; }
+
+        public event EventHandler<Vortice.Direct2D1.ID2D1DeviceContext> D2DInitialized;
+        public event EventHandler<Vortice.Direct2D1.ID2D1DeviceContext> D2DDisposing;
+        public event EventHandler<Vortice.Direct2D1.ID2D1DeviceContext> D2DDraw;
+
+        internal void OnD2DInitialized(Renderer renderer, Vortice.Direct2D1.ID2D1DeviceContext context)
+            => D2DInitialized?.Invoke(renderer, context);
+
+        internal void OnD2DDisposing(Renderer renderer, Vortice.Direct2D1.ID2D1DeviceContext context)
+            => D2DDisposing?.Invoke(renderer, context);
+
+        internal void OnD2DDraw(Renderer renderer, Vortice.Direct2D1.ID2D1DeviceContext context)
+            => D2DDraw?.Invoke(renderer, context);
+
         public Dictionary<VideoFilters, VideoFilter> Filters {get ; set; } = DefaultFilters();
 
         public static Dictionary<VideoFilters, VideoFilter> DefaultFilters()

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -220,7 +220,7 @@ public class Config : NotifyPropertyChanged
     public DataConfig       Data        { get; set; } = new();
 
     public Dictionary<string, ObservableDictionary<string, string>>
-                            Plugins     { get; set; } = new();
+                            Plugins     { get; set; } = [];
     private
            Dictionary<string, ObservableDictionary<string, string>>
                             defaultPlugins;
@@ -399,7 +399,7 @@ public class Config : NotifyPropertyChanged
         public bool     SeekOffsetAccurate4         { get; set; } = false;
         public double   SpeedOffset                 { get; set; } = 0.10;
         public double   SpeedOffset2                { get; set; } = 0.25;
-        public int      ZoomOffset                  { get => _ZoomOffset; set { if (Set(ref _ZoomOffset, value)) player?.ResetAll(); } }
+        public int      ZoomOffset                  { get => _ZoomOffset; set { if (SetUI(ref _ZoomOffset, value)) player?.ResetAll(); } }
         int _ZoomOffset = 10;
 
         public int      VolumeOffset                { get; set; } = 5;
@@ -410,9 +410,9 @@ public class Config : NotifyPropertyChanged
         {
             DemuxerConfig demuxer = (DemuxerConfig) MemberwiseClone();
 
-            demuxer.FormatOpt       = new Dictionary<string, string>();
-            demuxer.AudioFormatOpt  = new Dictionary<string, string>();
-            demuxer.SubtitlesFormatOpt = new Dictionary<string, string>();
+            demuxer.FormatOpt           = [];
+            demuxer.AudioFormatOpt      = [];
+            demuxer.SubtitlesFormatOpt  = [];
 
             foreach (var kv in FormatOpt) demuxer.FormatOpt.Add(kv.Key, kv.Value);
             foreach (var kv in AudioFormatOpt) demuxer.AudioFormatOpt.Add(kv.Key, kv.Value);
@@ -450,7 +450,7 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// List of FFmpeg formats to be excluded from interrupts
         /// </summary>
-        public List<string>     ExcludeInterruptFmts{ get; set; } = new List<string>() { "rtsp" };
+        public List<string>     ExcludeInterruptFmts{ get; set; } = ["rtsp"];
 
         /// <summary>
         /// Maximum allowed duration ticks for buffering
@@ -555,7 +555,7 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public Dictionary<string, string>
                                 ExtraHTTPQueryParamsToUnderlying
-                                                { get; set; } = new();
+                                                { get; set; } = [];
 
         /// <summary>
         /// FFmpeg's format options for demuxer
@@ -815,10 +815,10 @@ public class Config : NotifyPropertyChanged
         HDRtoSDRMethod _HDRtoSDRMethod = HDRtoSDRMethod.Hable;
 
         /// <summary>
-        /// The HDR to SDR Tone float correnction (not used by Reinhard)
+        /// SDR Display Peak Luminance (will be used for HDR to SDR conversion)
         /// </summary>
-        public unsafe float     HDRtoSDRTone                { get => _HDRtoSDRTone; set { if (Set(ref _HDRtoSDRTone, value) && player != null && player.VideoDecoder.VideoStream != null && player.VideoDecoder.VideoStream.ColorSpace == ColorSpace.BT2020) player.renderer.UpdateHDRtoSDR(); } }
-        float _HDRtoSDRTone = 1.4f;
+        public unsafe float     SDRDisplayNits              { get => _SDRDisplayNits; set { if (Set(ref _SDRDisplayNits, value) && player != null && player.VideoDecoder.VideoStream != null && player.VideoDecoder.VideoStream.ColorSpace == ColorSpace.BT2020) player.renderer.UpdateHDRtoSDR(); } }
+        float _SDRDisplayNits = 200f; // TODO: Retrieve this through Vortice (output6) but currently not supported
 
         /// <summary>
         /// Whether the renderer will use 10-bit swap chaing or 8-bit output
@@ -856,11 +856,11 @@ public class Config : NotifyPropertyChanged
         internal void OnD2DDraw(Renderer renderer, Vortice.Direct2D1.ID2D1DeviceContext context)
             => D2DDraw?.Invoke(renderer, context);
 
-        public Dictionary<VideoFilters, VideoFilter> Filters {get ; set; } = DefaultFilters();
+        public Dictionary<VideoFilters, VideoFilter> Filters { get ; set; } = DefaultFilters();
 
         public static Dictionary<VideoFilters, VideoFilter> DefaultFilters()
         {
-            Dictionary<VideoFilters, VideoFilter> filters = new();
+            Dictionary<VideoFilters, VideoFilter> filters = [];
 
             var available = Enum.GetValues(typeof(VideoFilters));
 
@@ -1032,10 +1032,9 @@ public class Config : NotifyPropertyChanged
 
         public SubtitlesConfig Clone()
         {
-            SubtitlesConfig subs = new();
-            subs = (SubtitlesConfig) MemberwiseClone();
+            SubtitlesConfig subs = (SubtitlesConfig) MemberwiseClone();
 
-            subs.Languages = new List<Language>();
+            subs.Languages = [];
             if (Languages != null) foreach(var lang in Languages) subs.Languages.Add(lang);
 
             subs.player = null;
@@ -1319,8 +1318,7 @@ public class Config : NotifyPropertyChanged
     {
         public DataConfig Clone()
         {
-            DataConfig data = new();
-            data = (DataConfig)MemberwiseClone();
+            DataConfig data = (DataConfig)MemberwiseClone();
 
             data.player = null;
 

--- a/FlyleafLib/Engine/Engine.Plugins.cs
+++ b/FlyleafLib/Engine/Engine.Plugins.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -63,6 +63,15 @@ public enum ColorRange : int
     Full        = 1,
     Limited     = 2
 }
+public enum HDRFormat : int
+{
+    None        = 0,
+    DolbyVision = 1,
+    HDR         = 2,
+    HDRPlus     = 3,
+    HLG         = 4,
+
+}
 
 public enum SubOCREngineType
 {

--- a/FlyleafLib/Engine/Language.cs
+++ b/FlyleafLib/Engine/Language.cs
@@ -220,8 +220,8 @@ public class Language : IEquatable<Language>
         { "wel","cym" },
     };
 
-    public static Language English = Get("eng");
-    public static Language Unknown = Get("und");
+    public static readonly Language English = Get("eng");
+    public static readonly Language Unknown = Get("und");
 
     public static List<Language> AllLanguages
     {

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.5</Version>
+    <Version>3.8.6</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
@@ -272,16 +272,14 @@ public partial class DecoderContext
         {
             Initialize();
 
-            if (input is Stream)
-            {
-                Playlist.IOStream = (Stream)input;
-            }
+            if (input is Stream iostream)
+                Playlist.IOStream = iostream;
             else
                 Playlist.Url = input.ToString(); // TBR: check UI update
 
-            args.Url = Playlist.Url;
-            args.IOStream = Playlist.IOStream;
-            args.Error = Open().Error;
+            args.Url        = Playlist.Url;
+            args.IOStream   = Playlist.IOStream;
+            args.Error      = Open().Error;
 
             if (Playlist.Items.Count == 0 && args.Success)
                 args.Error = "No playlist items were found";
@@ -482,9 +480,9 @@ public partial class DecoderContext
             }
 
             if (Config.Data.Enabled)
-            {
                 OpenSuggestedData();
-            }
+
+            MainDemuxer ??= VideoDemuxer;
 
             LoadPlaylistChapters();
 
@@ -667,7 +665,7 @@ public partial class DecoderContext
                     else if (stream.Type == MediaType.Subs)
                     {
                         int i = SubtitlesSelectedHelper.CurIndex;
-                        if (!EnableDecoding) 
+                        if (!EnableDecoding)
                            SubtitlesDemuxers[i].Dispose();
 
                         if (Playlist.Selected.ExternalSubtitlesStreams[i] != null)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 using Vortice;
@@ -7,13 +8,11 @@ using Vortice.Direct3D11;
 using Vortice.DXGI;
 using Vortice.DXGI.Debug;
 
-using FlyleafLib.MediaFramework.MediaDecoder;
-
 using static FlyleafLib.Logger;
-using System.Runtime.InteropServices;
-
 using ID3D11Device = Vortice.Direct3D11.ID3D11Device;
 using ID3D11DeviceContext = Vortice.Direct3D11.ID3D11DeviceContext;
+
+using FlyleafLib.MediaFramework.MediaDecoder;
 
 namespace FlyleafLib.MediaFramework.MediaRenderer;
 
@@ -30,8 +29,8 @@ public unsafe partial class Renderer
         BindFlags = BindFlags.VertexBuffer
     };
 
-    static float[] vertexBufferData = new[]
-    {
+    static float[] vertexBufferData =
+    [
         -1.0f,  -1.0f,  0,      0.0f, 1.0f,
         -1.0f,   1.0f,  0,      0.0f, 0.0f,
          1.0f,  -1.0f,  0,      1.0f, 1.0f,
@@ -39,10 +38,10 @@ public unsafe partial class Renderer
          1.0f,  -1.0f,  0,      1.0f, 1.0f,
         -1.0f,   1.0f,  0,      0.0f, 0.0f,
          1.0f,   1.0f,  0,      1.0f, 0.0f
-    };
+    ];
 
-    static FeatureLevel[] featureLevelsAll = new[]
-    {
+    static FeatureLevel[] featureLevelsAll =
+    [
         FeatureLevel.Level_12_1,
         FeatureLevel.Level_12_0,
         FeatureLevel.Level_11_1,
@@ -52,17 +51,17 @@ public unsafe partial class Renderer
         FeatureLevel.Level_9_3,
         FeatureLevel.Level_9_2,
         FeatureLevel.Level_9_1
-    };
+    ];
 
-    static FeatureLevel[] featureLevels = new[]
-    {
+    static FeatureLevel[] featureLevels =
+    [
         FeatureLevel.Level_11_0,
         FeatureLevel.Level_10_1,
         FeatureLevel.Level_10_0,
         FeatureLevel.Level_9_3,
         FeatureLevel.Level_9_2,
         FeatureLevel.Level_9_1
-    };
+    ];
 
     static BlendDescription blendDesc = new();
 
@@ -78,6 +77,14 @@ public unsafe partial class Renderer
         blendDesc.RenderTarget[0].RenderTargetWriteMask = ColorWriteEnable.All;
     }
 
+    Vortice.Direct2D1.ID2D1Device           device2d;
+    Vortice.Direct2D1.ID2D1DeviceContext    context2d;
+    Vortice.Direct2D1.ID2D1Bitmap1          bitmap2d;
+    Vortice.Direct2D1.BitmapProperties1     bitmapProps2d = new()
+    {
+        BitmapOptions   = Vortice.Direct2D1.BitmapOptions.Target | Vortice.Direct2D1.BitmapOptions.CannotDraw,
+        PixelFormat     = Vortice.DCommon.PixelFormat.Premultiplied
+    };
 
     ID3D11DeviceContext context;
 
@@ -199,7 +206,17 @@ public unsafe partial class Renderer
                 adapter.Dispose();
 
                 using (var mthread    = Device.QueryInterface<ID3D11Multithread>()) mthread.SetMultithreadProtected(true);
-                using (var dxgidevice = Device.QueryInterface<IDXGIDevice1>())      dxgidevice.MaximumFrameLatency = Config.Video.MaxFrameLatency;
+                using (var dxgidevice = Device.QueryInterface<IDXGIDevice1>())
+                {
+                    dxgidevice.MaximumFrameLatency = Config.Video.MaxFrameLatency;
+
+                    if (use2d)
+                    {
+                        device2d  = Vortice.Direct2D1.D2D1.D2D1CreateDevice(dxgidevice);
+                        context2d = device2d.CreateDeviceContext();
+                        Config.Video.OnD2DInitialized(this, context2d);
+                    }
+                }
 
                 // Input Layout
                 inputLayout = Device.CreateInputLayout(inputElements, ShaderCompiler.VSBlob);
@@ -321,6 +338,14 @@ public unsafe partial class Renderer
                 DisposeChild();
 
             Disposed = true;
+
+            if (use2d)
+            {
+                Config.Video.OnD2DDisposing(this, context2d);
+                bitmap2d?.Dispose();
+                context2d?.Dispose();
+                device2d?.Dispose();
+            }
 
             if (CanDebug) Log.Debug("Disposing");
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -252,8 +252,7 @@ public unsafe partial class Renderer
                     ByteWidth       = (uint)(sizeof(PSBufferType) + (16 - (sizeof(PSBufferType) % 16)))
                 });
                 context.PSSetConstantBuffer(0, psBuffer);
-                psBufferData.hdrmethod = HDRtoSDRMethod.None;
-                context.UpdateSubresource(psBufferData, psBuffer);
+                UpdateHDRtoSDR(false); // TODO: Passing Config -> psBuffer (currently mixed with Initialize filters)
 
                 // subs
                 ShaderBGRA = ShaderCompiler.CompilePS(Device, "bgra", @"color = float4(Texture1.Sample(Sampler, input.Texture).rgba);", null);
@@ -476,16 +475,13 @@ public unsafe partial class Renderer
     struct PSBufferType
     {
         public int coefsIndex;
-        public HDRtoSDRMethod hdrmethod;
-
         public float brightness;
         public float contrast;
-
-        public float g_luminance;
-        public float g_toneP1;
-        public float g_toneP2;
-
+        public float hue;
+        public float saturation;
         public float texWidth;
+        public HDRtoSDRMethod tonemap;
+        public float hdrtone;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -132,11 +132,11 @@ unsafe public partial class Renderer
 
                     inputColorSpace = new()
                     {
-                        Usage           = 0,
-                        RGB_Range       = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? (uint) 0 : 1,
-                        YCbCr_Matrix    = VideoStream.ColorSpace != ColorSpace.BT601 ? (uint) 1 : 0,
-                        YCbCr_xvYCC     = 0,
-                        Nominal_Range   = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? (uint) 2 : 1
+                        Usage           = 0u,
+                        RGB_Range       = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? 0u : 1u,
+                        YCbCr_Matrix    = VideoStream.ColorSpace != ColorSpace.BT601 ? 1u : 0u,
+                        YCbCr_xvYCC     = 0u,
+                        Nominal_Range   = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? 2u : 1u
                     };
 
                     vpov?.Dispose();
@@ -167,7 +167,7 @@ unsafe public partial class Renderer
                 }
                 else if (!Config.Video.SwsForce || VideoDecoder.VideoAccelerated) // FlyleafVP
                 {
-                    List<string> defines = new();
+                    List<string> defines = [];
 
                     if (oldVP != videoProcessor)
                     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -18,8 +18,15 @@ namespace FlyleafLib.MediaFramework.MediaRenderer;
 
 unsafe public partial class Renderer
 {
-    static string[] pixelOffsets = new[] { "r", "g", "b", "a" };
-    enum PSDefines { HDR, HLG, YUV }
+    static string[] pixelOffsets = ["r", "g", "b", "a"];
+
+    const string dYUVLimited    = "dYUVLimited";
+    const string dYUVFull       = "dYUVFull";
+    const string dBT2020        = "dBT2020";
+    const string dPQToLinear    = "dPQToLinear";
+    const string dHLGToLinear   = "dHLGToLinear";
+    const string dTone          = "dTone";
+
     enum PSCase : int
     {
         None,
@@ -38,7 +45,6 @@ unsafe public partial class Renderer
         SwsScale
     }
 
-    bool    checkHDR;
     PSCase  curPSCase;
     string  curPSUniqueId;
     float   curRatio = 1.0f;
@@ -68,7 +74,7 @@ unsafe public partial class Renderer
         }
     }
 
-    internal bool ConfigPlanes() //bool isNewInput = true) // currently not used
+    internal bool ConfigPlanes()
     {
         bool error = false;
 
@@ -85,23 +91,10 @@ unsafe public partial class Renderer
             VideoDecoder.DisposeFrame(LastFrame);
 
             curRatio    = VideoStream.AspectRatio.Value;
-            IsHDR       = VideoStream.ColorSpace == ColorSpace.BT2020 && ( // TBR: Should transfer IsHDR to VideoStream? | Unspecified (Space/Transfer)
-                          VideoStream.ColorTransfer == AVColorTransferCharacteristic.Smpte2084 ||  // PQ
-                          VideoStream.ColorTransfer == AVColorTransferCharacteristic.AribStdB67);// HLG
             VideoRect   = new RawRect(0, 0, (int)VideoStream.Width, (int)VideoStream.Height);
             rotationLinesize
                         = false;
             UpdateRotation(_RotationAngle, false);
-
-            if (IsHDR)
-            {
-                hdrPlusData = null;
-                displayData = new();
-                lightData   = new();
-                checkHDR    = true;
-            }
-            else
-                checkHDR = false;
 
             var oldVP = videoProcessor;
 
@@ -127,16 +120,16 @@ unsafe public partial class Renderer
                     {
                         VideoDecoder.DisposeFrames();
                         Config.Video.Filters[VideoFilters.Brightness].Value = Config.Video.Filters[VideoFilters.Brightness].DefaultValue;
-                        Config.Video.Filters[VideoFilters.Contrast].Value = Config.Video.Filters[VideoFilters.Contrast].DefaultValue;
+                        Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].DefaultValue;
                     }
 
                     inputColorSpace = new()
                     {
                         Usage           = 0u,
-                        RGB_Range       = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? 0u : 1u,
+                        RGB_Range       = VideoStream.ColorRange == ColorRange.Full  ? 0u : 1u,
                         YCbCr_Matrix    = VideoStream.ColorSpace != ColorSpace.BT601 ? 1u : 0u,
                         YCbCr_xvYCC     = 0u,
-                        Nominal_Range   = VideoStream.AVStream->codecpar->color_range == AVColorRange.Jpeg ? 2u : 1u
+                        Nominal_Range   = VideoStream.ColorRange == ColorRange.Full  ? 2u : 1u
                     };
 
                     vpov?.Dispose();
@@ -176,30 +169,48 @@ unsafe public partial class Renderer
                         Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].Minimum + ((Config.Video.Filters[VideoFilters.Contrast].Maximum - Config.Video.Filters[VideoFilters.Contrast].Minimum) / 2);
                     }
 
-                    if (IsHDR)
+                    if (VideoStream.HDRFormat != HDRFormat.None)
                     {
-                        // TBR: It currently works better without it
-                        //if (VideoStream.ColorTransfer == AVColorTransferCharacteristic.AVCOL_TRC_ARIB_STD_B67)
-                        //{
-                        //    defines.Add(PSDefines.HLG.ToString());
-                        //    curPSUniqueId += "g";
-                        //}
+                        if (VideoStream.HDRFormat == HDRFormat.HLG)
+                        {
+                            curPSUniqueId += "g";
+                            defines.Add(dHLGToLinear);
+                        }
+                        else
+                        {
+                            curPSUniqueId += "p";
+                            defines.Add(dPQToLinear);
+                        }
 
-                        curPSUniqueId += "h";
-                        defines.Add(PSDefines.HDR.ToString());
-                        psBufferData.coefsIndex = 0;
-                        UpdateHDRtoSDR(false);
+
+                        defines.Add(dTone);
                     }
-                    else
-                        psBufferData.coefsIndex = VideoStream.ColorSpace == ColorSpace.BT709 ? 1 : 2;
+                    else if (VideoStream.ColorSpace == ColorSpace.BT2020)
+                    {
+                        defines.Add(dBT2020);
+                        curPSUniqueId += "b";
+                    }
 
-                    for (int i=0; i<srvDesc.Length; i++)
+                    for (int i = 0; i < srvDesc.Length; i++)
                         srvDesc[i].ViewDimension = ShaderResourceViewDimension.Texture2D;
 
                     // 1. HW Decoding
                     if (VideoDecoder.VideoAccelerated)
                     {
-                        defines.Add(PSDefines.YUV.ToString());
+                        if (VideoStream.ColorRange == ColorRange.Limited)
+                            defines.Add(dYUVLimited);
+                        else
+                        {
+                            curPSUniqueId += "f";
+                            defines.Add(dYUVFull);
+                        }
+
+                        if (VideoStream.ColorSpace == ColorSpace.BT709)
+                            psBufferData.coefsIndex = 1;
+                        else if (VideoStream.ColorSpace == ColorSpace.BT2020)
+                            psBufferData.coefsIndex = 0;
+                        else
+                            psBufferData.coefsIndex = 2;
 
                         if (VideoDecoder.VideoStream.PixelComp0Depth > 8)
                         {
@@ -363,7 +374,20 @@ unsafe public partial class Renderer
 
                     else // YUV
                     {
-                        defines.Add(PSDefines.YUV.ToString());
+                        if (VideoStream.ColorRange == ColorRange.Limited)
+                            defines.Add(dYUVLimited);
+                        else
+                        {
+                            curPSUniqueId += "f";
+                            defines.Add(dYUVFull);
+                        }
+
+                        if (VideoStream.ColorSpace == ColorSpace.BT709)
+                            psBufferData.coefsIndex = 1;
+                        else if (VideoStream.ColorSpace == ColorSpace.BT2020)
+                            psBufferData.coefsIndex = 0;
+                        else
+                            psBufferData.coefsIndex = 2;
 
                         if (VideoStream.PixelPlanes == 1 && (
                             VideoStream.PixelFormat == AVPixelFormat.Y210le  || // Not tested
@@ -602,39 +626,6 @@ color = float4(Texture1.Sample(Sampler, input.Texture).rgb, 1.0);
             VideoFrame mFrame = new();
             mFrame.timestamp = (long)(frame->pts * VideoStream.Timebase) - VideoDecoder.Demuxer.StartTime;
             if (CanTrace) Log.Trace($"Processes {Utils.TicksToTime(mFrame.timestamp)}");
-
-            if (checkHDR)
-            {
-                // TODO Dolpy Vision / Vivid
-                //var hdrSideDolpyDynamic = av_frame_get_side_data(frame, AVFrameSideDataType.AV_FRAME_DATA_DOVI_METADATA);
-
-                var hdrSideDynamic = av_frame_get_side_data(frame, AVFrameSideDataType.DynamicHdrPlus);
-
-                if (hdrSideDynamic != null && hdrSideDynamic->data != null)
-                {
-                    hdrPlusData = (AVDynamicHDRPlus*) hdrSideDynamic->data;
-                    UpdateHDRtoSDR();
-                }
-                else
-                {
-                    var lightSide   = av_frame_get_side_data(frame, AVFrameSideDataType.ContentLightLevel);
-                    var displaySide = av_frame_get_side_data(frame, AVFrameSideDataType.MasteringDisplayMetadata);
-
-                    if (lightSide != null && lightSide->data != null && ((AVContentLightMetadata*)lightSide->data)->MaxCLL != 0)
-                    {
-                        lightData = *((AVContentLightMetadata*) lightSide->data);
-                        checkHDR = false;
-                        UpdateHDRtoSDR();
-                    }
-
-                    if (displaySide != null && displaySide->data != null && ((AVMasteringDisplayMetadata*)displaySide->data)->has_luminance != 0)
-                    {
-                        displayData = *((AVMasteringDisplayMetadata*) displaySide->data);
-                        checkHDR = false;
-                        UpdateHDRtoSDR();
-                    }
-                }
-            }
 
             if (curPSCase == PSCase.HWZeroCopy)
             {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
-using Vortice.DXGI;
 using Vortice.Direct3D11;
+using Vortice.DXGI;
+
+using static FlyleafLib.Logger;
 
 using FlyleafLib.MediaFramework.MediaDecoder;
 using FlyleafLib.MediaFramework.MediaFrame;
-
-using static FlyleafLib.Logger;
 
 namespace FlyleafLib.MediaFramework.MediaRenderer;
 
@@ -128,6 +127,9 @@ public unsafe partial class Renderer
             context.PSSetShaderResources(0, frame.srvs);
             context.Draw(6, 0);
 
+            if (use2d)
+                Config.Video.OnD2DDraw(this, context2d);
+
             if (overlayTexture != null)
             {
                 // Don't stretch the overlay (reduce height based on ratiox) | Sub's stream size might be different from video size (fix y based on percentage)
@@ -162,6 +164,7 @@ public unsafe partial class Renderer
         overlayTextureSrv   = null;
     }
 
+    SubresourceData subDataOverlay;
     internal void CreateOverlayTexture(SubtitlesFrame frame, int streamWidth, int streamHeight)
     {
         var rect    = frame.sub.rects[0];
@@ -178,15 +181,12 @@ public unsafe partial class Renderer
 
         fixed(byte* ptr = data)
         {
-            SubresourceData subData = new()
-            {
-                DataPointer = (nint)ptr,
-                RowPitch    = (uint)stride
-            };
+            subDataOverlay.DataPointer = (nint)ptr;
+            subDataOverlay.RowPitch    = (uint)stride;
 
             overlayTexture?.Dispose();
             overlayTextureSrv?.Dispose();
-            overlayTexture          = Device.CreateTexture2D(overlayTextureDesc, new SubresourceData[] { subData });
+            overlayTexture          = Device.CreateTexture2D(overlayTextureDesc, [subDataOverlay]);
             overlayTextureSrv       = Device.CreateShaderResourceView(overlayTexture);
             overlayTextureSRVs[0]   = overlayTextureSrv;
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -394,6 +394,13 @@ public partial class Renderer
             if (SCDisposed)
                 return;
 
+            if (use2d)
+            {
+                context2d.Target = null;
+                bitmap2d?.Dispose();
+                bitmap2d = null;
+            }
+
             ControlWidth = width;
             ControlHeight = height;
 
@@ -408,6 +415,13 @@ public partial class Renderer
                 vd1.CreateVideoProcessorOutputView(backBuffer, vpe, vpovd, out vpov);
 
             SetViewport();
+
+            if (use2d)
+            {
+                using var surface = backBuffer.QueryInterface<IDXGISurface>();
+                bitmap2d = context2d.CreateBitmapFromDxgiSurface(surface, bitmapProps2d);
+                context2d.Target = bitmap2d;
+            }
         }
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -108,10 +108,6 @@ unsafe public partial class Renderer
     VideoProcessorColorSpace            inputColorSpace;
     VideoProcessorColorSpace            outputColorSpace;
 
-    AVDynamicHDRPlus*                   hdrPlusData = null;
-    AVContentLightMetadata              lightData   = new();
-    AVMasteringDisplayMetadata          displayData = new();
-
     uint actualRotation;
     bool actualHFlip, actualVFlip;
     bool configLoadedChecked;
@@ -315,6 +311,12 @@ unsafe public partial class Renderer
         if (!Filters.ContainsKey(VideoFilters.Contrast))
             Filters.Add(VideoFilters.Contrast, new VideoFilter(VideoFilters.Contrast));
 
+        if (!Filters.ContainsKey(VideoFilters.Hue))
+            Filters.Add(VideoFilters.Hue, new VideoFilter(VideoFilters.Hue));
+
+        if (!Filters.ContainsKey(VideoFilters.Saturation))
+            Filters.Add(VideoFilters.Saturation, new VideoFilter(VideoFilters.Saturation));
+
         foreach(var filter in Filters.Values)
         {
             if (!Config.Video.Filters.ContainsKey(filter.Filter))
@@ -401,17 +403,22 @@ unsafe public partial class Renderer
                 int scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 100);
                 psBufferData.brightness = scaledValue / 100.0f;
                 context.UpdateSubresource(psBufferData, psBuffer);
-
                 break;
 
             case VideoFilters.Contrast:
                 scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 100);
                 psBufferData.contrast = scaledValue / 100.0f;
                 context.UpdateSubresource(psBufferData, psBuffer);
-
                 break;
 
-            default:
+            case VideoFilters.Hue:
+                psBufferData.hue = Scale(filter.Value, filter.Minimum, filter.Maximum, -3.14f, 3.14f);
+                context.UpdateSubresource(psBufferData, psBuffer);
+                break;
+
+            case VideoFilters.Saturation:
+                psBufferData.saturation = Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 2);
+                context.UpdateSubresource(psBufferData, psBuffer);
                 break;
         }
 
@@ -422,73 +429,14 @@ unsafe public partial class Renderer
         if(parent != null)
             return;
 
-        float lum1 = 400;
+        psBufferData.tonemap = Config.Video.HDRtoSDRMethod;
 
-        if (hdrPlusData != null)
-        {
-            lum1 = (float) (av_q2d(hdrPlusData->@params[0].average_maxrgb) * 100000.0);
-
-            // this is not accurate more research required
-            if (lum1 < 100)
-                lum1 *= 10;
-            lum1 = Math.Max(lum1, 400);
-        }
-        else if (Config.Video.HDRtoSDRMethod != HDRtoSDRMethod.Reinhard)
-        {
-            float lum2 = lum1;
-            float lum3 = lum1;
-
-            double lum = displayData.has_luminance != 0 ? av_q2d(displayData.max_luminance) : 400;
-
-            if (lightData.MaxCLL > 0)
-            {
-                if (lightData.MaxCLL >= lum)
-                {
-                    lum1 = (float)lum;
-                    lum2 = lightData.MaxCLL;
-                }
-                else
-                {
-                    lum1 = lightData.MaxCLL;
-                    lum2 = (float)lum;
-                }
-                lum3 = lightData.MaxFALL;
-                lum1 = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
-            }
-            else
-            {
-                lum1 = (float)lum;
-            }
-        }
-        else
-        {
-            if (lightData.MaxCLL > 0)
-                lum1 = lightData.MaxCLL;
-            else if (displayData.has_luminance != 0)
-                lum1 = (float)av_q2d(displayData.max_luminance);
-        }
-
-        psBufferData.hdrmethod = Config.Video.HDRtoSDRMethod;
-
-        if (psBufferData.hdrmethod == HDRtoSDRMethod.Hable)
-        {
-            psBufferData.g_luminance = lum1 > 1 ? lum1 : 400.0f;
-            psBufferData.g_toneP1 = 10000.0f / psBufferData.g_luminance * (2.0f / Config.Video.HDRtoSDRTone);
-            psBufferData.g_toneP2 = psBufferData.g_luminance / (100.0f * Config.Video.HDRtoSDRTone);
-        }
-        else if (psBufferData.hdrmethod == HDRtoSDRMethod.Reinhard)
-        {
-            psBufferData.g_toneP1 = lum1 > 0 ? (float)(Math.Log10(100) / Math.Log10(lum1)) : 0.72f;
-            if (psBufferData.g_toneP1 < 0.1f || psBufferData.g_toneP1 > 5.0f)
-                psBufferData.g_toneP1 = 0.72f;
-
-            psBufferData.g_toneP1 *= Config.Video.HDRtoSDRTone;
-        }
-        else if (psBufferData.hdrmethod == HDRtoSDRMethod.Aces)
-        {
-            psBufferData.g_luminance = lum1 > 1 ? lum1 : 400.0f;
-            psBufferData.g_toneP1 = Config.Video.HDRtoSDRTone;
-        }
+        if (psBufferData.tonemap == HDRtoSDRMethod.Hable)
+            psBufferData.hdrtone = 10_000f / Config.Video.SDRDisplayNits;
+        else if (psBufferData.tonemap == HDRtoSDRMethod.Reinhard)
+            psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 2f;
+        else if (psBufferData.tonemap == HDRtoSDRMethod.Aces)
+            psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 7f;
 
         if (updateResource)
         {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -186,6 +186,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     public RawRect          VideoRect       { get; set; }
 
     LogHandler Log;
+    bool use2d;
 
     public Renderer(VideoDecoder videoDecoder, IntPtr handle = new IntPtr(), int uniqueId = -1)
     {
@@ -193,6 +194,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
         VideoDecoder= videoDecoder;
         Config      = videoDecoder.Config;
         Log         = new LogHandler(("[#" + UniqueId + "]").PadRight(8, ' ') + " [Renderer      ] ");
+        use2d       = Config.Video.Use2DGraphics;
 
         overlayTextureDesc = new()
         {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -62,9 +62,6 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     CornerRadius cornerRadius = new(0);
     CornerRadius zeroCornerRadius = new(0);
 
-    public bool             IsHDR           { get => isHDR;         private set { SetUI(ref _IsHDR, value); isHDR = value; } }
-    bool _IsHDR, isHDR;
-
     public int              SideXPixels     { get; private set; }
     public int              SideYPixels     { get; private set; }
 

--- a/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-using FlyleafLib.MediaFramework.MediaDemuxer;
+﻿using FlyleafLib.MediaFramework.MediaDemuxer;
 
 namespace FlyleafLib.MediaFramework.MediaStream;
 
@@ -16,6 +14,8 @@ public unsafe class VideoStream : StreamBase
     public long                         FrameDuration       { get ;set; }
     public uint                         Height              { get; set; }
     public bool                         IsRGB               { get; set; }
+    public HDRFormat                    HDRFormat           { get; set; }
+
     public AVComponentDescriptor[]      PixelComps          { get; set; }
     public int                          PixelComp0Depth     { get; set; }
     public AVPixelFormat                PixelFormat         { get; set; }
@@ -48,9 +48,7 @@ public unsafe class VideoStream : StreamBase
         Width           = (uint)AVStream->codecpar->width;
         Height          = (uint)AVStream->codecpar->height;
 
-        // TBR: Maybe required also for input formats with AVFMT_NOTIMESTAMPS (and audio/subs)
-        // Possible FFmpeg.Autogen bug with Demuxer.FormatContext->iformat->flags (should be uint?) does not contain AVFMT_NOTIMESTAMPS (256 instead of 384)
-        if (Demuxer.Name == "h264" || Demuxer.Name == "hevc")
+        if (Demuxer.FormatContext->iformat->flags.HasFlag(FmtFlags.Notimestamps))
         {
             FixTimestamps = true;
 
@@ -68,7 +66,7 @@ public unsafe class VideoStream : StreamBase
             FPS  = av_q2d(av_guess_frame_rate(Demuxer.FormatContext, AVStream, frame));
         }
 
-        FrameDuration   = FPS > 0 ? (long) (10000000 / FPS) : 0;
+        FrameDuration   = FPS > 0 ? (long) (10_000_000 / FPS) : 0;
         TotalFrames     = AVStream->duration > 0 && FrameDuration > 0 ? (int) (AVStream->duration * Timebase / FrameDuration) : (FrameDuration > 0 ? (int) (Demuxer.Duration / FrameDuration) : 0);
 
         int x, y;
@@ -79,64 +77,139 @@ public unsafe class VideoStream : StreamBase
         av_reduce(&x, &y, Width  * sar.Num, Height * sar.Den, 1024 * 1024);
         AspectRatio = new AspectRatio(x, y);
 
-        if (PixelFormat != AVPixelFormat.None)
+        AVPacketSideData* pktSideData;
+        if ((pktSideData = av_packet_side_data_get(AVStream->codecpar->coded_side_data, AVStream->codecpar->nb_coded_side_data, AVPacketSideDataType.Displaymatrix)) != null && pktSideData->data != null)
         {
-            ColorRange = AVStream->codecpar->color_range == AVColorRange.Jpeg ? ColorRange.Full : ColorRange.Limited;
-
-            if (AVStream->codecpar->color_space == AVColorSpace.Bt470bg)
-                ColorSpace = ColorSpace.BT601;
-            else if (AVStream->codecpar->color_space == AVColorSpace.Bt709)
-                ColorSpace = ColorSpace.BT709;
-            else ColorSpace = AVStream->codecpar->color_space == AVColorSpace.Bt2020Cl || AVStream->codecpar->color_space == AVColorSpace.Bt2020Ncl
-                ? ColorSpace.BT2020
-                : Height > 576 ? ColorSpace.BT709 : ColorSpace.BT601;
-
-            // This causes issues
-            //if (AVStream->codecpar->color_space == AVColorSpace.AVCOL_SPC_UNSPECIFIED && AVStream->codecpar->color_trc == AVColorTransferCharacteristic.AVCOL_TRC_UNSPECIFIED && Height > 1080)
-            //{   // TBR: Handle Dolphy Vision?
-            //    ColorSpace = ColorSpace.BT2020;
-            //    ColorTransfer = AVColorTransferCharacteristic.AVCOL_TRC_SMPTE2084;
-            //}
-            //else
-            ColorTransfer = AVStream->codecpar->color_trc;
-
-            // We get rotation from frame side data only from 1st frame in case of exif orientation (mainly for jpeg) - TBR if required to check for each frame
-            AVFrameSideData* frameSideData;
-            AVPacketSideData* pktSideData;
-            double rotation = 0;
-            if (frame != null && (frameSideData = av_frame_get_side_data(frame, AVFrameSideDataType.Displaymatrix)) != null && frameSideData->data != null)
-                rotation = -Math.Round(av_display_rotation_get((int*)frameSideData->data)); //int_array9 displayMatrix = Marshal.PtrToStructure<int_array9>((nint)frameSideData->data); TBR: NaN why?
-            else if ((pktSideData = av_packet_side_data_get(AVStream->codecpar->coded_side_data, AVStream->codecpar->nb_coded_side_data, AVPacketSideDataType.Displaymatrix)) != null && pktSideData->data != null)
-                rotation = -Math.Round(av_display_rotation_get((int*)pktSideData->data));
-
+            double rotation = -Math.Round(av_display_rotation_get((int*)pktSideData->data));
             Rotation = rotation - (360*Math.Floor(rotation/360 + 0.9/360));
+        }
 
-            PixelFormatDesc = av_pix_fmt_desc_get(PixelFormat);
-            var comps       = PixelFormatDesc->comp.ToArray();
-            PixelComps      = new AVComponentDescriptor[PixelFormatDesc->nb_components];
-            for (int i=0; i<PixelComps.Length; i++)
-                PixelComps[i] = comps[i];
+        ColorRange = AVStream->codecpar->color_range == AVColorRange.Jpeg ? ColorRange.Full : ColorRange.Limited;
 
-            PixelInterleaved= PixelFormatDesc->log2_chroma_w != PixelFormatDesc->log2_chroma_h;
-            IsRGB           = (PixelFormatDesc->flags & PixFmtFlags.Rgb) != 0;
+        var colorSpace = AVStream->codecpar->color_space;
+        if (colorSpace == AVColorSpace.Bt709)
+            ColorSpace = ColorSpace.BT709;
+        else if (colorSpace == AVColorSpace.Bt470bg)
+            ColorSpace = ColorSpace.BT601;
+        else if (colorSpace == AVColorSpace.Bt2020Ncl || colorSpace == AVColorSpace.Bt2020Cl)
+            ColorSpace = ColorSpace.BT2020;
 
-            PixelSameDepth  = true;
-            PixelPlanes     = 0;
-            if (PixelComps.Length > 0)
+        ColorTransfer = AVStream->codecpar->color_trc;
+
+        // Avoid early check for HDR
+        //if (ColorTransfer == AVColorTransferCharacteristic.AribStdB67)
+        //    HDRFormat = HDRFormat.HLG;
+        //else if (ColorTransfer == AVColorTransferCharacteristic.Smpte2084)
+        //{
+        //    for (int i = 0; i < AVStream->codecpar->nb_coded_side_data; i++)
+        //    {
+        //        var csdata = AVStream->codecpar->coded_side_data[i];
+        //        switch (csdata.type)
+        //        {
+        //            case AVPacketSideDataType.DoviConf:
+        //                HDRFormat = HDRFormat.DolbyVision;
+        //                break;
+        //            case AVPacketSideDataType.DynamicHdr10Plus:
+        //                HDRFormat = HDRFormat.HDRPlus;
+        //                break;
+        //            case AVPacketSideDataType.ContentLightLevel:
+        //                //AVContentLightMetadata t2 = *((AVContentLightMetadata*)csdata.data);
+        //                break;
+        //            case AVPacketSideDataType.MasteringDisplayMetadata:
+        //                //AVMasteringDisplayMetadata t1 = *((AVMasteringDisplayMetadata*)csdata.data);
+        //                HDRFormat = HDRFormat.HDR;
+        //                break;
+        //        }
+        //    }
+        //}
+
+        if (frame != null)
+        {
+            AVFrameSideData* frameSideData;
+            if ((frameSideData = av_frame_get_side_data(frame, AVFrameSideDataType.Displaymatrix)) != null && frameSideData->data != null)
             {
-                PixelComp0Depth = PixelComps[0].depth;
-                int prevBit     = PixelComp0Depth;
-                for (int i=0; i<PixelComps.Length; i++)
-                {
-                    if (PixelComps[i].plane > PixelPlanes)
-                        PixelPlanes = PixelComps[i].plane;
-
-                    if (prevBit != PixelComps[i].depth)
-                        PixelSameDepth = false;
-                }
-
-                PixelPlanes++;
+                var rotation = -Math.Round(av_display_rotation_get((int*)frameSideData->data));
+                Rotation = rotation - (360*Math.Floor(rotation/360 + 0.9/360));
             }
+
+            ColorRange = frame->color_range == AVColorRange.Jpeg ? ColorRange.Full : ColorRange.Limited;
+
+            if (frame->color_trc != AVColorTransferCharacteristic.Unspecified)
+                ColorTransfer = frame->color_trc;
+
+            if (frame->colorspace == AVColorSpace.Bt709)
+                ColorSpace = ColorSpace.BT709;
+            else if (frame->colorspace == AVColorSpace.Bt470bg)
+                ColorSpace = ColorSpace.BT601;
+            else if (frame->colorspace == AVColorSpace.Bt2020Ncl || frame->colorspace == AVColorSpace.Bt2020Cl)
+                ColorSpace = ColorSpace.BT2020;
+
+            if (ColorTransfer == AVColorTransferCharacteristic.AribStdB67)
+                HDRFormat = HDRFormat.HLG;
+            else if (ColorTransfer == AVColorTransferCharacteristic.Smpte2084)
+            {
+                var dolbyData = av_frame_get_side_data(frame, AVFrameSideDataType.DoviMetadata);
+                if (dolbyData != null)
+                    HDRFormat = HDRFormat.DolbyVision;
+                else
+                {
+                    var hdrPlusData = av_frame_get_side_data(frame, AVFrameSideDataType.DynamicHdrPlus);
+                    if (hdrPlusData != null)
+                    {
+                        //AVDynamicHDRPlus* x1 = (AVDynamicHDRPlus*)hdrPlusData->data;
+                        HDRFormat = HDRFormat.HDRPlus;
+                    }
+                    else
+                    {
+                        //AVMasteringDisplayMetadata t1;
+                        //AVContentLightMetadata t2;
+
+                        //var masterData = av_frame_get_side_data(frame, AVFrameSideDataType.MasteringDisplayMetadata);
+                        //if (masterData != null)
+                        //    t1 = *((AVMasteringDisplayMetadata*)masterData->data);
+                        //var lightData   = av_frame_get_side_data(frame, AVFrameSideDataType.ContentLightLevel);
+                        //if (lightData != null)
+                        //    t2 = *((AVContentLightMetadata*) lightData->data);
+
+                        HDRFormat = HDRFormat.HDR;
+                    }
+                }
+            }
+
+            if (HDRFormat != HDRFormat.None) // Forcing BT.2020 with PQ/HLG transfer?
+                ColorSpace = ColorSpace.BT2020;
+            else if (ColorSpace == ColorSpace.None)
+                ColorSpace = Height > 576 ? ColorSpace.BT709 : ColorSpace.BT601;
+        }
+
+        if (PixelFormat == AVPixelFormat.None || PixelPlanes > 0) // Should re-analyze? (possible to get different pixel format on 2nd... call?)
+            return;
+
+        PixelFormatDesc = av_pix_fmt_desc_get(PixelFormat);
+        var comps       = PixelFormatDesc->comp.ToArray();
+        PixelComps      = new AVComponentDescriptor[PixelFormatDesc->nb_components];
+        for (int i=0; i<PixelComps.Length; i++)
+            PixelComps[i] = comps[i];
+
+        PixelInterleaved= PixelFormatDesc->log2_chroma_w != PixelFormatDesc->log2_chroma_h;
+        IsRGB           = (PixelFormatDesc->flags & PixFmtFlags.Rgb) != 0;
+
+        PixelSameDepth  = true;
+        PixelPlanes     = 0;
+        if (PixelComps.Length > 0)
+        {
+            PixelComp0Depth = PixelComps[0].depth;
+            int prevBit     = PixelComp0Depth;
+            for (int i=0; i<PixelComps.Length; i++)
+            {
+                if (PixelComps[i].plane > PixelPlanes)
+                    PixelPlanes = PixelComps[i].plane;
+
+                if (prevBit != PixelComps[i].depth)
+                    PixelSameDepth = false;
+            }
+
+            PixelPlanes++;
         }
     }
 }

--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -209,7 +209,7 @@ unsafe partial class Player
                 if (Config.Player.AutoPlay)
                     Play();
             }
-            else if (!defaultVideo && !defaultAudio)
+            else if (!defaultVideo && !defaultAudio && MainDemuxer != null)
             {
                 isLive  = MainDemuxer.IsLive;
                 duration= MainDemuxer.Duration;

--- a/FlyleafLib/Plugins/PluginHandler.cs
+++ b/FlyleafLib/Plugins/PluginHandler.cs
@@ -84,7 +84,7 @@ public class PluginHandler
     }
     private void LoadPlugins()
     {
-        Plugins = new Dictionary<string, PluginBase>();
+        Plugins = [];
 
         foreach (var type in Engine.Plugins.Types.Values)
         {
@@ -96,25 +96,25 @@ public class PluginHandler
             } catch (Exception e) { Log.Error($"[Plugins] [Error] Failed to load plugin ... ({e.Message} {Utils.GetRecInnerException(e)}"); }
             }
 
-        PluginsOpen                     = new Dictionary<string, IOpen>();
-        PluginsOpenSubtitles            = new Dictionary<string, IOpenSubtitles>();
-        PluginsScrapeItem               = new Dictionary<string, IScrapeItem>();
+        PluginsOpen                     = [];
+        PluginsOpenSubtitles            = [];
+        PluginsScrapeItem               = [];
 
-        PluginsSuggestItem              = new Dictionary<string, ISuggestPlaylistItem>();
+        PluginsSuggestItem              = [];
 
-        PluginsSuggestAudioStream       = new Dictionary<string, ISuggestAudioStream>();
-        PluginsSuggestVideoStream       = new Dictionary<string, ISuggestVideoStream>();
-        PluginsSuggestSubtitlesStream   = new Dictionary<string, ISuggestSubtitlesStream>();
-        PluginsSuggestSubtitles         = new Dictionary<string, ISuggestSubtitles>();
+        PluginsSuggestAudioStream       = [];
+        PluginsSuggestVideoStream       = [];
+        PluginsSuggestSubtitlesStream   = [];
+        PluginsSuggestSubtitles         = [];
 
-        PluginsSuggestExternalAudio     = new Dictionary<string, ISuggestExternalAudio>();
-        PluginsSuggestExternalVideo     = new Dictionary<string, ISuggestExternalVideo>();
+        PluginsSuggestExternalAudio     = [];
+        PluginsSuggestExternalVideo     = [];
         PluginsSuggestBestExternalSubtitles
-                                        = new Dictionary<string, ISuggestBestExternalSubtitles>();
+                                        = [];
 
-        PluginsSearchLocalSubtitles     = new Dictionary<string, ISearchLocalSubtitles>();
-        PluginsSearchOnlineSubtitles    = new Dictionary<string, ISearchOnlineSubtitles>();
-        PluginsDownloadSubtitles        = new Dictionary<string, IDownloadSubtitles>();
+        PluginsSearchLocalSubtitles     = [];
+        PluginsSearchOnlineSubtitles    = [];
+        PluginsDownloadSubtitles        = [];
 
         foreach (var plugin in Plugins.Values)
             LoadPluginInterfaces(plugin);

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -21,8 +21,6 @@ public static partial class Utils
                 GetWindowLong = GetWindowLongPtr64;
                 SetWindowLong = SetWindowLongPtr64;
             }
-
-            GetDPI(out DpiX, out DpiY);
         }
 
         public static Func<IntPtr, int, IntPtr, IntPtr> SetWindowLong;
@@ -257,23 +255,8 @@ public static partial class Utils
         public static int SignedLOWORD(int n) => (short)(n & 0xFFFF);
 
         #region DPI
-        public static double DpiX, DpiY;
-        public static int DpiXSource, DpiYSource;
-        const int LOGPIXELSX = 88, LOGPIXELSY = 90;
-        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
-        public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
-        public static void GetDPI(out double dpiX, out double dpiY) => GetDPI(IntPtr.Zero, out dpiX, out dpiY);
-        public static void GetDPI(IntPtr handle, out double dpiX, out double dpiY)
-        {
-            Graphics GraphicsObject = Graphics.FromHwnd(handle); // DESKTOP Handle
-            IntPtr dcHandle = GraphicsObject.GetHdc();
-            DpiXSource = GetDeviceCaps(dcHandle, LOGPIXELSX);
-            dpiX = DpiXSource / 96.0;
-            DpiYSource = GetDeviceCaps(dcHandle, LOGPIXELSY);
-            dpiY = DpiYSource / 96.0;
-            GraphicsObject.ReleaseHdc(dcHandle);
-            GraphicsObject.Dispose();
-        }
+        public static double DpiX = 0, DpiY = 0;
+        public static double DpiXSource = 96, DpiYSource = 96;
         #endregion
     }
 }

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace FlyleafLib;
 
-#pragma warning disable CA1401 // P/Invokes should not be visible
 public static partial class Utils
 {
     public static class NativeMethods
@@ -257,7 +255,26 @@ public static partial class Utils
         #region DPI
         public static double DpiX = 0, DpiY = 0;
         public static double DpiXSource = 96, DpiYSource = 96;
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr MonitorFromPoint(Point pt, uint dwFlags);
+
+        [DllImport("shcore.dll")]
+        public static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+        private const int MONITOR_DEFAULTTONEAREST = 2;
+        private const int MDT_EFFECTIVE_DPI = 0;
+        public static (double dpiX, double dpiY) GetDpiAtPoint(Point point)
+        {
+            IntPtr monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+
+            if (monitor != IntPtr.Zero && GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, out uint dpiX, out uint dpiY) == 0)
+                return (dpiX / 96.0, dpiY / 96.0);
+
+            // Fallback to primary monitor DPI
+            using var g = Graphics.FromHwnd(IntPtr.Zero);
+            return (g.DpiX / 96.0, g.DpiY / 96.0);
+        }
         #endregion
     }
 }
-#pragma warning restore CA1401 // P/Invokes should not be visible

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -22,8 +21,8 @@ public static partial class Utils
     // VLC : https://github.com/videolan/vlc/blob/master/modules/gui/qt/dialogs/preferences/simple_preferences.cpp
     // Kodi: https://github.com/xbmc/xbmc/blob/master/xbmc/settings/AdvancedSettings.cpp
 
-    public static List<string> ExtensionsAudio = new()
-    {
+    public static readonly List<string> ExtensionsAudio =
+    [
         // VLC
           "3ga" , "669" , "a52" , "aac" , "ac3"
         , "adt" , "adts", "aif" , "aifc", "aiff"
@@ -35,27 +34,27 @@ public static partial class Utils
         , "rmi" , "snd" , "s3m" , "spx" , "tta"
         , "voc" , "vqf" , "w64" , "wav" , "wma"
         , "wv"  , "xa"  , "xm"
-    };
+    ];
 
-    public static List<string> ExtensionsPictures = new()
-    {
+    public static readonly List<string> ExtensionsPictures =
+    [
         "apng", "bmp", "gif", "jpg", "jpeg", "png", "ico", "tif", "tiff", "tga","jfif"
-    };
+    ];
 
-    public static List<string> ExtensionsSubtitlesText = new()
-    {
+    public static readonly List<string> ExtensionsSubtitlesText =
+    [
         "ass", "ssa", "srt", "txt", "text", "vtt"
-    };
+    ];
 
-    public static List<string> ExtensionsSubtitlesBitmap = new()
-    {
+    public static readonly List<string> ExtensionsSubtitlesBitmap =
+    [
         "sub", "sup"
-    };
+    ];
 
-    public static List<string> ExtensionsSubtitles = [..ExtensionsSubtitlesText, ..ExtensionsSubtitlesBitmap];
+    public static readonly List<string> ExtensionsSubtitles = [..ExtensionsSubtitlesText, ..ExtensionsSubtitlesBitmap];
 
-    public static List<string> ExtensionsVideo = new()
-    {
+    public static readonly List<string> ExtensionsVideo =
+    [
         // VLC
           "3g2" , "3gp" , "3gp2", "3gpp", "amrec"
         , "amv" , "asf" , "avi" , "bik" , "divx"
@@ -72,7 +71,7 @@ public static partial class Utils
 
         // Additional
         , "dav"
-    };
+    ];
 
     private static int uniqueId;
     public static int GetUniqueId() { Interlocked.Increment(ref uniqueId); return uniqueId; }
@@ -473,7 +472,7 @@ public static partial class Utils
             if (url == null || url.Length < 5)
                 return url;
 
-            if (url[..5].ToLower() == "file:")
+            if (url[..5].Equals("file:", StringComparison.OrdinalIgnoreCase))
                 return new Uri(url).LocalPath;
         }
         catch { }
@@ -497,9 +496,7 @@ public static partial class Utils
             string targetPath = shortcut.TargetPath;
 
             if (string.IsNullOrEmpty(targetPath))
-            {
                 throw new InvalidOperationException("TargetPath is empty.");
-            }
 
             return targetPath;
         }
@@ -547,9 +544,8 @@ public static partial class Utils
             readable = i;
         }
         else
-        {
             return i.ToString("0 B"); // Byte
-        }
+
         // Divide by 1024 to get fractional value
         readable /= 1024;
         // Return formatted number with suffix
@@ -647,16 +643,15 @@ public static partial class Utils
     public static System.Windows.Media.Color VorticeToWPFColor(Vortice.Mathematics.Color sColor)
         => System.Windows.Media.Color.FromArgb(sColor.A, sColor.R, sColor.G, sColor.B);
     public static Vortice.Mathematics.Color WPFToVorticeColor(System.Windows.Media.Color wColor)
-        => new Vortice.Mathematics.Color(wColor.R, wColor.G, wColor.B, wColor.A);
+        => new(wColor.R, wColor.G, wColor.B, wColor.A);
 
-    public static double SWFREQ_TO_TICKS =  10000000.0 / Stopwatch.Frequency;
+    public static readonly double SWFREQ_TO_TICKS = 10000000.0 / Stopwatch.Frequency;
     public static string ToHexadecimal(byte[] bytes)
     {
         StringBuilder hexBuilder = new();
         for (int i = 0; i < bytes.Length; i++)
-        {
             hexBuilder.Append(bytes[i].ToString("x2"));
-        }
+
         return hexBuilder.ToString();
     }
     public static int GCD(int a, int b) => b == 0 ? a : GCD(b, a % b);

--- a/LLPlayer/Controls/Settings/SettingsPlugins.xaml.cs
+++ b/LLPlayer/Controls/Settings/SettingsPlugins.xaml.cs
@@ -38,5 +38,6 @@ public class GetDictionaryItemConverter : IMultiValueConverter
 
         return dictionary[key];
     }
-    public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture) { throw new NotImplementedException(); }
+    public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -161,11 +161,21 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBlock
                             Width="180"
-                            Text="HDR to SDR Tone" />
+                            Text="SDR Display Nits" />
+                        <Slider
+                            Width="200"
+                            Value="{Binding FL.PlayerConfig.Video.SDRDisplayNits}"
+                            Minimum="25"
+                            Maximum="400"
+                            Style="{StaticResource MaterialDesignDiscreteSlider}"
+                            materialDesign:SliderAssist.OnlyShowFocusVisualWhileDragging="True"
+                            VerticalAlignment="Center"
+                            IsSnapToTickEnabled="True" />
                         <TextBox
-                            Width="100"
-                            Text="{Binding FL.PlayerConfig.Video.HDRtoSDRTone}"
-                            helpers:TextBoxHelper.OnlyNumeric="Double" />
+                            Width="30"
+                            Margin="4 0 0 0"
+                            Text="{Binding FL.PlayerConfig.Video.SDRDisplayNits}"
+                            helpers:TextBoxHelper.OnlyNumeric="Int" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
@@ -181,51 +191,44 @@
             </GroupBox>
 
             <GroupBox Header="Filters">
-                <StackPanel>
-                    <ItemsControl ItemsSource="{Binding FL.PlayerConfig.Video.Filters.Values}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    Margin="0 0 0 8"
-                                    Visibility="{Binding Available, Converter={StaticResource BooleanToVisibilityConv}}">
-                                    <TextBlock
-                                        Width="180"
-                                        Text="{Binding Filter}" />
-                                    <Slider
-                                        Width="200"
-                                        Value="{Binding Value}"
-                                        Minimum="{Binding Minimum}"
-                                        Maximum="{Binding Maximum}"
-                                        Style="{StaticResource MaterialDesignDiscreteSlider}"
-                                        materialDesign:SliderAssist.OnlyShowFocusVisualWhileDragging="True"
-                                        VerticalAlignment="Center"
-                                        IsSnapToTickEnabled="True" />
-                                    <TextBox
-                                        Width="30"
-                                        Margin="4 0 0 0"
-                                        Text="{Binding Value}"
-                                        helpers:TextBoxHelper.OnlyNumeric="Int" />
-                                    <Button
-                                        Margin="6 0 0 0"
-                                        ToolTip="Reset to default"
-                                        Style="{StaticResource MaterialDesignIconButton}"
-                                        HorizontalAlignment="Center"
-                                        Width="24"
-                                        Height="24"
-                                        Command="{Binding SetDefaultValue}">
-                                        <materialDesign:PackIcon Kind="BackupRestore" />
-                                    </Button>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-
-                    <TextBlock Margin="10 10 10 0">
-                        Some filters will not work unless the Video Processor is D3D11.
-                        If you want to use them, Please set Video Processor to D3D11 in the Video Settings above.
-                    </TextBlock>
-                </StackPanel>
+                <ItemsControl ItemsSource="{Binding FL.PlayerConfig.Video.Filters.Values}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel
+                                Orientation="Horizontal"
+                                Margin="0 0 0 8"
+                                Visibility="{Binding Available, Converter={StaticResource BooleanToVisibilityConv}}">
+                                <TextBlock
+                                    Width="180"
+                                    Text="{Binding Filter}" />
+                                <Slider
+                                    Width="200"
+                                    Value="{Binding Value}"
+                                    Minimum="{Binding Minimum}"
+                                    Maximum="{Binding Maximum}"
+                                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                                    materialDesign:SliderAssist.OnlyShowFocusVisualWhileDragging="True"
+                                    VerticalAlignment="Center"
+                                    IsSnapToTickEnabled="True" />
+                                <TextBox
+                                    Width="30"
+                                    Margin="4 0 0 0"
+                                    Text="{Binding Value}"
+                                    helpers:TextBoxHelper.OnlyNumeric="Int" />
+                                <Button
+                                    Margin="6 0 0 0"
+                                    ToolTip="Reset to default"
+                                    Style="{StaticResource MaterialDesignIconButton}"
+                                    HorizontalAlignment="Center"
+                                    Width="24"
+                                    Height="24"
+                                    Command="{Binding SetDefaultValue}">
+                                    <materialDesign:PackIcon Kind="BackupRestore" />
+                                </Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </GroupBox>
         </StackPanel>
     </ScrollViewer>

--- a/LLPlayer/Converters/FlyleafConverters.cs
+++ b/LLPlayer/Converters/FlyleafConverters.cs
@@ -8,6 +8,23 @@ using static FlyleafLib.MediaFramework.MediaDemuxer.Demuxer;
 
 namespace LLPlayer.Converters;
 
+[ValueConversion(typeof(long), typeof(string))]
+public class TicksToTimeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var ts = TimeSpan.FromTicks((long)value);
+
+        if (ts.TotalHours > 9)
+            return ((int)ts.TotalHours) + ts.ToString(@"\:mm\:ss");
+        else
+            return ts.ToString(@"hh\:mm\:ss");
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
 [ValueConversion(typeof(int), typeof(Qualities))]
 public class QualityToLevelsConverter : IValueConverter
 {
@@ -26,14 +43,15 @@ public class QualityToLevelsConverter : IValueConverter
 
         if (videoHeight > 1080)
             return Qualities._4k;
-        if (videoHeight > 720)
+        else if (videoHeight > 720)
             return Qualities.High;
-        if (videoHeight == 720)
+        else if (videoHeight == 720)
             return Qualities.Med;
-
-        return Qualities.Low;
+        else
+            return Qualities.Low;
     }
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) { throw new NotImplementedException(); }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(int), typeof(Volumes))]
@@ -53,13 +71,15 @@ public class VolumeToLevelsConverter : IValueConverter
 
         if (volume == 0)
             return Volumes.Mute;
-        if (volume > 99)
+        else if (volume > 99)
             return Volumes.High;
-        if (volume > 49)
+        else if (volume > 49)
             return Volumes.Med;
-        return Volumes.Low;
+        else
+            return Volumes.Low;
     }
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) { throw new NotImplementedException(); }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }
 
 public class SumConverter : IMultiValueConverter
@@ -88,9 +108,7 @@ public class SumConverter : IMultiValueConverter
 public class PlaylistItemsConverter : IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
-    {
-        return $"Playlist ({values[0]}/{values[1]})";
-    }
+        => $"Playlist ({values[0]}/{values[1]})";
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         => throw new NotImplementedException();
@@ -109,6 +127,7 @@ public class ColorToHexConverter : IValueConverter
         string hex = UpperHexString(color.R) +
                       UpperHexString(color.G) +
                       UpperHexString(color.B);
+
         return hex;
     }
 
@@ -135,9 +154,7 @@ public class Tuple3Converter : IMultiValueConverter
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 public class SubIndexToIsEnabledConverter : IMultiValueConverter
@@ -158,9 +175,7 @@ public class SubIndexToIsEnabledConverter : IMultiValueConverter
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(IEnumerable<Chapter>), typeof(DoubleCollection))]
@@ -184,9 +199,7 @@ public class ChaptersToTicksConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(IEnumerable<Chapter>), typeof(TickPlacement))]
@@ -205,9 +218,7 @@ public class ChaptersToTickPlacementConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 public class AspectRatioIsCheckedConverter : IMultiValueConverter
@@ -228,7 +239,5 @@ public class AspectRatioIsCheckedConverter : IMultiValueConverter
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }

--- a/LLPlayer/Converters/GeneralConverters.cs
+++ b/LLPlayer/Converters/GeneralConverters.cs
@@ -44,7 +44,8 @@ public class BooleanToVisibilityMiscConverter : IValueConverter
         return (bool)value ? Visibility.Visible : FalseVisibility;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(double), typeof(double))]
@@ -103,7 +104,8 @@ public class EnumToStringConverter : IValueConverter
         }
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(Enum), typeof(string))]
@@ -119,9 +121,7 @@ public class EnumToDescriptionConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(Enum), typeof(bool))]
@@ -155,9 +155,7 @@ public class EnumToVisibilityConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(Color), typeof(Brush))]
@@ -166,18 +164,16 @@ public class ColorToBrushConverter : IValueConverter
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is Color color)
-        {
             return new SolidColorBrush(color);
-        }
+
         return Binding.DoNothing;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is SolidColorBrush brush)
-        {
             return brush.Color;
-        }
+
         return default(Color);
     }
 }
@@ -232,9 +228,7 @@ public class KeyToStringConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 [ValueConversion(typeof(long), typeof(string))]
@@ -251,9 +245,7 @@ public class FileSizeHumanConverter : IValueConverter
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 
     private static string FormatBytes(long bytes)
     {

--- a/LLPlayer/LLPlayer.csproj
+++ b/LLPlayer/LLPlayer.csproj
@@ -14,6 +14,7 @@
     <Description>The media player for language learning.</Description>
     <PackageProjectUrl>https://llplayer.com</PackageProjectUrl>
     <Version>0.2.2</Version>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LLPlayer/Resources/Converters.xaml
+++ b/LLPlayer/Resources/Converters.xaml
@@ -5,12 +5,12 @@
 
     <!--Flyleaf Converters-->
     <flyleaf:StringToRationalConverter x:Key="StringToRationalConv"/>
-    <flyleaf:TicksToTimeConverter x:Key="TicksToTimeConv"/>
     <flyleaf:TicksToSecondsConverter x:Key="TicksToSecondsConv" />
     <flyleaf:TicksToTimeSpanConverter x:Key="TicksToTimeSpanConv"/>
     <flyleaf:TicksToMilliSecondsConverter x:Key="TicksToMilliSecondsConv"/>
 
     <!--Flyleaf WPF Converters-->
+    <conv:TicksToTimeConverter x:Key="TicksToTimeConv"/>
     <conv:QualityToLevelsConverter x:Key="QualityToLevelsConv"/>
     <conv:VolumeToLevelsConverter x:Key="VolumeToLevelsConv"/>
     <conv:SumConverter x:Key="SumConv"/>

--- a/LLPlayer/app.manifest
+++ b/LLPlayer/app.manifest
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2</dpiAwareness>
+			<longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+		</windowsSettings>
+	</application>
+</assembly>


### PR DESCRIPTION
Update FlyleafLib v3.8.6 from v3.8.5

## Changelog
- FlyleafHost: Fixes dynamic changes issue with DPI awareness
- Player.Open: Fixes a null reference issue
- Renderer: Adds support for custom Direct2D (with Vortice) overlay drawing
- Renderer: Better handling of common HDR to SDR (HDR10/HLG)
- Renderer: Tonemaps (Hable/Reinhard/Aces) Improvements
- Renderer: Adds Config.Video.SDRDisplayNits which improves HDR to SDR based on monitor's peak brightness
- Renderer: Adds support for BT.2020 SDR
- Renderer: Improves support for YUV full color range sources
- Renderer: Adds Hue/Saturation Filters
- Renderer: Overall Performance Improvements
- FlyleafME: Support for > 24h
- FlyleafME: Updated Settings

[Breaking Changes]
- Config.Video.HDRtoSDRTone replaces by SDRDisplayNits

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/50557f99c895b19e654e5e3352090a5e4a6b3e65...43f523c8f86af8ce688ba586214b0a3bf6f2e0ff