### PR TITLE
Update FlyleafLib v3.8.7

### DIFF
--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -121,16 +121,17 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="PanXOffset"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.PanXOffset}"/>
+                    <TextBlock Style="{StaticResource TextInfo}" Text="Pan Offsets"/>
+                    <TextBlock Style="{StaticResource TextValue}">
+                        <TextBlock Style="{StaticResource TextValue}">
+                            <Run Text="{Binding Player.PanXOffset, Mode=OneWay}"/>
+                            <Run Text="|"/>
+                            <Run Text="{Binding Player.PanYOffset, Mode=OneWay}"/>
+                        </TextBlock>
+                    </TextBlock>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="PanYOffset"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.PanYOffset}"/>
-                </StackPanel>
-
-                 <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="Rotation"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Rotation}"/>
                 </StackPanel>
@@ -229,18 +230,17 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="Config|AspectRatio"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Config.Video.AspectRatio}"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="CustomAspectRatio"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Config.Video.CustomAspectRatio}"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="AspectRatio"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.AspectRatio}"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{StaticResource TextInfo}" Text="Size"/>
+                    <TextBlock Style="{StaticResource TextValue}">
+                        <Run Text="{Binding Player.Video.Width, Mode=OneWay}"/>
+                        <Run Text="x"/>
+                        <Run Text="{Binding Player.Video.Height, Mode=OneWay}"/>
+                    </TextBlock>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
@@ -249,13 +249,8 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="Width"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.Width}"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="Height"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.Height}"/>
+                    <TextBlock Style="{StaticResource TextInfo}" Text="Color Format"/>
+                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.ColorFormat}"/>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
@@ -269,8 +264,13 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="ProfileMismatch"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Config.Decoder.AllowProfileMismatch}"/>
+                    <TextBlock Style="{StaticResource TextInfo}" Text="DeInterlace"/>
+                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.FieldType}"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+                    <TextBlock Style="{StaticResource TextInfo}" Text="ZeroCopy"/>
+                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.ZeroCopy}"/>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
@@ -282,12 +282,6 @@
                     <TextBlock Style="{StaticResource TextInfo}" Text="VideoProcessor"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.VideoProcessor}"/>
                 </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="ZeroCopy"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.ZeroCopy}"/>
-                </StackPanel>
-
             </StackPanel>
 
             <!-- Subtitles -->

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -342,11 +342,6 @@ public class Config : NotifyPropertyChanged
         public long     SeekAccurateFixMargin       { get; set => Set(ref field, value); } = TimeSpan.FromMilliseconds(0).Ticks;
 
         /// <summary>
-        /// Margin time to move back forward when getting frame (ticks)
-        /// </summary>
-        public long     SeekGetFrameFixMargin       { get; set => Set(ref field, value); } = TimeSpan.FromMilliseconds(3000).Ticks;
-
-        /// <summary>
         /// Snapshot encoding will be used (valid formats bmp, png, jpg/jpeg)
         /// </summary>
         public string   SnapshotFormat              { get ;set; } = "bmp";
@@ -797,15 +792,8 @@ public class Config : NotifyPropertyChanged
         public Vortice.DXGI.PresentFlags
                                 PresentFlags                { get; set; } = Vortice.DXGI.PresentFlags.DoNotWait;
 
-        /// <summary>
-        /// Enables the video processor to perform post process deinterlacing
-        /// (D3D11 video processor should be enabled and support bob deinterlace method)
-        /// </summary>
-        public bool             Deinterlace                 { get=> _Deinterlace;   set { if (Set(ref _Deinterlace, value)) player?.renderer?.UpdateDeinterlace(); } }
-        bool _Deinterlace;
-
-        public bool             DeinterlaceBottomFirst      { get=> _DeinterlaceBottomFirst; set { if (Set(ref _DeinterlaceBottomFirst, value)) player?.renderer?.UpdateDeinterlace(); } }
-        bool _DeinterlaceBottomFirst;
+        public DeInterlace      DeInterlace                 { get => _DeInterlace;  set { if (Set(ref _DeInterlace, value)) player?.renderer?.UpdateDeinterlace(); } }
+        DeInterlace _DeInterlace = DeInterlace.Auto;
 
         /// <summary>
         /// The HDR to SDR method that will be used by the pixel shader
@@ -818,7 +806,7 @@ public class Config : NotifyPropertyChanged
         /// SDR Display Peak Luminance (will be used for HDR to SDR conversion)
         /// </summary>
         public unsafe float     SDRDisplayNits              { get => _SDRDisplayNits; set { if (Set(ref _SDRDisplayNits, value) && player != null && player.VideoDecoder.VideoStream != null && player.VideoDecoder.VideoStream.ColorSpace == ColorSpace.BT2020) player.renderer.UpdateHDRtoSDR(); } }
-        float _SDRDisplayNits = 200f; // TODO: Retrieve this through Vortice (output6) but currently not supported
+        float _SDRDisplayNits = Engine.Video.RecommendedLuminance;
 
         /// <summary>
         /// Whether the renderer will use 10-bit swap chaing or 8-bit output

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Data;
 
 using FlyleafLib.Controls.WPF;
 using FlyleafLib.MediaFramework.MediaDecoder;
@@ -36,7 +37,7 @@ public class Config : NotifyPropertyChanged
 
             if (defaultOptions == null || defaultOptions.Count == 0) continue;
 
-            Plugins.Add(plugin.Name, new ObservableDictionary<string, string>());
+            Plugins.Add(plugin.Name, []);
             foreach (var opt in defaultOptions)
                 Plugins[plugin.Name].Add(opt.Key, opt.Value);
         }
@@ -95,12 +96,8 @@ public class Config : NotifyPropertyChanged
 
             // plugin option deleted
             foreach (var opt in plugin.Value)
-            {
                 if (!config.defaultPlugins[plugin.Key].ContainsKey(opt.Key))
-                {
                     config.Plugins[plugin.Key].Remove(opt.Key);
-                }
-            }
         }
 
         // Restore added plugin options
@@ -115,12 +112,8 @@ public class Config : NotifyPropertyChanged
 
             // plugin option added
             foreach (var opt in plugin.Value)
-            {
                 if (!config.Plugins[plugin.Key].ContainsKey(opt.Key))
-                {
                     config.Plugins[plugin.Key][opt.Key] = opt.Value;
-                }
-            }
         }
 
         config.UpdateDefault();
@@ -668,17 +661,23 @@ public class Config : NotifyPropertyChanged
         bool _LowDelay;
 
         public Dictionary<string, string>
-                                AudioCodecOpt       { get; set; } = new();
+                                AudioCodecOpt       { get; set; } = [];
         public Dictionary<string, string>
-                                VideoCodecOpt       { get; set; } = new();
+                                VideoCodecOpt       { get; set; } = [];
         public Dictionary<string, string>
-                                SubtitlesCodecOpt   { get; set; } = new();
+                                SubtitlesCodecOpt   { get; set; } = [];
 
         public Dictionary<string, string> GetCodecOptPtr(MediaType type)
             => type == MediaType.Video ? VideoCodecOpt : type == MediaType.Audio ? AudioCodecOpt : SubtitlesCodecOpt;
     }
     public class VideoConfig : NotifyPropertyChanged
     {
+        public VideoConfig()
+        {
+            BindingOperations.EnableCollectionSynchronization(Filters, lockFilters);
+            BindingOperations.EnableCollectionSynchronization(D3Filters, lockD3Filters);
+        }
+
         public VideoConfig Clone()
         {
             VideoConfig video = (VideoConfig) MemberwiseClone();
@@ -844,19 +843,16 @@ public class Config : NotifyPropertyChanged
         internal void OnD2DDraw(Renderer renderer, Vortice.Direct2D1.ID2D1DeviceContext context)
             => D2DDraw?.Invoke(renderer, context);
 
-        public Dictionary<VideoFilters, VideoFilter> Filters { get ; set; } = DefaultFilters();
-
-        public static Dictionary<VideoFilters, VideoFilter> DefaultFilters()
-        {
-            Dictionary<VideoFilters, VideoFilter> filters = [];
-
-            var available = Enum.GetValues(typeof(VideoFilters));
-
-            foreach(object filter in available)
-                filters.Add((VideoFilters)filter, new VideoFilter((VideoFilters)filter));
-
-            return filters;
-        }
+        /// <summary>
+        /// When you change a filter value from one VP will update also the other if exists (however might not exact same picture output)
+        /// </summary>
+        public bool             SyncVPFilters               { get; set; } = true;
+        public ObservableDictionary<VideoFilters, FLVideoFilter> Filters
+                                                            { get ; set; } = [];
+        public ObservableDictionary<VideoFilters, D3VideoFilter> D3Filters
+                                                            { get ; set; } = [];
+        internal readonly object lockFilters    = new();
+        internal readonly object lockD3Filters  = new();
     }
     public class AudioConfig : NotifyPropertyChanged
     {

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -16,7 +16,7 @@ public class VideoEngine
     /// </summary>
     public ObservableCollection<VideoDevice>
                             CapDevices          { get; set; } = [];
-    
+
     /// <summary>
     /// List of GPU Adpaters <see cref="Config.VideoConfig.GPUAdapter"/>
     /// </summary>
@@ -27,6 +27,7 @@ public class VideoEngine
     /// List of GPU Outputs from default GPU Adapter (Note: will no be updated on screen connect/disconnect)
     /// </summary>
     public List<GPUOutput>  Screens             { get; private set; } = [];
+    public float            RecommendedLuminance{ get; set; }
 
     internal IDXGIFactory2  Factory;
 
@@ -55,7 +56,7 @@ public class VideoEngine
 
     private Dictionary<long, GPUAdapter> GetAdapters()
     {
-        Dictionary<long, GPUAdapter> adapters = new();
+        Dictionary<long, GPUAdapter> adapters = [];
 
         string dump = "";
 
@@ -63,22 +64,52 @@ public class VideoEngine
         {
             bool hasOutput = false;
 
-            List<GPUOutput> outputs = new();
+            List<GPUOutput> outputs = [];
 
             int maxHeight = 0;
-            for (uint o=0; adapter.EnumOutputs(o, out var output).Success; o++)
+            for (uint o = 0; adapter.EnumOutputs(o, out var output).Success; o++)
             {
-                GPUOutput gpout = new()
+                IDXGIOutput6 output6 = null;
+                GPUOutput gpout;
+
+                if (Environment.OSVersion.Version.Major >= 10)
+                    try { output6 = output.QueryInterface<IDXGIOutput6>(); } catch { }
+
+                if (output6 != null)
                 {
-                    Id        = GPUOutput.GPUOutputIdGenerator++,
-                    DeviceName= output.Description.DeviceName,
-                    Left      = output.Description.DesktopCoordinates.Left,
-                    Top       = output.Description.DesktopCoordinates.Top,
-                    Right     = output.Description.DesktopCoordinates.Right,
-                    Bottom    = output.Description.DesktopCoordinates.Bottom,
-                    IsAttached= output.Description.AttachedToDesktop,
-                    Rotation  = (int)output.Description.Rotation
-                };
+                    var outdesc = output6.Description1;
+
+                    gpout = new()
+                    {
+                        Id          = GPUOutput.GPUOutputIdGenerator++,
+                        DeviceName  = outdesc.DeviceName,
+                        Left        = outdesc.DesktopCoordinates.Left,
+                        Top         = outdesc.DesktopCoordinates.Top,
+                        Right       = outdesc.DesktopCoordinates.Right,
+                        Bottom      = outdesc.DesktopCoordinates.Bottom,
+                        IsAttached  = outdesc.AttachedToDesktop,
+                        Rotation    = (int)outdesc.Rotation,
+                        MaxLuminance= outdesc.MaxLuminance
+                    };
+
+                    output6.Dispose();
+                }
+                else
+                {
+                    var outdesc = output.Description;
+
+                    gpout = new()
+                    {
+                        Id          = GPUOutput.GPUOutputIdGenerator++,
+                        DeviceName  = outdesc.DeviceName,
+                        Left        = outdesc.DesktopCoordinates.Left,
+                        Top         = outdesc.DesktopCoordinates.Top,
+                        Right       = outdesc.DesktopCoordinates.Right,
+                        Bottom      = outdesc.DesktopCoordinates.Bottom,
+                        IsAttached  = outdesc.AttachedToDesktop,
+                        Rotation    = (int)outdesc.Rotation
+                    };
+                }
 
                 if (maxHeight < gpout.Height)
                     maxHeight = gpout.Height;
@@ -86,29 +117,37 @@ public class VideoEngine
                 outputs.Add(gpout);
 
                 if (gpout.IsAttached)
+                {
                     hasOutput = true;
+                    if (gpout.MaxLuminance > 0 && (RecommendedLuminance == 0 || gpout.MaxLuminance < RecommendedLuminance))
+                        RecommendedLuminance = gpout.MaxLuminance;
+                }
 
                 output.Dispose();
             }
 
+            if (RecommendedLuminance == 0)
+                RecommendedLuminance = 200;
+
             if (Screens.Count == 0 && outputs.Count > 0)
                 Screens = outputs;
 
-            adapters[adapter.Description1.Luid] = new GPUAdapter()
+            var adapterdesc = adapter.Description1;
+            adapters[adapterdesc.Luid] = new GPUAdapter()
             {
-                SystemMemory    = adapter.Description1.DedicatedSystemMemory.Value,
-                VideoMemory     = adapter.Description1.DedicatedVideoMemory.Value,
-                SharedMemory    = adapter.Description1.SharedSystemMemory.Value,
-                Vendor          = VendorIdStr(adapter.Description1.VendorId),
-                Description     = adapter.Description1.Description,
-                Id              = adapter.Description1.DeviceId,
-                Luid            = adapter.Description1.Luid,
+                SystemMemory    = adapterdesc.DedicatedSystemMemory.Value,
+                VideoMemory     = adapterdesc.DedicatedVideoMemory.Value,
+                SharedMemory    = adapterdesc.SharedSystemMemory.Value,
+                Vendor          = VendorIdStr(adapterdesc.VendorId),
+                Description     = adapterdesc.Description,
+                Id              = adapterdesc.DeviceId,
+                Luid            = adapterdesc.Luid,
                 MaxHeight       = maxHeight,
                 HasOutput       = hasOutput,
                 Outputs         = outputs
             };
 
-            dump += $"[#{i+1}] {adapters[adapter.Description1.Luid]}\r\n";
+            dump += $"[#{i+1}] {adapters[adapterdesc.Luid]}\r\n";
 
             adapter.Dispose();
         }

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -38,6 +38,14 @@ public enum HDRtoSDRMethod : int
     Hable       = 2,
     Reinhard    = 3
 }
+
+public enum DeInterlace : int
+{
+    Auto        = -2,
+    Progressive = -1,
+    TopField    =  0,
+    BottomField =  1
+}
 public enum VideoProcessors
 {
     Auto,
@@ -89,18 +97,19 @@ public enum SubASREngineType
 
 public class GPUOutput
 {
-    public static int GPUOutputIdGenerator;
+    internal static int GPUOutputIdGenerator;
 
-    public int      Id          { get; set; }
-    public string   DeviceName  { get; internal set; }
-    public int      Left        { get; internal set; }
-    public int      Top         { get; internal set; }
-    public int      Right       { get; internal set; }
-    public int      Bottom      { get; internal set; }
-    public int      Width       => Right- Left;
-    public int      Height      => Bottom- Top;
-    public bool     IsAttached  { get; internal set; }
-    public int      Rotation    { get; internal set; }
+    public int      Id              { get; internal set; }
+    public string   DeviceName      { get; internal set; }
+    public int      Left            { get; internal set; }
+    public int      Top             { get; internal set; }
+    public int      Right           { get; internal set; }
+    public int      Bottom          { get; internal set; }
+    public int      Width           => Right- Left;
+    public int      Height          => Bottom- Top;
+    public bool     IsAttached      { get; internal set; }
+    public int      Rotation        { get; internal set; }
+    public float    MaxLuminance    { get; internal set; }
 
     public override string ToString()
     {

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.6</Version>
+    <Version>3.8.7</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -792,14 +792,23 @@ public unsafe partial class DecoderContext : PluginHandler
                         VideoDecoder.StartTime = (long)(frame->pts * VideoStream.Timebase) - VideoDemuxer.StartTime;
 
                         var mFrame = VideoDecoder.Renderer.FillPlanes(frame);
-                        if (mFrame != null) VideoDecoder.Frames.Enqueue(mFrame);
+                        if (mFrame != null)
+                            VideoDecoder.Frames.Enqueue(mFrame);
+                        else if (VideoDecoder.handleDeviceReset)
+                        {
+                            VideoDecoder.HandleDeviceReset();
+                            continue;
+                        }
 
                         do
                         {
                             ret = avcodec_receive_frame(VideoDecoder.CodecCtx, frame);
                             if (ret != 0) break;
                             mFrame = VideoDecoder.Renderer.FillPlanes(frame);
-                            if (mFrame != null) VideoDecoder.Frames.Enqueue(mFrame);
+                            if (mFrame != null)
+                                VideoDecoder.Frames.Enqueue(mFrame);
+                            else if (VideoDecoder.handleDeviceReset)
+                                VideoDecoder.HandleDeviceReset();
                         } while (!VideoDemuxer.Disposed && !Interrupt);
 
                         av_frame_free(&frame);

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -662,6 +662,7 @@ public unsafe class VideoDecoder : DecoderBase
             skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
             CodecChanged?.Invoke(this);
 
+            DisposeFrame(Renderer.LastFrame);
             if (VideoStream.PixelFormat == AVPixelFormat.None || !Renderer.ConfigPlanes())
             {
                 Log.Error("[Pixel Format] Unknown");

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -20,7 +20,7 @@ namespace FlyleafLib.MediaFramework.MediaDecoder;
 public unsafe class VideoDecoder : DecoderBase
 {
     public ConcurrentQueue<VideoFrame>
-                            Frames              { get; protected set; } = new ConcurrentQueue<VideoFrame>();
+                            Frames              { get; protected set; } = [];
     public Renderer         Renderer            { get; private set; }
     public bool             VideoAccelerated    { get; internal set; }
     public bool             ZeroCopy            { get; internal set; }
@@ -35,7 +35,7 @@ public unsafe class VideoDecoder : DecoderBase
     const SwsFlags          SCALING_LQ          = SwsFlags.Bicublin;
 
     internal SwsContext*    swsCtx;
-    IntPtr                  swsBufferPtr;
+    nint                    swsBufferPtr;
     internal byte_ptrArray4 swsData;
     internal int_array4     swsLineSize;
 
@@ -46,15 +46,19 @@ public unsafe class VideoDecoder : DecoderBase
     bool                    checkExtraFrames; // DecodeFrameNext
 
     // Reverse Playback
-    ConcurrentStack<List<IntPtr>>
-                            curReverseVideoStack    = new();
-    List<IntPtr>            curReverseVideoPackets  = new();
-    List<VideoFrame>        curReverseVideoFrames   = new();
+    ConcurrentStack<List<nint>>
+                            curReverseVideoStack    = [];
+    List<nint>              curReverseVideoPackets  = [];
+    List<VideoFrame>        curReverseVideoFrames   = [];
     int                     curReversePacketPos     = 0;
 
     // Drop frames if FPS is higher than allowed
     int                     curSpeedFrame           = 9999; // don't skip first frame (on start/after seek-flush)
     double                  skipSpeedFrames         = 0;
+
+    // Fixes Seek Backwards failure on broken formats
+    long                    curFixSeekDelta         = 0;
+    const long              FIX_SEEK_DELTA_MCS      = 2_100_000;
 
     public VideoDecoder(Config config, int uniqueId = -1) : base(config, uniqueId)
         => getHWformat = new AVCodecContext_get_format(get_format);
@@ -75,12 +79,12 @@ public unsafe class VideoDecoder : DecoderBase
     public void CreateRenderer() // TBR: It should be in the constructor but DecoderContext will not work with null VideoDecoder for AudioOnly
     {
         if (Renderer == null)
-            Renderer = new Renderer(this, IntPtr.Zero, UniqueId);
+            Renderer = new Renderer(this, 0, UniqueId);
         else if (Renderer.Disposed)
             Renderer.Initialize();
     }
     public void DestroyRenderer() => Renderer?.Dispose();
-    public void CreateSwapChain(IntPtr handle)
+    public void CreateSwapChain(nint handle)
     {
         CreateRenderer();
         Renderer.InitializeSwapChain(handle);
@@ -265,7 +269,7 @@ public unsafe class VideoDecoder : DecoderBase
         {
             lock (Renderer.lockDevice)
             {
-                textureFFmpeg   = new ID3D11Texture2D((IntPtr) va_frames_ctx->texture);
+                textureFFmpeg   = new ID3D11Texture2D((nint) va_frames_ctx->texture);
                 ZeroCopy = Config.Decoder.ZeroCopy == FlyleafLib.ZeroCopy.Enabled || (Config.Decoder.ZeroCopy == FlyleafLib.ZeroCopy.Auto && codecCtx->width == textureFFmpeg.Description.Width && codecCtx->height == textureFFmpeg.Description.Height);
                 filledFromCodec = false;
             }
@@ -622,6 +626,7 @@ public unsafe class VideoDecoder : DecoderBase
             int ret = 0;
 
             filledFromCodec = true;
+            curFixSeekDelta = 0;
 
             avcodec_parameters_from_context(Stream.AVStream->codecpar, codecCtx);
             VideoStream.AVStream->time_base = codecCtx->pkt_timebase;
@@ -633,6 +638,19 @@ public unsafe class VideoDecoder : DecoderBase
                 VideoStream.FrameDuration   = VideoStream.FPS > 0 ? (long) (10000000 / VideoStream.FPS) : 0;
                 if (VideoStream.FrameDuration > 0)
                     VideoStream.Demuxer.VideoPackets.frameDuration = VideoStream.FrameDuration;
+            }
+
+            if (VideoStream.FieldOrder != DeInterlace.Progressive)
+            {
+                VideoStream.FPS2 = VideoStream.FPS;
+                VideoStream.FrameDuration2 = VideoStream.FrameDuration;
+                VideoStream.FPS /= 2;
+                VideoStream.FrameDuration *= 2;
+            }
+            else
+            {
+                VideoStream.FPS2 = VideoStream.FPS * 2;
+                VideoStream.FrameDuration2 = VideoStream.FrameDuration / 2;
             }
 
             skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
@@ -788,14 +806,14 @@ public unsafe class VideoDecoder : DecoderBase
                         {
                             packet = (AVPacket*)curReverseVideoPackets[i];
                             av_packet_free(&packet);
-                            curReverseVideoPackets[curReversePacketPos - 1] = IntPtr.Zero;
+                            curReverseVideoPackets[curReversePacketPos - 1] = 0;
                             curReverseVideoPackets.RemoveAt(i);
                         }
 
                         avcodec_flush_buffers(codecCtx);
                         curReversePacketPos = 0;
 
-                        for (int i=curReverseVideoFrames.Count -1; i>=0; i--)
+                        for (int i = curReverseVideoFrames.Count - 1; i >= 0; i--)
                             Frames.Enqueue(curReverseVideoFrames[i]);
 
                         curReverseVideoFrames.Clear();
@@ -818,7 +836,7 @@ public unsafe class VideoDecoder : DecoderBase
                         if (shouldProcess)
                         {
                             av_packet_free(&packet);
-                            curReverseVideoPackets[curReversePacketPos - 1] = IntPtr.Zero;
+                            curReverseVideoPackets[curReversePacketPos - 1] = 0;
                             var mFrame = Renderer.FillPlanes(frame);
                             if (mFrame != null) curReverseVideoFrames.Add(mFrame);
                         }
@@ -873,68 +891,82 @@ public unsafe class VideoDecoder : DecoderBase
         }
     }
 
+    /// <summary>
+    /// Gets the frame number of a VideoFrame timestamp
+    /// </summary>
+    /// <param name="timestamp"></param>
+    /// <returns></returns>
     public int GetFrameNumber(long timestamp)
-    {
-        // Incoming timestamps are zero-base from demuxer start time (not from video stream start time)
-        timestamp -= VideoStream.StartTime - demuxer.StartTime;
+        => Math.Max(0, (int)((timestamp + 2_0000 - VideoStream.StartTime + demuxer.StartTime) / VideoStream.FrameDuration));
 
-        if (timestamp < 1)
-            return 0;
+    /// <summary>
+    /// Gets the frame number of an AVFrame timestamp
+    /// </summary>
+    /// <param name="timestamp"></param>
+    /// <returns></returns>
+    public int GetFrameNumber2(long timestamp)
+        => Math.Max(0, (int)((timestamp + 2_0000 - VideoStream.StartTime) / VideoStream.FrameDuration));
 
-        // offset 2ms
-        return (int) ((timestamp + 20000) / VideoStream.FrameDuration);
-    }
+    /// <summary>
+    /// Gets the VideoFrame timestamp from the frame number
+    /// </summary>
+    /// <param name="frameNumber"></param>
+    /// <returns></returns>
+    public long GetFrameTimestamp(int frameNumber)
+        => VideoStream.StartTime + (frameNumber * VideoStream.FrameDuration);
 
     /// <summary>
     /// Performs accurate seeking to the requested VideoFrame and returns it
     /// </summary>
-    /// <param name="index">Zero based frame index</param>
+    /// <param name="frameNumber">Zero based frame index</param>
     /// <returns>The requested VideoFrame or null on failure</returns>
-    public VideoFrame GetFrame(int index)
+    public VideoFrame GetFrame(int frameNumber)
     {
-        int ret;
+        long requiredTimestamp = GetFrameTimestamp(frameNumber);
+        long curSeekMcs = requiredTimestamp / 10;
+        int curFrameNumber;
 
-        // Calculation of FrameX timestamp (based on fps/avgFrameDuration) | offset 2ms
-        long frameTimestamp = VideoStream.StartTime + (index * VideoStream.FrameDuration) - 20000;
-        //Log.Debug($"Searching for {Utils.TicksToTime(frameTimestamp)}");
-
-        demuxer.Pause();
-        Pause();
-
-        // TBR
-        //if (demuxer.FormatContext->pb != null)
-        //    avio_flush(demuxer.FormatContext->pb);
-        //avformat_flush(demuxer.FormatContext);
-
-        // Seeking at frameTimestamp or previous I/Key frame and flushing codec | Temp fix (max I/distance 3sec) for ffmpeg bug that fails to seek on keyframe with HEVC
-        // More issues with mpegts seeking backwards (those should be used also in the reverse playback in the demuxer)
-        demuxer.Interrupter.SeekRequest();
-        ret = codecCtx->codec_id == AVCodecID.Hevc|| (demuxer.FormatContext->iformat != null) // TBR: this is on FFInputFormat now -> && demuxer.FormatContext->iformat-> read_seek.Pointer == IntPtr.Zero)
-            ? av_seek_frame(demuxer.FormatContext, -1, Math.Max(0, frameTimestamp - Config.Player.SeekGetFrameFixMargin) / 10, SeekFlags.Any)
-            : av_seek_frame(demuxer.FormatContext, -1, frameTimestamp / 10, SeekFlags.Frame | SeekFlags.Backward);
-
-        demuxer.DisposePackets();
-
-        if (demuxer.Status == Status.Ended) demuxer.Status = Status.Stopped;
-        if (ret < 0) return null; // handle seek error
-        Flush();
-        checkExtraFrames = false;
-
-        while (DecodeFrameNext() == 0)
+        do
         {
-            // Skip frames before our actual requested frame
-            if ((long)(frame->pts * VideoStream.Timebase) < frameTimestamp)
+            demuxer.Pause();
+            Pause();
+            demuxer.Interrupter.SeekRequest();
+            int ret = av_seek_frame(demuxer.FormatContext, -1, curSeekMcs - curFixSeekDelta, SeekFlags.Frame | SeekFlags.Backward);
+
+            demuxer.DisposePackets();
+
+            if (demuxer.Status == Status.Ended)
+                demuxer.Status = Status.Stopped;
+
+            if (ret < 0)
+                return null;
+
+            Flush();
+            checkExtraFrames = false;
+
+            if (DecodeFrameNext() != 0)
+                return null;
+
+            long seekedTimestamp = (long)(frame->pts * VideoStream.Timebase);
+
+            if (GetFrameNumber2(seekedTimestamp) > frameNumber)
             {
-                //Log.Debug($"[Skip] [pts: {frame->pts}] [time: {Utils.TicksToTime((long)(frame->pts * VideoStream.Timebase))}] | [fltime: {Utils.TicksToTime(((long)(frame->pts * VideoStream.Timebase) - demuxer.StartTime))}]");
-                av_frame_unref(frame);
+                curFixSeekDelta += FIX_SEEK_DELTA_MCS;
                 continue;
             }
 
-            //Log.Debug($"[Found] [pts: {frame->pts}] [time: {Utils.TicksToTime((long)(frame->pts * VideoStream.Timebase))}] | {Utils.TicksToTime(VideoStream.StartTime + (index * VideoStream.FrameDuration))} | [fltime: {Utils.TicksToTime(((long)(frame->pts * VideoStream.Timebase) - demuxer.StartTime))}]");
-            return Renderer.FillPlanes(frame);
-        }
+            do
+            {
+                curFrameNumber = GetFrameNumber2((long)(frame->pts * VideoStream.Timebase));
+                if (curFrameNumber >= frameNumber)
+                    return Renderer.FillPlanes(frame);
 
-        return null;
+                av_frame_unref(frame);
+
+            } while (DecodeFrameNext() == 0);
+
+            return null;
+        } while (true);
     }
 
     /// <summary>
@@ -1082,7 +1114,7 @@ public unsafe class VideoDecoder : DecoderBase
             curReverseVideoStack.TryPop(out var t2);
             for (int i = 0; i<t2.Count; i++)
             {
-                if (t2[i] == IntPtr.Zero) continue;
+                if (t2[i] == 0) continue;
                 AVPacket* packet = (AVPacket*)t2[i];
                 av_packet_free(&packet);
             }
@@ -1090,7 +1122,7 @@ public unsafe class VideoDecoder : DecoderBase
 
         for (int i = 0; i<curReverseVideoPackets.Count; i++)
         {
-            if (curReverseVideoPackets[i] == IntPtr.Zero) continue;
+            if (curReverseVideoPackets[i] == 0) continue;
             AVPacket* packet = (AVPacket*)curReverseVideoPackets[i];
             av_packet_free(&packet);
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -1,7 +1,6 @@
 ﻿using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-
 using Vortice;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
@@ -252,6 +251,7 @@ public unsafe partial class Renderer
                     ByteWidth       = (uint)(sizeof(PSBufferType) + (16 - (sizeof(PSBufferType) % 16)))
                 });
                 context.PSSetConstantBuffer(0, psBuffer);
+                psBufferData.fieldType = FieldType;
                 UpdateHDRtoSDR(false); // TODO: Passing Config -> psBuffer (currently mixed with Initialize filters)
 
                 // subs
@@ -479,9 +479,14 @@ public unsafe partial class Renderer
         public float contrast;
         public float hue;
         public float saturation;
-        public float texWidth;
+        public float uvOffset;
+        public float yoffset;
         public HDRtoSDRMethod tonemap;
         public float hdrtone;
+        public DeInterlace fieldType;
+
+        private float _pad1;
+        private float _pad2;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -98,7 +98,7 @@ public unsafe partial class Renderer
     ID3D11PixelShader   ShaderBGRA;
 
     ID3D11Buffer        psBuffer;
-    PSBufferType        psBufferData;
+    PSBufferType        psBufferData = new();
 
     ID3D11Buffer        vsBuffer;
     VSBufferType        vsBufferData;
@@ -133,7 +133,7 @@ public unsafe partial class Renderer
                 #endif
 
                 // Finding User Definied adapter
-                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.ToUpper() != "WARP")
+                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && !Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
                 {
                     for (uint i=0; Engine.Video.Factory.EnumAdapters1(i, out adapter).Success; i++)
                     {
@@ -154,7 +154,7 @@ public unsafe partial class Renderer
                 }
 
                 // Creating WARP (force by user or us after late failure)
-                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.ToUpper() == "WARP")
+                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
                     D3D11.D3D11CreateDevice(null, DriverType.Warp, creationFlagsWarp, featureLevels, out tempDevice).CheckError();
 
                 // Creating User Defined or Default
@@ -252,7 +252,6 @@ public unsafe partial class Renderer
                 });
                 context.PSSetConstantBuffer(0, psBuffer);
                 psBufferData.fieldType = FieldType;
-                UpdateHDRtoSDR(false); // TODO: Passing Config -> psBuffer (currently mixed with Initialize filters)
 
                 // subs
                 ShaderBGRA = ShaderCompiler.CompilePS(Device, "bgra", @"color = float4(Texture1.Sample(Sampler, input.Texture).rgba);", null);
@@ -270,7 +269,7 @@ public unsafe partial class Renderer
 
             } catch (Exception e)
             {
-                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || Config.Video.GPUAdapter.ToUpper() != "WARP")
+                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || !Config.Video.GPUAdapter.Equals("WARP", StringComparison.OrdinalIgnoreCase))
                 {
                     try { if (Device != null) Log.Warn($"Device Remove Reason = {Device.DeviceRemovedReason.Description}"); } catch { } // For troubleshooting
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -492,10 +492,13 @@ public unsafe partial class Renderer
     struct PSBufferType
     {
         public int coefsIndex;
-        public float brightness;
-        public float contrast;
-        public float hue;
-        public float saturation;
+
+        // Filters
+        public float brightness;    // -0.5  to 0.5     (0.0 default)
+        public float contrast;      //  0.0  to 2.0     (1.0 default)
+        public float hue;           // -3.14 to 3.14    (0.0 default)
+        public float saturation;    //  0.0  to 2.0     (1.0 default)
+
         public float uvOffset;
         public float yoffset;
         public HDRtoSDRMethod tonemap;
@@ -504,6 +507,17 @@ public unsafe partial class Renderer
 
         private float _pad1;
         private float _pad2;
+
+        public PSBufferType()
+        {
+            brightness  = 0;
+            contrast    = 1;
+            hue         = 0;
+            saturation  = 1;
+
+            tonemap     = HDRtoSDRMethod.Hable;
+            fieldType   = DeInterlace.Progressive;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -457,6 +457,23 @@ public unsafe partial class Renderer
         }
     }
 
+    void HandleDeviceReset()
+    {
+        if (VideoDecoder != null && VideoStream != null)
+        {
+            var running = VideoDecoder.IsRunning;
+            var stream = VideoStream;
+            VideoDecoder.Dispose();
+            Flush();
+            VideoDecoder.Open(stream); // Should Re-ConfigPlanes()
+            VideoDecoder.keyPacketRequired = true;
+            if (running)
+                VideoDecoder.Start();
+        }
+        else
+            Flush();
+    }
+
     #if DEBUG
     public static void ReportLiveObjects()
     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Filters.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Filters.cs
@@ -1,0 +1,323 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+using Vortice.Direct3D11;
+
+using FlyleafLib.Controls.WPF;
+
+using static FlyleafLib.Utils;
+
+namespace FlyleafLib.MediaFramework.MediaRenderer;
+
+unsafe public partial class Renderer
+{
+    bool alreadySetup;
+    void SetupFilters()
+    {
+        var cfgFLFilters = Config.Video.Filters;
+        var cfgD3Filters = Config.Video.D3Filters;
+
+        if (alreadySetup) // Possible different values for D3D11 Filters?*
+        {
+            if (HasFLFilters)
+                foreach(var cfgFLFilter in cfgFLFilters.Values)
+                    UpdateFLFilterValue(cfgFLFilter, false);
+
+            foreach(var cfgD3Filter in cfgD3Filters.Values)
+                UpdateD3FilterValue(cfgD3Filter, false);
+
+            return;
+        }
+
+        alreadySetup = true;
+        HasFLFilters = false;
+
+        var d3Filters = curVPCC.Filters;
+
+        foreach(VideoFilters filter in Enum.GetValues(typeof(VideoFilters)))
+        {
+            if (flFilters.TryGetValue(filter, out var flFilter))
+            {
+                if (cfgFLFilters.TryGetValue(filter, out var cfgFLFilter))
+                {
+                    cfgFLFilter.SetFilter(this, flFilter);
+                    HasFLFilters = cfgFLFilter.Value != cfgFLFilter.Default;
+                    UpdateFLFilterValue(cfgFLFilter, false);
+                }
+                else
+                {
+                    cfgFLFilter = new(this, flFilter);
+                    cfgFLFilters.Add(filter, cfgFLFilter);
+                    UpdateFLFilterValue(cfgFLFilter, false);
+                }
+            }
+
+            if (d3Filters.TryGetValue(filter, out var d3Filter))
+            {
+                if (cfgD3Filters.TryGetValue(filter, out var cfgD3Filter))
+                    cfgD3Filter.SetFilter(this, d3Filter);
+                else
+                {
+                    cfgD3Filter = new(this, d3Filter);
+                    cfgD3Filters.Add(filter, cfgD3Filter);
+                }
+            }
+        }
+    }
+
+    internal void UpdateFLFilterValue(FLVideoFilter cfgFilter, bool present = true)
+    {
+        lock (lockDevice)
+        {
+            if (Disposed || parent != null)
+                return;
+
+            float value = Scale(cfgFilter.Value, cfgFilter.Minimum, cfgFilter.Maximum, cfgFilter.filter.Minimum2, cfgFilter.filter.Maximum2);
+
+            switch (cfgFilter.Filter)
+            {
+                case VideoFilters.Brightness:
+
+                    psBufferData.brightness = value;
+                    break;
+
+                case VideoFilters.Contrast:
+                    psBufferData.contrast = value;
+                    break;
+
+                case VideoFilters.Hue:
+                    psBufferData.hue = value;
+                    break;
+
+                case VideoFilters.Saturation:
+                    psBufferData.saturation = value;
+                    break;
+            }
+
+            context.UpdateSubresource(psBufferData, psBuffer);
+
+            // Switch pixel shader (w/o filters) only if required
+            var hasFilters = cfgFilter.Value != cfgFilter.Default;
+            if (hasFilters != HasFLFilters)
+            {
+                if (hasFilters)
+                {
+                    HasFLFilters = true;
+                    if (videoProcessor == VideoProcessors.Flyleaf)
+                        ConfigPlanes();
+                }
+                else if (!Config.Video.Filters.Where(f => f.Value.Value != f.Value.Default).Any())
+                {
+                    HasFLFilters = false;
+                    if (videoProcessor == VideoProcessors.Flyleaf)
+                        ConfigPlanes();
+                }
+            }
+
+            if (present)
+                Present();
+        }
+    }
+    internal void UpdateD3FilterValue(D3VideoFilter cfgFilter, bool present = true)
+    {
+        lock (lockDevice)
+        {
+            if (Disposed || parent != null)
+                return;
+
+            vc.VideoProcessorSetStreamFilter(vp, 0, ConvertFromVideoProcessorFilterCaps((VideoProcessorFilterCaps)cfgFilter.Filter), true,
+                (int)Scale(cfgFilter.Value, cfgFilter.Minimum, cfgFilter.Maximum, cfgFilter.filter.Minimum, cfgFilter.filter.Maximum));
+
+            if (present)
+                Present();
+        }
+    }
+
+    static Dictionary<VideoFilters, VideoFilterLocal> flFilters = new()
+    {
+        [VideoFilters.Brightness]   = new()
+        {
+            Filter  = VideoFilters.Brightness,
+            Minimum = -100,
+            Maximum = 100,
+            Default = 0,
+            Step    = 1,
+
+            Minimum2 = -0.5f,
+            Maximum2 =  0.5f
+        },
+        [VideoFilters.Contrast]     = new()
+        {
+            Filter  = VideoFilters.Contrast,
+            Minimum = -100,
+            Maximum = 100,
+            Default = 0,
+            Step    = 1,
+
+            Minimum2 = 0,
+            Maximum2 = 2
+        },
+        [VideoFilters.Hue]          = new()
+        {
+            Filter  = VideoFilters.Hue,
+            Minimum = -180,
+            Maximum = 180,
+            Default = 0,
+            Step    = 1,
+
+            Minimum2 = -3.14f,
+            Maximum2 =  3.14f
+        },
+        [VideoFilters.Saturation]   = new()
+        {
+            Filter  = VideoFilters.Saturation,
+            Minimum = -100,
+            Maximum = 100,
+            Default = 0,
+            Step    = 1,
+
+            Minimum2 = 0,
+            Maximum2 = 2
+        },
+    };
+}
+
+class VideoFilterLocal
+{
+    public VideoFilters Filter      { get; set; }
+    public int          Minimum     { get; set; }
+    public int          Maximum     { get; set; }
+    public int          Default     { get; set; }
+    public float        Step        { get; set; }
+
+    // Actual for pixel shader
+    public float        Minimum2    { get; set; }
+    public float        Maximum2    { get; set; }
+}
+
+public class FLVideoFilter : VideoFilter
+{
+    internal FLVideoFilter(Renderer renderer,VideoFilterLocal filter) : base(renderer, filter) { }
+
+    public override void UpdateValue()
+    {
+        renderer.UpdateFLFilterValue(this);
+        if (renderer.Config.Video.SyncVPFilters && renderer.Config.Video.D3Filters.TryGetValue(Filter, out var d3Filter))
+            d3Filter.SetValue2(_Value == _Default ? d3Filter._Default : (int)Scale(_Value, Minimum, Maximum, d3Filter.Minimum, d3Filter.Maximum));
+    }
+
+    internal void SetValue2(int value)
+    {
+        if (_Value == value)
+            return;
+
+        _Value = value;
+        RaiseUI(nameof(Value));
+        renderer.UpdateFLFilterValue(this);
+    }
+}
+
+public class D3VideoFilter : VideoFilter
+{
+    internal D3VideoFilter(Renderer renderer, VideoFilterLocal filter) : base(renderer, filter) { }
+
+    public override void UpdateValue()
+    {
+        renderer.UpdateD3FilterValue(this);
+        if (renderer.Config.Video.SyncVPFilters && renderer.Config.Video.Filters.TryGetValue(Filter, out var flFilter))
+            flFilter.SetValue2(_Value == _Default ? flFilter._Default : (int)Scale(_Value, Minimum, Maximum, flFilter.Minimum, flFilter.Maximum));
+    }
+    internal void SetValue2(int value)
+    {
+        if (_Value == value)
+            return;
+
+        _Value = value;
+        RaiseUI(nameof(Value));
+        renderer.UpdateD3FilterValue(this);
+    }
+}
+
+public abstract class VideoFilter : NotifyPropertyChanged
+{
+    [JsonIgnore]
+    public bool         Available   => filter != null;
+    internal VideoFilterLocal filter;
+    internal void SetFilter(Renderer renderer, VideoFilterLocal filter)
+    {
+        this.renderer   = renderer;
+        this.filter     = filter;
+        RaiseUI(nameof(Available));
+    }
+
+    public VideoFilters Filter      { get => _Filter;       internal set => SetUI(ref _Filter, value); }
+    protected VideoFilters _Filter = VideoFilters.Brightness;
+
+    public int          Minimum     { get => _Minimum;      internal set => SetUI(ref _Minimum, value); }
+    protected int _Minimum = 0;
+
+    public int          Maximum     { get => _Maximum;      internal set => SetUI(ref _Maximum, value); }
+    protected int _Maximum = 100;
+
+    public float        Step        { get => _Step;         internal set => SetUI(ref _Step, value); }
+    protected float _Step = 1;
+
+    public int          Default
+    {
+        get => _Default;
+        internal set
+        {
+            if (SetUI(ref _Default, value))
+            {
+                SetDefaultValue.OnCanExecuteChanged();
+            }
+        }
+    }
+    internal int _Default = 50;
+
+    public int          Value
+    {
+        get => _Value;
+        set
+        {
+            int v = value;
+            v = Math.Min(v, Maximum);
+            v = Math.Max(v, Minimum);
+
+            if (Set(ref _Value, v))
+            {
+                if (renderer != null)
+                    UpdateValue();
+
+                SetDefaultValue.OnCanExecuteChanged();
+            }
+
+            //{ var prev = _Value; if (Set(ref _Value, value)) renderer?.UpdateFilterValue(this, prev); } }
+        }
+    }
+    protected int _Value = 50;
+
+    public abstract void UpdateValue();
+
+    [JsonIgnore]
+    public RelayCommand SetDefaultValue => field ??= new(_ =>
+    {
+        Value = Default;
+    }, _ => Value != Default);
+
+    internal Renderer renderer;
+
+    internal VideoFilter(Renderer renderer, VideoFilterLocal filter)
+    {
+        this.renderer   = renderer;
+        this.filter     = filter;
+        _Filter         = filter.Filter;
+
+        Minimum = filter.Minimum;
+        Maximum = filter.Maximum;
+        Default = filter.Default;
+        Step    = filter.Step;
+        _Value  = filter.Default;
+    }
+}

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -27,6 +27,7 @@ unsafe public partial class Renderer
     const string dPQToLinear    = "dPQToLinear";
     const string dHLGToLinear   = "dHLGToLinear";
     const string dTone          = "dTone";
+    const string dFilters       = "dFilters";
 
     enum PSCase : int
     {
@@ -122,11 +123,7 @@ unsafe public partial class Renderer
                 if (videoProcessor == VideoProcessors.D3D11)
                 {
                     if (oldVP != videoProcessor)
-                    {
                         VideoDecoder.DisposeFrames();
-                        Config.Video.Filters[VideoFilters.Brightness].Value = Config.Video.Filters[VideoFilters.Brightness].DefaultValue;
-                        Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].DefaultValue;
-                    }
 
                     inputColorSpace = new()
                     {
@@ -168,10 +165,12 @@ unsafe public partial class Renderer
                     List<string> defines = [];
 
                     if (oldVP != videoProcessor)
-                    {
                         VideoDecoder.DisposeFrames();
-                        Config.Video.Filters[VideoFilters.Brightness].Value = Config.Video.Filters[VideoFilters.Brightness].Minimum + ((Config.Video.Filters[VideoFilters.Brightness].Maximum - Config.Video.Filters[VideoFilters.Brightness].Minimum) / 2);
-                        Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].Minimum + ((Config.Video.Filters[VideoFilters.Contrast].Maximum - Config.Video.Filters[VideoFilters.Contrast].Minimum) / 2);
+
+                    if (HasFLFilters)
+                    {
+                        curPSUniqueId += "-";
+                        defines.Add(dFilters);
                     }
 
                     if (VideoStream.HDRFormat != HDRFormat.None)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -90,8 +90,6 @@ unsafe public partial class Renderer
             if (Disposed || VideoStream == null)
                 return false;
 
-            VideoDecoder.DisposeFrame(LastFrame);
-
             curRatio    = VideoStream.AspectRatio.Value;
             VideoRect   = new RawRect(0, 0, (int)VideoStream.Width, (int)VideoStream.Height);
             rotationLinesize
@@ -103,6 +101,12 @@ unsafe public partial class Renderer
             VideoProcessor = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
                 (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != DeInterlace.Progressive && Config.Video.VideoProcessor != VideoProcessors.Flyleaf)) ?
                 VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
+
+            if (oldVP != videoProcessor)
+            {
+                VideoDecoder.DisposeFrame(LastFrame);
+                VideoDecoder.DisposeFrames();
+            }
 
             if (fieldType != FieldType)
             {
@@ -122,9 +126,6 @@ unsafe public partial class Renderer
             {
                 if (videoProcessor == VideoProcessors.D3D11)
                 {
-                    if (oldVP != videoProcessor)
-                        VideoDecoder.DisposeFrames();
-
                     inputColorSpace = new()
                     {
                         Usage           = 0u,
@@ -163,9 +164,6 @@ unsafe public partial class Renderer
                 else if (!Config.Video.SwsForce || VideoDecoder.VideoAccelerated) // FlyleafVP
                 {
                     List<string> defines = [];
-
-                    if (oldVP != videoProcessor)
-                        VideoDecoder.DisposeFrames();
 
                     if (HasFLFilters)
                     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -97,19 +97,23 @@ unsafe public partial class Renderer
             UpdateRotation(_RotationAngle, false);
 
             var oldVP = videoProcessor;
-
-            // Defaults to D3D11VP
-            //VideoProcessor = !VideoDecoder.VideoAccelerated || D3D11VPFailed || Config.Video.VideoProcessor == VideoProcessors.Flyleaf || (Config.Video.VideoProcessor == VideoProcessors.Auto && isHDR && !Config.Video.Deinterlace) ? VideoProcessors.Flyleaf : VideoProcessors.D3D11;
-
-            // Defaults to FlyleafVP
+            var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : Config.Video.DeInterlace;
             VideoProcessor = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
-                (Config.Video.Deinterlace || Config.Video.VideoProcessor == VideoProcessors.D3D11) ?
+                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != DeInterlace.Progressive && Config.Video.VideoProcessor != VideoProcessors.Flyleaf)) ?
                 VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
 
-            textDesc[0].BindFlags &= ~BindFlags.RenderTarget; // Only D3D11VP without ZeroCopy requires it
-            curPSCase = PSCase.None;
-            prevPSUniqueId = curPSUniqueId;
-            curPSUniqueId = "";
+            if (fieldType != FieldType)
+            {
+                FieldType = fieldType;
+                vc?.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType == DeInterlace.Progressive ? VideoFrameFormat.Progressive : (FieldType == DeInterlace.BottomField ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
+                psBufferData.fieldType = FieldType;
+            }
+
+            textDesc[0].BindFlags
+                            &= ~BindFlags.RenderTarget; // Only D3D11VP without ZeroCopy requires it
+            curPSCase       = PSCase.None;
+            prevPSUniqueId  = curPSUniqueId;
+            curPSUniqueId   = "";
 
             Log.Debug($"Preparing planes for {VideoStream.PixelFormatStr} with {videoProcessor}");
             if ((VideoStream.PixelFormatDesc->flags & PixFmtFlags.Be) == 0) // We currently force SwsScale for BE (RGBA64/BGRA64 BE noted that could work as is?*)
@@ -182,7 +186,6 @@ unsafe public partial class Renderer
                             defines.Add(dPQToLinear);
                         }
 
-
                         defines.Add(dTone);
                     }
                     else if (VideoStream.ColorSpace == ColorSpace.BT2020)
@@ -190,6 +193,8 @@ unsafe public partial class Renderer
                         defines.Add(dBT2020);
                         curPSUniqueId += "b";
                     }
+
+                    psBufferData.yoffset = 1.0f / VideoStream.Height;
 
                     for (int i = 0; i < srvDesc.Length; i++)
                         srvDesc[i].ViewDimension = ShaderResourceViewDimension.Texture2D;
@@ -398,7 +403,7 @@ unsafe public partial class Renderer
                             curPSCase = PSCase.YUVPacked;
                             curPSUniqueId += ((int)curPSCase).ToString();
 
-                            psBufferData.texWidth = 1.0f / (VideoStream.Width >> 1);
+                            psBufferData.uvOffset = 1.0f / (VideoStream.Width >> 1);
                             textDesc[0].Width   = VideoStream.Width;
                             textDesc[0].Height  = VideoStream.Height;
 
@@ -416,10 +421,10 @@ unsafe public partial class Renderer
                             }
 
                             string header = @"
-        float  posx = input.Texture.x - (texWidth * 0.25);
-        float  fx = frac(posx / texWidth);
-        float  pos1 = posx + ((0.5 - fx) * texWidth);
-        float  pos2 = posx + ((1.5 - fx) * texWidth);
+        float  posx = input.Texture.x - (Config.uvOffset * 0.25);
+        float  fx = frac(posx / Config.uvOffset);
+        float  pos1 = posx + ((0.5 - fx) * Config.uvOffset);
+        float  pos2 = posx + ((1.5 - fx) * Config.uvOffset);
 
         float4 c1 = Texture1.Sample(Sampler, float2(pos1, input.Texture.y));
         float4 c2 = Texture1.Sample(Sampler, float2(pos2, input.Texture.y));

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -46,7 +46,7 @@ public unsafe partial class Renderer
                     Log.Error($"Device Lost ({e.ResultCode} | {Device.DeviceRemovedReason} | {e.Message})");
                     Thread.Sleep(100);
 
-                    Flush();
+                    HandleDeviceReset();
                 }
                 else
                 {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PresentOffline.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PresentOffline.cs
@@ -64,10 +64,13 @@ public partial class Renderer
                 vpivd.Texture2D.ArraySlice = 0;
                 vd1.CreateVideoProcessorInputView(frame.textures[0], vpe, vpivd, out vpiv);
             }
+            if (vpiv != null)
+            {
+                vpsa[0].InputSurface = vpiv;
+                vc.VideoProcessorBlt(vp, vpov, 0, 1, vpsa);
+                vpiv.Dispose();
+            }
 
-            vpsa[0].InputSurface = vpiv;
-            vc.VideoProcessorBlt(vp, vpov, 0, 1, vpsa);
-            vpiv.Dispose();
             vpov.Dispose();
             tmpResource.Dispose();
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -30,7 +30,7 @@ public partial class Renderer
     // Support Windows 8+
     private SwapChainDescription1 GetSwapChainDesc(int width, int height, bool isComp = false, bool alpha = false)
     {
-        if (Device.FeatureLevel < FeatureLevel.Level_10_0 || (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.ToUpper() == "WARP"))
+        if (Device.FeatureLevel < FeatureLevel.Level_10_0 || (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase)))
         {
             return new()
             {
@@ -105,7 +105,7 @@ public partial class Renderer
             }
             catch (Exception e)
             {
-                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || Config.Video.GPUAdapter.ToUpper() != "WARP")
+                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || !Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
                 {
                     try { if (Device != null) Log.Warn($"Device Remove Reason = {Device.DeviceRemovedReason.Description}"); } catch { } // For troubleshooting
 
@@ -298,8 +298,8 @@ public partial class Renderer
 
         if (ratio < ControlWidth / (float) ControlHeight)
         {
-            newHeight = (int)(ControlHeight * zoom);
-            newWidth = (int)(newHeight * ratio);
+            newHeight   = (int)(ControlHeight * zoom);
+            newWidth    = (int)(newHeight * ratio);
 
             SideXPixels = newWidth > ControlWidth && false ? 0 : (int) (ControlWidth - (ControlHeight * ratio)); // TBR
             SideYPixels = 0;
@@ -312,8 +312,8 @@ public partial class Renderer
         }
         else
         {
-            newWidth = (int)(ControlWidth * zoom);
-            newHeight = (int)(newWidth / ratio);
+            newWidth    = (int)(ControlWidth * zoom);
+            newHeight   = (int)(newWidth / ratio);
 
             SideYPixels = newHeight > ControlHeight && false ? 0 : (int) (ControlHeight - (ControlWidth / ratio));
             SideXPixels = 0;
@@ -344,7 +344,11 @@ public partial class Renderer
                 int cropTop     = GetViewport.Y < 0 ? (int) GetViewport.Y * -1 : 0;
                 int cropBottom  = GetViewport.Y + GetViewport.Height > ControlHeight ? (int) (GetViewport.Y + GetViewport.Height - ControlHeight) : 0;
 
-                dst = new RawRect(Math.Max((int)GetViewport.X, 0), Math.Max((int)GetViewport.Y, 0), Math.Min((int)GetViewport.Width + (int)GetViewport.X, ControlWidth), Math.Min((int)GetViewport.Height + (int)GetViewport.Y, ControlHeight));
+                dst = new RawRect(
+                    Math.Max((int)GetViewport.X, 0),
+                    Math.Max((int)GetViewport.Y, 0),
+                    Math.Min((int)GetViewport.Width + (int)GetViewport.X, ControlWidth),
+                    Math.Min((int)GetViewport.Height + (int)GetViewport.Y, ControlHeight));
 
                 if (_RotationAngle == 90)
                 {
@@ -436,14 +440,14 @@ public partial class Renderer
         clip.SetRight(ControlWidth);
         clip.SetTop(0);
         clip.SetBottom(ControlHeight);
-        clip.SetTopLeftRadiusX((float)cornerRadius.TopLeft);
-        clip.SetTopLeftRadiusY((float)cornerRadius.TopLeft);
-        clip.SetTopRightRadiusX((float)cornerRadius.TopRight);
-        clip.SetTopRightRadiusY((float)cornerRadius.TopRight);
-        clip.SetBottomLeftRadiusX((float)cornerRadius.BottomLeft);
-        clip.SetBottomLeftRadiusY((float)cornerRadius.BottomLeft);
-        clip.SetBottomRightRadiusX((float)cornerRadius.BottomRight);
-        clip.SetBottomRightRadiusY((float)cornerRadius.BottomRight);
+        clip.SetTopLeftRadiusX      ((float)cornerRadius.TopLeft);
+        clip.SetTopLeftRadiusY      ((float)cornerRadius.TopLeft);
+        clip.SetTopRightRadiusX     ((float)cornerRadius.TopRight);
+        clip.SetTopRightRadiusY     ((float)cornerRadius.TopRight);
+        clip.SetBottomLeftRadiusX   ((float)cornerRadius.BottomLeft);
+        clip.SetBottomLeftRadiusY   ((float)cornerRadius.BottomLeft);
+        clip.SetBottomRightRadiusX  ((float)cornerRadius.BottomRight);
+        clip.SetBottomRightRadiusY  ((float)cornerRadius.BottomRight);
         dCompVisual.SetClip(clip).CheckError();
         clip.Dispose();
         dCompDevice.Commit().CheckError();

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -64,7 +64,7 @@ public partial class Renderer
         }
     }
 
-    internal void InitializeSwapChain(IntPtr handle)
+    internal void InitializeSwapChain(nint handle)
     {
         lock (lockDevice)
         {
@@ -115,7 +115,7 @@ public partial class Renderer
                 }
                 else
                 {
-                    ControlHandle = IntPtr.Zero;
+                    ControlHandle = 0;
                     Log.Error($"[SwapChain] Initialization failed ({e.Message})");
                 }
 
@@ -198,11 +198,12 @@ public partial class Renderer
             Log.Info($"Destroying swap chain [Handle: {ControlHandle}]");
 
             // Unassign renderer's WndProc if still there and re-assign the old one
-            if (ControlHandle != IntPtr.Zero)
+            if (ControlHandle != 0)
             {
                 if (!isFlushing) // SetWindowSubclass requires UI thread so avoid calling it on flush (Player.Stop)
                     RemoveWindowSubclass(ControlHandle, wndProcDelegatePtr, UIntPtr.Zero);
-                ControlHandle = IntPtr.Zero;
+
+                ControlHandle = 0;
             }
 
             if (SwapChainWinUIClbk != null)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.VisualBasic.FileIO;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
-using System.Text.Json.Serialization;
+using System.Threading;
+
 using Vortice.Direct3D11;
 using Vortice.DXGI;
-
-using FlyleafLib.Controls.WPF;
 
 using static FlyleafLib.Logger;
 using static FlyleafLib.Utils;
@@ -21,6 +19,7 @@ unsafe public partial class Renderer
      */
 
     static Dictionary<string, VideoProcessorCapsCache> VideoProcessorsCapsCache = [];
+    VideoProcessorCapsCache curVPCC;
 
     internal static VideoProcessorFilter ConvertFromVideoProcessorFilterCaps(VideoProcessorFilterCaps filter)
     {
@@ -52,12 +51,12 @@ unsafe public partial class Renderer
             _ => VideoProcessorFilterCaps.StereoAdjustment,
         };
     }
-    internal static VideoFilter ConvertFromVideoProcessorFilterRange(VideoProcessorFilterRange filter) => new()
+    internal static VideoFilterLocal ConvertFromVideoProcessorFilterRange(VideoProcessorFilterRange filter) => new()
     {
-        Minimum = filter.Minimum,
-        Maximum = filter.Maximum,
-        Value   = filter.Default,
-        Step    = filter.Multiplier
+        Minimum     = filter.Minimum,
+        Maximum     = filter.Maximum,
+        Default     = filter.Default,
+        Step        = filter.Multiplier
     };
 
     VideoColor                          D3D11VPBackgroundColor;
@@ -89,34 +88,34 @@ unsafe public partial class Renderer
 
     uint actualRotation;
     bool actualHFlip, actualVFlip;
-    bool configLoadedChecked;
 
-    void InitializeVideoProcessor()
+    bool InitializeVideoProcessor()
     {
-        lock (VideoProcessorsCapsCache)
-            try
+        try
+        {
+            vpcd.InputWidth = 1;
+            vpcd.InputHeight= 1;
+            vpcd.OutputWidth = vpcd.InputWidth;
+            vpcd.OutputHeight= vpcd.InputHeight;
+
+            outputColorSpace = new VideoProcessorColorSpace()
             {
-                vpcd.InputWidth = 1;
-                vpcd.InputHeight= 1;
-                vpcd.OutputWidth = vpcd.InputWidth;
-                vpcd.OutputHeight= vpcd.InputHeight;
+                Usage           = 0,
+                RGB_Range       = 0,
+                YCbCr_Matrix    = 1,
+                YCbCr_xvYCC     = 0,
+                Nominal_Range   = 2
+            };
 
-                outputColorSpace = new VideoProcessorColorSpace()
+            lock (VideoProcessorsCapsCache)
+            {
+                if (VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out curVPCC))
                 {
-                    Usage           = 0,
-                    RGB_Range       = 0,
-                    YCbCr_Matrix    = 1,
-                    YCbCr_xvYCC     = 0,
-                    Nominal_Range   = 2
-                };
+                    while (curVPCC.Wait)
+                        Thread.Sleep(10);
 
-                if (VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out var cache))
-                {
-                    if (cache.Failed)
-                    {
-                        InitializeFilters();
-                        return;
-                    }
+                    if (curVPCC.Failed)
+                        return false;
 
                     vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
                     vc  = context.QueryInterface<ID3D11VideoContext1>();
@@ -124,151 +123,141 @@ unsafe public partial class Renderer
                     vd1.CreateVideoProcessorEnumerator(ref vpcd, out vpe);
 
                     if (vpe == null)
-                    {
-                        VPFailed();
-                        return;
-                    }
+                        return false;
 
-                    // if (!vpcc.TypeIndex != -1)
-                    vd1.CreateVideoProcessor(vpe, (uint)cache.TypeIndex, out vp);
-                    InitializeFilters();
+                    vd1.CreateVideoProcessor(vpe, (uint)curVPCC.TypeIndex, out vp);
 
-                    return;
+                    return true;
                 }
 
-                cache = new();
-                VideoProcessorsCapsCache.Add(Device.Tag.ToString(), cache);
+                curVPCC = new();
+                VideoProcessorsCapsCache.Add(Device.Tag.ToString(), curVPCC);
+            }
 
-                vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
-                vc  = context.QueryInterface<ID3D11VideoContext>();
+            vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
+            vc  = context.QueryInterface<ID3D11VideoContext>();
 
-                vd1.CreateVideoProcessorEnumerator(ref vpcd, out vpe);
+            vd1.CreateVideoProcessorEnumerator(ref vpcd, out vpe);
 
-                if (vpe == null || Device.FeatureLevel < Vortice.Direct3D.FeatureLevel.Level_10_0)
+            if (vpe == null || Device.FeatureLevel < Vortice.Direct3D.FeatureLevel.Level_10_0)
+                return false;
+
+            var vpe1    = vpe.QueryInterface<ID3D11VideoProcessorEnumerator1>();
+            var vpCaps  = vpe.VideoProcessorCaps;
+            string dump = "";
+
+            if (CanDebug)
+            {
+                var hlg     = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020,  Format.B8G8R8A8_UNorm, ColorSpaceType.RgbFullG22NoneP709);
+                var hdr10   = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbStudioG2084NoneP2020);
+
+                dump += $"=====================================================\r\n";
+                dump += $"MaxInputStreams           {vpCaps.MaxInputStreams}\r\n";
+                dump += $"MaxStreamStates           {vpCaps.MaxStreamStates}\r\n";
+                dump += $"HDR10 Limited             {(hlg   ? "yes" : "no")}\r\n";
+                dump += $"HLG                       {(hdr10 ? "yes" : "no")}\r\n";
+
+                dump += $"\n[Video Processor Device Caps]\r\n";
+                foreach (VideoProcessorDeviceCaps cap in Enum.GetValues(typeof(VideoProcessorDeviceCaps)))
+                    dump += $"{cap,-25} {((vpCaps.DeviceCaps & cap) != 0 ? "yes" : "no")}\r\n";
+
+                dump += $"\n[Video Processor Feature Caps]\r\n";
+                foreach (VideoProcessorFeatureCaps cap in Enum.GetValues(typeof(VideoProcessorFeatureCaps)))
+                    dump += $"{cap,-25} {((vpCaps.FeatureCaps & cap) != 0 ? "yes" : "no")}\r\n";
+
+                dump += $"\n[Video Processor Stereo Caps]\r\n";
+                foreach (VideoProcessorStereoCaps cap in Enum.GetValues(typeof(VideoProcessorStereoCaps)))
+                    dump += $"{cap,-25} {((vpCaps.StereoCaps & cap) != 0 ? "yes" : "no")}\r\n";
+
+                dump += $"\n[Video Processor Input Format Caps]\r\n";
+                foreach (VideoProcessorFormatCaps cap in Enum.GetValues(typeof(VideoProcessorFormatCaps)))
+                    dump += $"{cap,-25} {((vpCaps.InputFormatCaps & cap) != 0 ? "yes" : "no")}\r\n";
+
+                dump += $"\n[Video Processor Filter Caps]\r\n";
+            }
+
+            foreach (VideoProcessorFilterCaps filter in Enum.GetValues(typeof(VideoProcessorFilterCaps)))
+                if ((vpCaps.FilterCaps & filter) != 0)
                 {
-                    VPFailed();
-                    return;
+                    vpe1.GetVideoProcessorFilterRange(ConvertFromVideoProcessorFilterCaps(filter), out var range);
+                    if (CanDebug) dump += $"{filter,-25} [{range.Minimum,6} - {range.Maximum,4}] | x{range.Multiplier,4} | *{range.Default}\r\n";
+                    var vf = ConvertFromVideoProcessorFilterRange(range);
+                    vf.Filter = (VideoFilters)filter;
+                    curVPCC.Filters.Add((VideoFilters)filter, vf);
                 }
+                else if (CanDebug)
+                    dump += $"{filter,-25} no\r\n";
 
-                var vpe1    = vpe.QueryInterface<ID3D11VideoProcessorEnumerator1>();
-                cache.HLG   = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020,  Format.B8G8R8A8_UNorm, ColorSpaceType.RgbFullG22NoneP709);
-                cache.HDR10 = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbStudioG2084NoneP2020);
+            if (CanDebug)
+            {
+                dump += $"\n[Video Processor Input Format Caps]\r\n";
+                foreach (VideoProcessorAutoStreamCaps cap in Enum.GetValues(typeof(VideoProcessorAutoStreamCaps)))
+                    dump += $"{cap,-25} {((vpCaps.AutoStreamCaps & cap) != 0 ? "yes" : "no")}\r\n";
+            }
 
-                var vpCaps  = vpe.VideoProcessorCaps;
-                string dump = "";
+            uint typeIndex = 0;
+            VideoProcessorRateConversionCaps rcCap = new();
+            for (uint i = 0; i < vpCaps.RateConversionCapsCount; i++)
+            {
+                vpe.GetVideoProcessorRateConversionCaps(i, out rcCap);
+                VideoProcessorProcessorCaps pCaps = (VideoProcessorProcessorCaps) rcCap.ProcessorCaps;
 
                 if (CanDebug)
                 {
-                    dump += $"=====================================================\r\n";
-                    dump += $"MaxInputStreams           {vpCaps.MaxInputStreams}\r\n";
-                    dump += $"MaxStreamStates           {vpCaps.MaxStreamStates}\r\n";
-                    dump += $"HDR10 Limited             {(cache.HLG     ? "yes" : "no")}\r\n";
-                    dump += $"HLG                       {(cache.HDR10   ? "yes" : "no")}\r\n";
+                    dump += $"\n[Video Processor Rate Conversion Caps #{i}]\r\n";
 
-                    dump += $"\n[Video Processor Device Caps]\r\n";
-                    foreach (VideoProcessorDeviceCaps cap in Enum.GetValues(typeof(VideoProcessorDeviceCaps)))
-                        dump += $"{cap,-25} {((vpCaps.DeviceCaps & cap) != 0 ? "yes" : "no")}\r\n";
+                    dump += $"\n\t[Video Processor Rate Conversion Caps]\r\n";
+                    var fields = typeof(VideoProcessorRateConversionCaps).GetFields();
+                    foreach (var field in fields)
+                        dump += $"\t{field.Name,-35} {field.GetValue(rcCap)}\r\n";
 
-                    dump += $"\n[Video Processor Feature Caps]\r\n";
-                    foreach (VideoProcessorFeatureCaps cap in Enum.GetValues(typeof(VideoProcessorFeatureCaps)))
-                        dump += $"{cap,-25} {((vpCaps.FeatureCaps & cap) != 0 ? "yes" : "no")}\r\n";
-
-                    dump += $"\n[Video Processor Stereo Caps]\r\n";
-                    foreach (VideoProcessorStereoCaps cap in Enum.GetValues(typeof(VideoProcessorStereoCaps)))
-                        dump += $"{cap,-25} {((vpCaps.StereoCaps & cap) != 0 ? "yes" : "no")}\r\n";
-
-                    dump += $"\n[Video Processor Input Format Caps]\r\n";
-                    foreach (VideoProcessorFormatCaps cap in Enum.GetValues(typeof(VideoProcessorFormatCaps)))
-                        dump += $"{cap,-25} {((vpCaps.InputFormatCaps & cap) != 0 ? "yes" : "no")}\r\n";
-
-                    dump += $"\n[Video Processor Filter Caps]\r\n";
+                    dump += $"\n\t[Video Processor Processor Caps]\r\n";
+                    foreach (VideoProcessorProcessorCaps cap in Enum.GetValues(typeof(VideoProcessorProcessorCaps)))
+                        dump += $"\t{cap,-35} {(((VideoProcessorProcessorCaps)rcCap.ProcessorCaps & cap) != 0 ? "yes" : "no")}\r\n";
                 }
 
-                foreach (VideoProcessorFilterCaps filter in Enum.GetValues(typeof(VideoProcessorFilterCaps)))
-                    if ((vpCaps.FilterCaps & filter) != 0)
-                    {
-                        vpe1.GetVideoProcessorFilterRange(ConvertFromVideoProcessorFilterCaps(filter), out var range);
-                        if (CanDebug) dump += $"{filter,-25} [{range.Minimum,6} - {range.Maximum,4}] | x{range.Multiplier,4} | *{range.Default}\r\n";
-                        var vf = ConvertFromVideoProcessorFilterRange(range);
-                        vf.Filter = (VideoFilters)filter;
-                        cache.Filters.Add((VideoFilters)filter, vf);
-                    }
-                    else if (CanDebug)
-                        dump += $"{filter,-25} no\r\n";
+                typeIndex = i;
 
-                if (CanDebug)
-                {
-                    dump += $"\n[Video Processor Input Format Caps]\r\n";
-                    foreach (VideoProcessorAutoStreamCaps cap in Enum.GetValues(typeof(VideoProcessorAutoStreamCaps)))
-                        dump += $"{cap,-25} {((vpCaps.AutoStreamCaps & cap) != 0 ? "yes" : "no")}\r\n";
-                }
+                if (((VideoProcessorProcessorCaps)rcCap.ProcessorCaps & VideoProcessorProcessorCaps.DeinterlaceBob) != 0)
+                    break; // TBR: When we add past/future frames support
+            }
+            vpe1.Dispose();
 
-                uint typeIndex = 0;
-                VideoProcessorRateConversionCaps rcCap = new();
-                for (uint i = 0; i < vpCaps.RateConversionCapsCount; i++)
-                {
-                    vpe.GetVideoProcessorRateConversionCaps(i, out rcCap);
-                    VideoProcessorProcessorCaps pCaps = (VideoProcessorProcessorCaps) rcCap.ProcessorCaps;
+            if (CanDebug) Log.Debug($"D3D11 Video Processor\r\n{dump}");
 
-                    if (CanDebug)
-                    {
-                        dump += $"\n[Video Processor Rate Conversion Caps #{i}]\r\n";
+            curVPCC.TypeIndex = (int)typeIndex;
+            vd1.CreateVideoProcessor(vpe, typeIndex, out vp);
+            if (vp == null)
+                return false;
 
-                        dump += $"\n\t[Video Processor Rate Conversion Caps]\r\n";
-                        var fields = typeof(VideoProcessorRateConversionCaps).GetFields();
-                        foreach (var field in fields)
-                            dump += $"\t{field.Name,-35} {field.GetValue(rcCap)}\r\n";
+            curVPCC.Failed = false;
+            Log.Info($"D3D11 Video Processor Initialized (Rate Caps #{typeIndex})");
 
-                        dump += $"\n\t[Video Processor Processor Caps]\r\n";
-                        foreach (VideoProcessorProcessorCaps cap in Enum.GetValues(typeof(VideoProcessorProcessorCaps)))
-                            dump += $"\t{cap,-35} {(((VideoProcessorProcessorCaps)rcCap.ProcessorCaps & cap) != 0 ? "yes" : "no")}\r\n";
-                    }
+            return true;
 
-                    typeIndex = i;
-
-                    if (((VideoProcessorProcessorCaps)rcCap.ProcessorCaps & VideoProcessorProcessorCaps.DeinterlaceBob) != 0)
-                        break; // TBR: When we add past/future frames support
-                }
-                vpe1.Dispose();
-
-                if (CanDebug) Log.Debug($"D3D11 Video Processor\r\n{dump}");
-
-                cache.TypeIndex = (int)typeIndex;
-                cache.VideoProcessorCaps = vpCaps;
-                cache.VideoProcessorRateConversionCaps = rcCap;
-
-                //if (typeIndex != -1)
-                vd1.CreateVideoProcessor(vpe, typeIndex, out vp);
-                if (vp == null)
-                {
-                    VPFailed();
-                    return;
-                }
-
-                cache.Failed = false;
-                Log.Info($"D3D11 Video Processor Initialized (Rate Caps #{typeIndex})");
-
-            } catch { DisposeVideoProcessor(); Log.Error($"D3D11 Video Processor Initialization Failed"); }
-
-        InitializeFilters();
-    }
-    void VPFailed()
-    {
-        Log.Error($"D3D11 Video Processor Initialization Failed");
-
-        if (!VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out var vpcc))
-        {
-            vpcc = new();
-            VideoProcessorsCapsCache.Add(Device.Tag.ToString(), vpcc);
         }
+        catch { return false; }
+        finally
+        {
+            curVPCC.Wait = false;
 
-        vpcc.Failed = true;
-        vpcc.Filters.Add(VideoFilters.Brightness, new() { Filter = VideoFilters.Brightness });
-        vpcc.Filters.Add(VideoFilters.Contrast,   new() { Filter = VideoFilters.Contrast });
+            if (curVPCC.Failed)
+            {
+                Log.Error($"D3D11 Video Processor Initialization Failed");
+                DisposeVideoProcessor();
+            }
+            else
+            {
+                UpdateBackgroundColor();
+                vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
+            }
 
-        DisposeVideoProcessor();
-        InitializeFilters();
+            lock (Config.Video.lockFilters)
+                lock (Config.Video.D3Filters)
+                    SetupFilters();
+        }
     }
+
     void DisposeVideoProcessor()
     {
         vpiv?.Dispose();
@@ -279,56 +268,6 @@ unsafe public partial class Renderer
         vd1?. Dispose();
 
         vc = null;
-    }
-    void InitializeFilters()
-    {
-        Filters = VideoProcessorsCapsCache[Device.Tag.ToString()].Filters;
-
-        // Add FLVP filters if D3D11VP does not support them
-        if (!Filters.ContainsKey(VideoFilters.Brightness))
-            Filters.Add(VideoFilters.Brightness,new(VideoFilters.Brightness));
-
-        if (!Filters.ContainsKey(VideoFilters.Contrast))
-            Filters.Add(VideoFilters.Contrast,  new(VideoFilters.Contrast));
-
-        if (!Filters.ContainsKey(VideoFilters.Hue))
-            Filters.Add(VideoFilters.Hue,       new(VideoFilters.Hue));
-
-        if (!Filters.ContainsKey(VideoFilters.Saturation))
-            Filters.Add(VideoFilters.Saturation,new(VideoFilters.Saturation));
-
-        foreach(var filter in Filters.Values)
-        {
-            if (!Config.Video.Filters.ContainsKey(filter.Filter))
-                continue;
-
-            var cfgFilter = Config.Video.Filters[filter.Filter];
-            cfgFilter.Available = true;
-            cfgFilter.renderer  = this;
-
-            if (!configLoadedChecked && !Config.Loaded)
-            {
-                cfgFilter.Minimum       = filter.Minimum;
-                cfgFilter.Maximum       = filter.Maximum;
-                cfgFilter.DefaultValue  = filter.Value;
-                cfgFilter.Value         = filter.Value;
-                cfgFilter.Step          = filter.Step;
-            }
-
-            UpdateFilterValue(cfgFilter);
-        }
-
-        configLoadedChecked = true;
-        UpdateBackgroundColor();
-
-        vc?.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
-
-        // Reset FLVP filters to defaults (can be different from D3D11VP filters scaling)
-        if (videoProcessor == VideoProcessors.Flyleaf)
-        {
-            Config.Video.Filters[VideoFilters.Brightness].Value = Config.Video.Filters[VideoFilters.Brightness].Minimum + ((Config.Video.Filters[VideoFilters.Brightness].Maximum - Config.Video.Filters[VideoFilters.Brightness].Minimum) / 2);
-            Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].  Minimum + ((Config.Video.Filters[VideoFilters.Contrast].  Maximum - Config.Video.Filters[VideoFilters.Contrast].  Minimum) / 2);
-        }
     }
 
     internal void UpdateBackgroundColor()
@@ -377,46 +316,6 @@ unsafe public partial class Renderer
             psBufferData.fieldType = fieldType;
             context.UpdateSubresource(psBufferData, psBuffer);
         }
-    }
-    internal void UpdateFilterValue(VideoFilter filter)
-    {
-        // D3D11VP
-        if (Filters.TryGetValue(filter.Filter, out var filterFilter) && vc != null)
-        {
-            int scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, filterFilter.Minimum, filterFilter.Maximum);
-            vc.VideoProcessorSetStreamFilter(vp, 0, ConvertFromVideoProcessorFilterCaps((VideoProcessorFilterCaps)filter.Filter), true, scaledValue);
-        }
-
-        if (parent != null)
-            return;
-
-        // FLVP
-        switch (filter.Filter)
-        {
-            case VideoFilters.Brightness:
-                int scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 100);
-                psBufferData.brightness = scaledValue / 100.0f;
-                context.UpdateSubresource(psBufferData, psBuffer);
-                break;
-
-            case VideoFilters.Contrast:
-                scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 100);
-                psBufferData.contrast = scaledValue / 100.0f;
-                context.UpdateSubresource(psBufferData, psBuffer);
-                break;
-
-            case VideoFilters.Hue:
-                psBufferData.hue = Scale(filter.Value, filter.Minimum, filter.Maximum, -3.14f, 3.14f);
-                context.UpdateSubresource(psBufferData, psBuffer);
-                break;
-
-            case VideoFilters.Saturation:
-                psBufferData.saturation = Scale(filter.Value, filter.Minimum, filter.Maximum, 0, 2);
-                context.UpdateSubresource(psBufferData, psBuffer);
-                break;
-        }
-
-        Present();
     }
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {
@@ -521,75 +420,11 @@ unsafe public partial class Renderer
     }
 }
 
-public class VideoFilter : NotifyPropertyChanged
+internal class VideoProcessorCapsCache
 {
-    internal Renderer renderer;
-
-    [JsonIgnore]
-    public bool         Available   { get => _Available;    set => SetUI(ref _Available, value); }
-    bool _Available;
-
-    public VideoFilters Filter      { get => _Filter;       set => SetUI(ref _Filter, value); }
-    VideoFilters _Filter = VideoFilters.Brightness;
-
-    public int          Minimum     { get => _Minimum;      set => SetUI(ref _Minimum, value); }
-    int _Minimum = 0;
-
-    public int          Maximum     { get => _Maximum;      set => SetUI(ref _Maximum, value); }
-    int _Maximum = 100;
-
-    public float        Step        { get => _Step;         set => SetUI(ref _Step, value); }
-    float _Step = 1;
-
-    public int          DefaultValue
-    {
-        get;
-        set
-        {
-            if (SetUI(ref field, value))
-            {
-                SetDefaultValue.OnCanExecuteChanged();
-            }
-        }
-    } = 50;
-
-    public int          Value
-    {
-        get;
-        set
-        {
-            int v = value;
-            v = Math.Min(v, Maximum);
-            v = Math.Max(v, Minimum);
-
-            if (Set(ref field, v))
-            {
-                renderer?.UpdateFilterValue(this);
-                SetDefaultValue.OnCanExecuteChanged();
-            }
-        }
-    } = 50;
-
-    public RelayCommand SetDefaultValue => field ??= new(_ =>
-    {
-        Value = DefaultValue;
-    }, _ => Value != DefaultValue);
-
-    //internal void SetValue(int value) => SetUI(ref _Value, value, true, nameof(Value));
-
-    public VideoFilter() { }
-    public VideoFilter(VideoFilters filter)
-        => Filter = filter;
-}
-
-public class VideoProcessorCapsCache
-{
+    public bool Wait        = true; // to avoid locking until init
     public bool Failed      = true;
     public int  TypeIndex   = -1;
-    public bool HLG;
-    public bool HDR10;
-    public VideoProcessorCaps               VideoProcessorCaps;
-    public VideoProcessorRateConversionCaps VideoProcessorRateConversionCaps;
 
-    public Dictionary<VideoFilters, VideoFilter> Filters { get; set; } = [];
+    public Dictionary<VideoFilters, VideoFilterLocal> Filters { get; set; } = [];
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -1,16 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.VisualBasic.FileIO;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Text.Json.Serialization;
-using Vortice.DXGI;
 using Vortice.Direct3D11;
-
-using ID3D11VideoContext = Vortice.Direct3D11.ID3D11VideoContext;
+using Vortice.DXGI;
 
 using FlyleafLib.Controls.WPF;
-using FlyleafLib.MediaPlayer;
 
 using static FlyleafLib.Logger;
 using static FlyleafLib.Utils;
+using ID3D11VideoContext = Vortice.Direct3D11.ID3D11VideoContext;
 
 namespace FlyleafLib.MediaFramework.MediaRenderer;
 
@@ -21,57 +20,37 @@ unsafe public partial class Renderer
      * 2) Filter default values will change when the device/adapter is changed
      */
 
-    public static Dictionary<string, VideoProcessorCapsCache> VideoProcessorsCapsCache = new();
+    static Dictionary<string, VideoProcessorCapsCache> VideoProcessorsCapsCache = [];
 
     internal static VideoProcessorFilter ConvertFromVideoProcessorFilterCaps(VideoProcessorFilterCaps filter)
     {
-        switch (filter)
+        return filter switch
         {
-            case VideoProcessorFilterCaps.Brightness:
-                return VideoProcessorFilter.Brightness;
-            case VideoProcessorFilterCaps.Contrast:
-                return VideoProcessorFilter.Contrast;
-            case VideoProcessorFilterCaps.Hue:
-                return VideoProcessorFilter.Hue;
-            case VideoProcessorFilterCaps.Saturation:
-                return VideoProcessorFilter.Saturation;
-            case VideoProcessorFilterCaps.EdgeEnhancement:
-                return VideoProcessorFilter.EdgeEnhancement;
-            case VideoProcessorFilterCaps.NoiseReduction:
-                return VideoProcessorFilter.NoiseReduction;
-            case VideoProcessorFilterCaps.AnamorphicScaling:
-                return VideoProcessorFilter.AnamorphicScaling;
-            case VideoProcessorFilterCaps.StereoAdjustment:
-                return VideoProcessorFilter.StereoAdjustment;
-
-            default:
-                return VideoProcessorFilter.StereoAdjustment;
-        }
+            VideoProcessorFilterCaps.Brightness         => VideoProcessorFilter.Brightness,
+            VideoProcessorFilterCaps.Contrast           => VideoProcessorFilter.Contrast,
+            VideoProcessorFilterCaps.Hue                => VideoProcessorFilter.Hue,
+            VideoProcessorFilterCaps.Saturation         => VideoProcessorFilter.Saturation,
+            VideoProcessorFilterCaps.EdgeEnhancement    => VideoProcessorFilter.EdgeEnhancement,
+            VideoProcessorFilterCaps.NoiseReduction     => VideoProcessorFilter.NoiseReduction,
+            VideoProcessorFilterCaps.AnamorphicScaling  => VideoProcessorFilter.AnamorphicScaling,
+            VideoProcessorFilterCaps.StereoAdjustment   => VideoProcessorFilter.StereoAdjustment,
+            _ => VideoProcessorFilter.StereoAdjustment,
+        };
     }
     internal static VideoProcessorFilterCaps ConvertFromVideoProcessorFilter(VideoProcessorFilter filter)
     {
-        switch (filter)
+        return filter switch
         {
-            case VideoProcessorFilter.Brightness:
-                return VideoProcessorFilterCaps.Brightness;
-            case VideoProcessorFilter.Contrast:
-                return VideoProcessorFilterCaps.Contrast;
-            case VideoProcessorFilter.Hue:
-                return VideoProcessorFilterCaps.Hue;
-            case VideoProcessorFilter.Saturation:
-                return VideoProcessorFilterCaps.Saturation;
-            case VideoProcessorFilter.EdgeEnhancement:
-                return VideoProcessorFilterCaps.EdgeEnhancement;
-            case VideoProcessorFilter.NoiseReduction:
-                return VideoProcessorFilterCaps.NoiseReduction;
-            case VideoProcessorFilter.AnamorphicScaling:
-                return VideoProcessorFilterCaps.AnamorphicScaling;
-            case VideoProcessorFilter.StereoAdjustment:
-                return VideoProcessorFilterCaps.StereoAdjustment;
-
-            default:
-                return VideoProcessorFilterCaps.StereoAdjustment;
-        }
+            VideoProcessorFilter.Brightness             => VideoProcessorFilterCaps.Brightness,
+            VideoProcessorFilter.Contrast               => VideoProcessorFilterCaps.Contrast,
+            VideoProcessorFilter.Hue                    => VideoProcessorFilterCaps.Hue,
+            VideoProcessorFilter.Saturation             => VideoProcessorFilterCaps.Saturation,
+            VideoProcessorFilter.EdgeEnhancement        => VideoProcessorFilterCaps.EdgeEnhancement,
+            VideoProcessorFilter.NoiseReduction         => VideoProcessorFilterCaps.NoiseReduction,
+            VideoProcessorFilter.AnamorphicScaling      => VideoProcessorFilterCaps.AnamorphicScaling,
+            VideoProcessorFilter.StereoAdjustment       => VideoProcessorFilterCaps.StereoAdjustment,
+            _ => VideoProcessorFilterCaps.StereoAdjustment,
+        };
     }
     internal static VideoFilter ConvertFromVideoProcessorFilterRange(VideoProcessorFilterRange filter) => new()
     {
@@ -89,21 +68,21 @@ unsafe public partial class Renderer
     ID3D11VideoProcessorInputView       vpiv;
     ID3D11VideoProcessorOutputView      vpov;
 
-    VideoProcessorStream[]              vpsa    = new VideoProcessorStream[] { new VideoProcessorStream() { Enable = true } };
+    VideoProcessorStream[]              vpsa    = [new() { Enable = true }];
     VideoProcessorContentDescription    vpcd    = new()
         {
-            Usage = VideoUsage.PlaybackNormal,
-            InputFrameFormat = VideoFrameFormat.InterlacedTopFieldFirst,
+            Usage           = VideoUsage.PlaybackNormal,
+            InputFrameFormat= VideoFrameFormat.Progressive,
 
-            InputFrameRate  = new Rational(1, 1),
-            OutputFrameRate = new Rational(1, 1),
+            InputFrameRate  = new(1, 1),
+            OutputFrameRate = new(1, 1),
         };
     VideoProcessorOutputViewDescription vpovd   = new() { ViewDimension = VideoProcessorOutputViewDimension.Texture2D };
     VideoProcessorInputViewDescription  vpivd   = new()
         {
             FourCC          = 0,
             ViewDimension   = VideoProcessorInputViewDimension.Texture2D,
-            Texture2D       = new Texture2DVideoProcessorInputView() { MipSlice = 0, ArraySlice = 0 }
+            Texture2D       = new() { MipSlice = 0, ArraySlice = 0 }
         };
     VideoProcessorColorSpace            inputColorSpace;
     VideoProcessorColorSpace            outputColorSpace;
@@ -131,9 +110,9 @@ unsafe public partial class Renderer
                     Nominal_Range   = 2
                 };
 
-                if (VideoProcessorsCapsCache.ContainsKey(Device.Tag.ToString()))
+                if (VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out var cache))
                 {
-                    if (VideoProcessorsCapsCache[Device.Tag.ToString()].Failed)
+                    if (cache.Failed)
                     {
                         InitializeFilters();
                         return;
@@ -150,14 +129,14 @@ unsafe public partial class Renderer
                         return;
                     }
 
-                    // if (!VideoProcessorsCapsCache[Device.Tag.ToString()].TypeIndex != -1)
-                    vd1.CreateVideoProcessor(vpe, (uint)VideoProcessorsCapsCache[Device.Tag.ToString()].TypeIndex, out vp);
+                    // if (!vpcc.TypeIndex != -1)
+                    vd1.CreateVideoProcessor(vpe, (uint)cache.TypeIndex, out vp);
                     InitializeFilters();
 
                     return;
                 }
 
-                VideoProcessorCapsCache cache = new();
+                cache = new();
                 VideoProcessorsCapsCache.Add(Device.Tag.ToString(), cache);
 
                 vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
@@ -171,11 +150,11 @@ unsafe public partial class Renderer
                     return;
                 }
 
-                var vpe1 = vpe.QueryInterface<ID3D11VideoProcessorEnumerator1>();
-                bool supportHLG = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbFullG22NoneP709);
-                bool supportHDR10Limited = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbStudioG2084NoneP2020);
+                var vpe1    = vpe.QueryInterface<ID3D11VideoProcessorEnumerator1>();
+                cache.HLG   = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020,  Format.B8G8R8A8_UNorm, ColorSpaceType.RgbFullG22NoneP709);
+                cache.HDR10 = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbStudioG2084NoneP2020);
 
-                var vpCaps = vpe.VideoProcessorCaps;
+                var vpCaps  = vpe.VideoProcessorCaps;
                 string dump = "";
 
                 if (CanDebug)
@@ -183,8 +162,8 @@ unsafe public partial class Renderer
                     dump += $"=====================================================\r\n";
                     dump += $"MaxInputStreams           {vpCaps.MaxInputStreams}\r\n";
                     dump += $"MaxStreamStates           {vpCaps.MaxStreamStates}\r\n";
-                    dump += $"HDR10 Limited             {(supportHDR10Limited ? "yes" : "no")}\r\n";
-                    dump += $"HLG                       {(supportHLG ? "yes" : "no")}\r\n";
+                    dump += $"HDR10 Limited             {(cache.HLG     ? "yes" : "no")}\r\n";
+                    dump += $"HLG                       {(cache.HDR10   ? "yes" : "no")}\r\n";
 
                     dump += $"\n[Video Processor Device Caps]\r\n";
                     foreach (VideoProcessorDeviceCaps cap in Enum.GetValues(typeof(VideoProcessorDeviceCaps)))
@@ -255,13 +234,11 @@ unsafe public partial class Renderer
                 if (CanDebug) Log.Debug($"D3D11 Video Processor\r\n{dump}");
 
                 cache.TypeIndex = (int)typeIndex;
-                cache.HLG = supportHLG;
-                cache.HDR10Limited = supportHDR10Limited;
                 cache.VideoProcessorCaps = vpCaps;
                 cache.VideoProcessorRateConversionCaps = rcCap;
 
                 //if (typeIndex != -1)
-                vd1.CreateVideoProcessor(vpe, (uint)typeIndex, out vp);
+                vd1.CreateVideoProcessor(vpe, typeIndex, out vp);
                 if (vp == null)
                 {
                     VPFailed();
@@ -279,12 +256,15 @@ unsafe public partial class Renderer
     {
         Log.Error($"D3D11 Video Processor Initialization Failed");
 
-        if (!VideoProcessorsCapsCache.ContainsKey(Device.Tag.ToString()))
-            VideoProcessorsCapsCache.Add(Device.Tag.ToString(), new VideoProcessorCapsCache());
-        VideoProcessorsCapsCache[Device.Tag.ToString()].Failed = true;
+        if (!VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out var vpcc))
+        {
+            vpcc = new();
+            VideoProcessorsCapsCache.Add(Device.Tag.ToString(), vpcc);
+        }
 
-        VideoProcessorsCapsCache[Device.Tag.ToString()].Filters.Add(VideoFilters.Brightness, new VideoFilter()  {  Filter = VideoFilters.Brightness });
-        VideoProcessorsCapsCache[Device.Tag.ToString()].Filters.Add(VideoFilters.Contrast, new VideoFilter()    {  Filter = VideoFilters.Contrast });
+        vpcc.Failed = true;
+        vpcc.Filters.Add(VideoFilters.Brightness, new() { Filter = VideoFilters.Brightness });
+        vpcc.Filters.Add(VideoFilters.Contrast,   new() { Filter = VideoFilters.Contrast });
 
         DisposeVideoProcessor();
         InitializeFilters();
@@ -306,16 +286,16 @@ unsafe public partial class Renderer
 
         // Add FLVP filters if D3D11VP does not support them
         if (!Filters.ContainsKey(VideoFilters.Brightness))
-            Filters.Add(VideoFilters.Brightness, new VideoFilter(VideoFilters.Brightness));
+            Filters.Add(VideoFilters.Brightness,new(VideoFilters.Brightness));
 
         if (!Filters.ContainsKey(VideoFilters.Contrast))
-            Filters.Add(VideoFilters.Contrast, new VideoFilter(VideoFilters.Contrast));
+            Filters.Add(VideoFilters.Contrast,  new(VideoFilters.Contrast));
 
         if (!Filters.ContainsKey(VideoFilters.Hue))
-            Filters.Add(VideoFilters.Hue, new VideoFilter(VideoFilters.Hue));
+            Filters.Add(VideoFilters.Hue,       new(VideoFilters.Hue));
 
         if (!Filters.ContainsKey(VideoFilters.Saturation))
-            Filters.Add(VideoFilters.Saturation, new VideoFilter(VideoFilters.Saturation));
+            Filters.Add(VideoFilters.Saturation,new(VideoFilters.Saturation));
 
         foreach(var filter in Filters.Values)
         {
@@ -324,7 +304,7 @@ unsafe public partial class Renderer
 
             var cfgFilter = Config.Video.Filters[filter.Filter];
             cfgFilter.Available = true;
-            cfgFilter.renderer = this;
+            cfgFilter.renderer  = this;
 
             if (!configLoadedChecked && !Config.Loaded)
             {
@@ -341,17 +321,13 @@ unsafe public partial class Renderer
         configLoadedChecked = true;
         UpdateBackgroundColor();
 
-        if (vc != null)
-        {
-            vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
-            vc.VideoProcessorSetStreamFrameFormat(vp, 0, !Config.Video.Deinterlace ? VideoFrameFormat.Progressive : (Config.Video.DeinterlaceBottomFirst ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
-        }
+        vc?.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
 
         // Reset FLVP filters to defaults (can be different from D3D11VP filters scaling)
         if (videoProcessor == VideoProcessors.Flyleaf)
         {
             Config.Video.Filters[VideoFilters.Brightness].Value = Config.Video.Filters[VideoFilters.Brightness].Minimum + ((Config.Video.Filters[VideoFilters.Brightness].Maximum - Config.Video.Filters[VideoFilters.Brightness].Minimum) / 2);
-            Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].Minimum + ((Config.Video.Filters[VideoFilters.Contrast].Maximum - Config.Video.Filters[VideoFilters.Contrast].Minimum) / 2);
+            Config.Video.Filters[VideoFilters.Contrast].Value   = Config.Video.Filters[VideoFilters.Contrast].  Minimum + ((Config.Video.Filters[VideoFilters.Contrast].  Maximum - Config.Video.Filters[VideoFilters.Contrast].  Minimum) / 2);
         }
     }
 
@@ -369,27 +345,45 @@ unsafe public partial class Renderer
     {
         lock (lockDevice)
         {
+            if (Disposed || parent != null)
+                return;
+
+            FieldType = Config.Video.DeInterlace == DeInterlace.Auto ? (VideoStream != null ? VideoStream.FieldOrder : DeInterlace.Progressive) : Config.Video.DeInterlace;
+            vc?.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType == DeInterlace.Progressive ? VideoFrameFormat.Progressive : (FieldType == DeInterlace.BottomField ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
+            psBufferData.fieldType = FieldType;
+
+            var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : Config.Video.DeInterlace;
+            var newVp = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
+                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != DeInterlace.Progressive && Config.Video.VideoProcessor != VideoProcessors.Flyleaf)) ?
+                VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
+
+            if (newVp != VideoProcessor)
+                ConfigPlanes();
+            else
+                context.UpdateSubresource(psBufferData, psBuffer);
+
+            Present();
+        }
+    }
+    internal void SetFieldType(DeInterlace fieldType)
+    {
+        lock (lockDevice)
+        {
             if (Disposed)
                 return;
 
-            vc?.VideoProcessorSetStreamFrameFormat(vp, 0, !Config.Video.Deinterlace ? VideoFrameFormat.Progressive : (Config.Video.DeinterlaceBottomFirst ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
-
-            if (Config.Video.VideoProcessor != VideoProcessors.Auto)
-                return;
-
-            if (parent != null)
-                return;
-
-            ConfigPlanes();
-            Present();
+            //vpsa[0].InputFrameOrField = fieldType == DeInterlace.BottomField ? 1u : 0u; // TBR
+            vc?.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType == DeInterlace.Progressive ? VideoFrameFormat. Progressive : (fieldType == DeInterlace.BottomField ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
+            psBufferData.fieldType = fieldType;
+            context.UpdateSubresource(psBufferData, psBuffer);
         }
     }
     internal void UpdateFilterValue(VideoFilter filter)
     {
         // D3D11VP
-        if (Filters.ContainsKey(filter.Filter) && vc != null)
+        if (Filters.TryGetValue(filter.Filter, out var filterFilter) && vc != null)
         {
-            int scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, Filters[filter.Filter].Minimum, Filters[filter.Filter].Maximum);
+            int scaledValue = (int) Scale(filter.Value, filter.Minimum, filter.Maximum, filterFilter.Minimum, filterFilter.Maximum);
             vc.VideoProcessorSetStreamFilter(vp, 0, ConvertFromVideoProcessorFilterCaps((VideoProcessorFilterCaps)filter.Filter), true, scaledValue);
         }
 
@@ -441,8 +435,7 @@ unsafe public partial class Renderer
         if (updateResource)
         {
             context.UpdateSubresource(psBufferData, psBuffer);
-            if (!VideoDecoder.IsRunning)
-                Present();
+            Present();
         }
     }
     void UpdateRotation(uint angle, bool refresh = true)
@@ -477,7 +470,7 @@ unsafe public partial class Renderer
         else if (actualRotation < 360)
             _d3d11vpRotation = VideoProcessorRotation.Rotation270;
 
-        vsBufferData.mat  = Matrix4x4.CreateFromYawPitchRoll(0.0f, 0.0f, (float) (Math.PI / 180 * actualRotation));
+        vsBufferData.mat = Matrix4x4.CreateFromYawPitchRoll(0.0f, 0.0f, (float) (Math.PI / 180 * actualRotation));
 
         if (_HFlip || _VFlip)
         {
@@ -585,18 +578,18 @@ public class VideoFilter : NotifyPropertyChanged
     //internal void SetValue(int value) => SetUI(ref _Value, value, true, nameof(Value));
 
     public VideoFilter() { }
-    public VideoFilter(VideoFilters filter, Player player = null)
+    public VideoFilter(VideoFilters filter)
         => Filter = filter;
 }
 
 public class VideoProcessorCapsCache
 {
-    public bool Failed = true;
-    public int  TypeIndex = -1;
+    public bool Failed      = true;
+    public int  TypeIndex   = -1;
     public bool HLG;
-    public bool HDR10Limited;
+    public bool HDR10;
     public VideoProcessorCaps               VideoProcessorCaps;
     public VideoProcessorRateConversionCaps VideoProcessorRateConversionCaps;
 
-    public Dictionary<VideoFilters, VideoFilter> Filters { get; set; } = new();
+    public Dictionary<VideoFilters, VideoFilter> Filters { get; set; } = [];
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -133,7 +133,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
 
     public Point            ZoomCenter      { get => zoomCenter;                set => SetZoomCenter(value); }
     Point zoomCenter = ZoomCenterPoint;
-    public static Point ZoomCenterPoint = new(0.5, 0.5);
+    internal static Point ZoomCenterPoint = new(0.5, 0.5);
     public void SetZoomCenter(Point p, bool refresh = true)
     {
         lock(lockDevice)
@@ -180,9 +180,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     }
 
     public int              UniqueId        { get; private set; }
-
-    public Dictionary<VideoFilters, VideoFilter>
-                            Filters         { get; set; }
+    public bool             HasFLFilters    { get; private set; }
     public VideoFrame       LastFrame       { get; set; }
     public RawRect          VideoRect       { get; set; }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.cs
@@ -377,9 +377,10 @@ inline float3 ToneReinhard(float3 x) //, float whitepoint=2.2) // or gamma?*
 #pragma warning( disable: 4000 )
 inline float3 Hue(float3 rgb, float angle)
 {
-    [branch]
-    if (angle == 0)
-        return rgb;
+    // Compiler optimization will ignore it
+    //[branch]
+    //if (angle == 0)
+    //    return rgb;
 
     static const float3x3 hueBase = float3x3(
         0.299,  0.587,  0.114,
@@ -407,9 +408,10 @@ inline float3 Hue(float3 rgb, float angle)
 
 inline float3 Saturation(float3 rgb, float saturation)
 {
-    [branch]
-    if (saturation == 1.0)
-        return rgb;
+    // Compiler optimization will ignore it
+    //[branch]
+    //if (saturation == 1.0)
+    //    return rgb;
 
     static const float3 kBT709 = float3(0.2126, 0.7152, 0.0722);
 
@@ -501,13 +503,15 @@ float4 main(PSInput input) : SV_TARGET
 
 #endif
 
+#if defined(dFilters)
     // Contrast / Brightness / Hue / Saturation
-    c *= Config.contrast * 2.0f;
-    c += Config.brightness - 0.5f;
+    c *= Config.contrast;
+    c += Config.brightness;
     c = Hue(c, Config.hue);
     c = Saturation(c, Config.saturation);
+#endif
 
-    return saturate(float4(c, color.a));
+    return saturate(float4(c, 1.0));
 }
 ";
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.cs
@@ -20,7 +20,8 @@ internal class BlobWrapper
 
 internal static class ShaderCompiler
 {
-    internal static Blob VSBlob = Compile(VS, false); // TODO Embedded?
+    static readonly string SHADERVER = Environment.OSVersion.Version.Major >= 10 ? "_5_0" : "_4_0_level_9_3";
+    internal static Blob VSBlob = Compile(VS, false);
 
     const int MAXSIZE = 64;
     static Dictionary<string, BlobWrapper> cache = new();
@@ -82,11 +83,11 @@ internal static class ShaderCompiler
     {
         string psOrvs = isPS ? "ps" : "vs";
 
-        // Optimization could actually cause issues (mainly with literal values)
+        // NOTE: Optimization could actually cause issues (mainly with literal values)
         #if DEBUG
-        Compiler.Compile(bytes, defines, null, "main", null, $"{psOrvs}_5_0", ShaderFlags.SkipOptimization, out var shaderBlob, out var psError);
+        Compiler.Compile(bytes, defines, null, "main", null, $"{psOrvs}{SHADERVER}", ShaderFlags.SkipOptimization, out var shaderBlob, out var psError);
         #else
-        Compiler.Compile(bytes, defines, null, "main", null, $"{psOrvs}_5_0", ShaderFlags.OptimizationLevel3, out var shaderBlob, out var psError);
+        Compiler.Compile(bytes, defines, null, "main", null, $"{psOrvs}{SHADERVER}", ShaderFlags.OptimizationLevel3, out var shaderBlob, out var psError);
         #endif
 
         if (psError != null && psError.BufferPointer != IntPtr.Zero)

--- a/FlyleafLib/MediaPlayer/Commands.cs
+++ b/FlyleafLib/MediaPlayer/Commands.cs
@@ -198,7 +198,12 @@ public class Commands
         => player.Rotation = uint.Parse(obj.ToString());
 
     private void ResetFilterAction(object filter)
-        => player.Config.Video.Filters[(VideoFilters)filter].Value = player.Config.Video.Filters[(VideoFilters)filter].DefaultValue;
+    {
+        if (player.renderer.VideoProcessor == VideoProcessors.Flyleaf && player.Config.Video.Filters.TryGetValue((VideoFilters)filter, out var flFilter))
+            flFilter.Value = flFilter.Default;
+        else if (player.renderer.VideoProcessor == VideoProcessors.D3D11 && player.Config.Video.D3Filters.TryGetValue((VideoFilters)filter, out var d3Filter))
+            d3Filter.Value = d3Filter.Default;
+    }
 
     public void SpeedSetAction(object speed)
     {

--- a/FlyleafLib/MediaPlayer/Player.Extra.cs
+++ b/FlyleafLib/MediaPlayer/Player.Extra.cs
@@ -246,23 +246,8 @@ unsafe partial class Player
 
             if (VideoDecoder.Frames.IsEmpty)
             {
-                // Temp fix for previous timestamps until we seperate GetFrame for Extractor and the Player
-                reversePlaybackResync = true;
-                int askedFrame = VideoDecoder.GetFrameNumber(CurTime) - 1;
-                //Log.Debug($"CurTime1: {TicksToTime(CurTime)}, Asked: {askedFrame}");
-                vFrame = VideoDecoder.GetFrame(askedFrame);
-                if (vFrame == null) return;
-
-                int recvFrame = VideoDecoder.GetFrameNumber(vFrame.timestamp);
-                //Log.Debug($"CurTime2: {TicksToTime(vFrame.timestamp)}, Got: {recvFrame}");
-                if (askedFrame != recvFrame)
-                {
-                    VideoDecoder.DisposeFrame(vFrame);
-                    vFrame = null;
-                    vFrame = askedFrame > recvFrame
-                        ? VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime))
-                        : VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime) - 2);
-                }
+                reversePlaybackResync = true; // Temp fix for previous timestamps until we seperate GetFrame for Extractor and the Player
+                vFrame = VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime) - 1);
             }
             else
                 VideoDecoder.Frames.TryDequeue(out vFrame);

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -96,12 +96,15 @@ partial class Player
             }
             finally
             {
-                VideoDecoder.DisposeFrame(vFrame);
+                if (vFrame != renderer.LastFrame)
+                    VideoDecoder.DisposeFrame(vFrame);
                 vFrame = null;
                 for (int i = 0; i < subNum; i++)
                 {
                     sFrames[i] = null;
                 }
+
+                renderer.CurFieldType = renderer.FieldType;
 
                 if (Status == Status.Stopped)
                     decoder?.Initialize();

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -386,6 +386,8 @@ unsafe partial class Player
                 if (VideoDemuxer.Interrupter.Timedout)
                     break;
 
+                renderer.CurFieldType = renderer.FieldType;
+
                 OnBufferingStarted();
                 MediaBuffer();
                 requiresBuffering = false;
@@ -614,7 +616,22 @@ unsafe partial class Player
                             UI(() => UpdateCurTime());
                     }
 
-                VideoDecoder.Frames.TryDequeue(out vFrame);
+                if (renderer.FieldType == DeInterlace.Progressive)
+                    VideoDecoder.Frames.TryDequeue(out vFrame);
+                else
+                {
+                    if (renderer.CurFieldType != renderer.FieldType)
+                    {
+                        VideoDecoder.Frames.TryDequeue(out vFrame);
+                        renderer.CurFieldType = renderer.FieldType;
+                    }
+                    else
+                    {
+                        renderer.CurFieldType = renderer.FieldType == DeInterlace.TopField ? DeInterlace.BottomField : DeInterlace.TopField;
+                        vFrame.timestamp += renderer.VideoStream.FrameDuration2;
+                    }
+                }
+
                 if (vFrame != null && Config.Player.MaxLatency != 0)
                     CheckLatency();
             }
@@ -635,6 +652,7 @@ unsafe partial class Player
                 Video.framesDropped++;
                 VideoDecoder.DisposeFrame(vFrame);
                 VideoDecoder.Frames.TryDequeue(out vFrame);
+                renderer.CurFieldType = renderer.FieldType;
             }
 
             // Set the current time to SubtitleManager in a loop

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -465,8 +465,8 @@ unsafe partial class Player
 
             if (aFrame != null)
             {
-                curAudioDeviceDelay = Audio.GetDeviceDelay();
-                audioBufferedDuration = Audio.GetBufferedDuration();
+                curAudioDeviceDelay     = Audio.GetDeviceDelay();
+                audioBufferedDuration   = Audio.GetBufferedDuration();
                 aDistanceMs = (int) ((((aFrame.timestamp - startTicks) / speed) - (elapsedTicks - curAudioDeviceDelay)) / 10000);
 
                 // Try to keep the audio buffer full enough to avoid audio crackling (up to 50ms)

--- a/FlyleafLib/MediaPlayer/Video.cs
+++ b/FlyleafLib/MediaPlayer/Video.cs
@@ -67,11 +67,17 @@ public class Video : NotifyPropertyChanged
     internal int    _Height, height;
 
     public bool         VideoAcceleration
-                                                { get => videoAcceleration; internal set => Set(ref _VideoAcceleration, value); }
+                                        { get => videoAcceleration; internal set => Set(ref _VideoAcceleration, value); }
     internal bool   _VideoAcceleration, videoAcceleration;
 
     public bool         ZeroCopy        { get => zeroCopy;          internal set => Set(ref _ZeroCopy, value); }
     internal bool   _ZeroCopy, zeroCopy;
+
+    public HDRFormat    HDRFormat       { get => hdrFormat;         internal set => Set(ref _HDRFormat, value); }
+    internal HDRFormat _HDRFormat, hdrFormat;
+
+    public string       ColorFormat     { get => colorFormat;       internal set => Set(ref _ColorFormat, value); }
+    string          _ColorFormat, colorFormat;
 
     public Player Player => player;
 
@@ -96,6 +102,8 @@ public class Video : NotifyPropertyChanged
             Height              = Height;
             VideoAcceleration   = VideoAcceleration;
             ZeroCopy            = ZeroCopy;
+            HDRFormat           = HDRFormat;
+            ColorFormat         = ColorFormat;
 
             FramesDisplayed     = FramesDisplayed;
             FramesDropped       = FramesDropped;
@@ -115,6 +123,8 @@ public class Video : NotifyPropertyChanged
         videoAcceleration  = false;
         zeroCopy           = false;
         isOpened           = false;
+        hdrFormat          = HDRFormat.None;
+        colorFormat         = "";
 
         player.UIAdd(uiAction);
     }
@@ -132,6 +142,8 @@ public class Video : NotifyPropertyChanged
         videoAcceleration
                     = decoder.VideoDecoder.VideoAccelerated;
         zeroCopy    = decoder.VideoDecoder.ZeroCopy;
+        hdrFormat   = decoder.VideoStream.HDRFormat;
+        colorFormat = $"{decoder.VideoStream.ColorSpace}\r\n{decoder.VideoStream.ColorTransfer}\r\n{decoder.VideoStream.ColorRange}";
         isOpened    =!decoder.VideoDecoder.Disposed;
 
         framesDisplayed = 0;

--- a/LLPlayer/Controls/Settings/SettingsPlayer.xaml
+++ b/LLPlayer/Controls/Settings/SettingsPlayer.xaml
@@ -237,16 +237,6 @@
                             Text="{Binding FL.PlayerConfig.Player.SeekAccurateFixMargin, Converter={StaticResource TicksToMilliSecondsConv}}"
                             helpers:TextBoxHelper.OnlyNumeric="Uint" />
                     </StackPanel>
-
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Width="180"
-                            Text="Seek GetFrame Fix Margin (ms)" />
-                        <TextBox
-                            Width="100"
-                            Text="{Binding FL.PlayerConfig.Player.SeekGetFrameFixMargin, Converter={StaticResource TicksToMilliSecondsConv}}"
-                            helpers:TextBoxHelper.OnlyNumeric="Uint" />
-                    </StackPanel>
                 </StackPanel>
             </GroupBox>
 

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -59,27 +59,25 @@
                             Width="100"
                             ItemsSource="{x:Static flyleaf:AspectRatio.AspectRatios}"
                             SelectedItem="{Binding FL.Player. Config.Video.AspectRatio}" />
-                    </StackPanel>
 
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel.Style>
-                            <Style TargetType="StackPanel">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                                <Setter Property="Margin" Value="0 0 0 8" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ElementName=cmbAspectRatio, Path=Text}" Value="Custom">
-                                        <Setter Property="Visibility" Value="Visible" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </StackPanel.Style>
-                        <TextBlock
-                            Width="180"
-                            Text="Custom Ratio" />
                         <TextBox
-                            Width="100"
+                            Width="60"
+                            HorizontalContentAlignment="Right"
+                            VerticalContentAlignment="Center"
+                            Margin="10 0 0 0"
                             PreviewTextInput="ValidationRatio"
-                            Text="{Binding FL.PlayerConfig.Video.CustomAspectRatio, Converter={StaticResource StringToRationalConv}}" />
+                            Text="{Binding FL.PlayerConfig.Video.CustomAspectRatio, Converter={StaticResource StringToRationalConv}}">
+                            <TextBox.Style>
+                                <Style TargetType="TextBox" BasedOn="{StaticResource MaterialDesignTextBox}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ElementName=cmbAspectRatio, Path=Text}" Value="Custom">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBox.Style>
+                        </TextBox>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
@@ -199,7 +197,39 @@
             </GroupBox>
 
             <GroupBox Header="Filters">
-                <ItemsControl ItemsSource="{Binding FL.PlayerConfig.Video.Filters.Values}">
+                <ItemsControl>
+                    <ItemsControl.Style>
+                        <Style TargetType="ItemsControl">
+                            <Setter Property="ItemsSource" Value="{x:Null}"/>
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding FL.PlayerConfig.Video.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.Auto}"/>
+                                        <Condition Binding="{Binding FL.Player.renderer.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.Flyleaf}"/>
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="ItemsSource" Value="{Binding FL.PlayerConfig.Video.Filters.Values}"/>
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding FL.PlayerConfig.Video.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.Auto}"/>
+                                        <Condition Binding="{Binding FL.Player.renderer.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.D3D11}"/>
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="ItemsSource" Value="{Binding FL.PlayerConfig.Video.D3Filters.Values}"/>
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <DataTrigger Binding="{Binding FL.PlayerConfig.Video.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.Flyleaf}">
+                                    <Setter Property="ItemsSource" Value="{Binding FL.PlayerConfig.Video.Filters.Values}"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding FL.PlayerConfig.Video.VideoProcessor}" Value="{x:Static flyleaf:VideoProcessors.D3D11}">
+                                    <Setter Property="ItemsSource" Value="{Binding FL.PlayerConfig.Video.D3Filters.Values}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ItemsControl.Style>
+
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <StackPanel

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -27,6 +27,12 @@
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
 
+        <ObjectDataProvider x:Key="DeInterlaceEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="flyleaf:DeInterlace"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+
         <ObjectDataProvider x:Key="HDRtoSDRMethodEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
             <ObjectDataProvider.MethodParameters>
                 <x:Type TypeName="flyleaf:HDRtoSDRMethod"/>
@@ -80,8 +86,10 @@
                         <TextBlock
                             Width="180"
                             Text="Deinterlace" />
-                        <ToggleButton
-                            IsChecked="{Binding FL.PlayerConfig.Video.Deinterlace}" />
+                        <ComboBox
+                            Width="100"
+                            ItemsSource="{Binding Source={StaticResource DeInterlaceEnum}}"
+                            SelectedItem="{Binding FL.PlayerConfig.Video.DeInterlace}" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml.cs
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml.cs
@@ -13,6 +13,9 @@ public partial class SettingsVideo : UserControl
 
     private void ValidationRatio(object sender, TextCompositionEventArgs e)
     {
-        e.Handled = !Regex.IsMatch(e.Text, @"^[0-9\.\,\/\:]+$");
+        e.Handled = !RegRatio().IsMatch(e.Text);
     }
+
+    [GeneratedRegex(@"^[0-9\.\,\/\:]+$")]
+    private static partial Regex RegRatio();
 }

--- a/LLPlayer/Extensions/TextBoxMiscHelper.cs
+++ b/LLPlayer/Extensions/TextBoxMiscHelper.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 
 namespace LLPlayer.Extensions;
 
-public static class TextBoxMiscHelper
+public static partial class TextBoxMiscHelper
 {
     public static bool GetIsHexValidationEnabled(DependencyObject obj)
     {
@@ -41,6 +41,9 @@ public static class TextBoxMiscHelper
 
     private static void OnPreviewTextInput(object sender, TextCompositionEventArgs e)
     {
-        e.Handled = !Regex.IsMatch(e.Text, "^[0-9a-f]+$", RegexOptions.IgnoreCase);
+        e.Handled = !RegHex().IsMatch(e.Text);
     }
+
+    [GeneratedRegex(@"^[0-9a-f]+$", RegexOptions.IgnoreCase, "en-150")]
+    private static partial Regex RegHex();
 }

--- a/LLPlayer/Resources/Validators.xaml.cs
+++ b/LLPlayer/Resources/Validators.xaml.cs
@@ -19,9 +19,9 @@ public class ColorHexRule : ValidationRule
     {
         if (value != null && Regex.IsMatch(value.ToString() ?? string.Empty, "^[0-9a-f]{6}$", RegexOptions.IgnoreCase))
         {
-            return new ValidationResult(true, null);
+            return new(true, null);
         }
 
-        return new ValidationResult(false, "Invalid");
+        return new(false, "Invalid");
     }
 }

--- a/LLPlayer/Services/AppActions.cs
+++ b/LLPlayer/Services/AppActions.cs
@@ -524,10 +524,11 @@ public class AppActions
 
     public DelegateCommand CmdSetSubtitlesFont => field ??= new(() =>
     {
-        ColorFontDialog dialog = new();
-
-        dialog.Topmost = _config.AlwaysOnTop;
-        dialog.Font = new FontInfo(new FontFamily(_config.Subs.SubsFontFamily), _config.Subs.SubsFontSize, (FontStyle)_fontStyleConv.ConvertFromString(_config.Subs.SubsFontStyle)!, (FontStretch)_fontStretchConv.ConvertFromString(_config.Subs.SubsFontStretch)!, (FontWeight)_fontWeightConv.ConvertFromString(_config.Subs.SubsFontWeight)!, new SolidColorBrush(Colors.Black));
+        ColorFontDialog dialog = new()
+        {
+            Topmost = _config.AlwaysOnTop,
+            Font = new FontInfo(new FontFamily(_config.Subs.SubsFontFamily), _config.Subs.SubsFontSize, (FontStyle)_fontStyleConv.ConvertFromString(_config.Subs.SubsFontStyle)!, (FontStretch)_fontStretchConv.ConvertFromString(_config.Subs.SubsFontStretch)!, (FontWeight)_fontWeightConv.ConvertFromString(_config.Subs.SubsFontWeight)!, new SolidColorBrush(Colors.Black))
+        };
 
         _player.Activity.ForceFullActive();
 

--- a/LLPlayer/Views/FlyleafOverlay.xaml
+++ b/LLPlayer/Views/FlyleafOverlay.xaml
@@ -84,7 +84,18 @@
 
             <!-- Debug Info -->
             <!-- TODO: L: make it dedicated window -->
-            <flyleaf:PlayerDebug DataContext="{Binding FL}" VerticalAlignment="Center" HorizontalAlignment="Center" Player="{Binding Player}" BoxColor="#AA000000" HeaderColor="White" InfoColor="{DynamicResource MaterialDesign.Brush.Primary.Light}" ValueColor="{DynamicResource MaterialDesign.Brush.Secondary.Light}" Visibility="{Binding Config.ShowDebug, Converter={StaticResource BooleanToVisibilityConv}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+            <flyleaf:PlayerDebug x:Name="playerDebug" DataContext="{Binding FL}" VerticalAlignment="Center" HorizontalAlignment="Center" BoxColor="#AA000000" HeaderColor="White" InfoColor="{DynamicResource MaterialDesign.Brush.Primary.Light}" ValueColor="{DynamicResource MaterialDesign.Brush.Secondary.Light}" Visibility="{Binding Config.ShowDebug, Converter={StaticResource BooleanToVisibilityConv}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
+                <flyleaf:PlayerDebug.Style>
+                    <Style TargetType="flyleaf:PlayerDebug">
+                        <Setter Property="Player" Value="{x:Null}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Visibility, ElementName=playerDebug}" Value="Visible">
+                                <Setter Property="Player" Value="{Binding Player}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </flyleaf:PlayerDebug.Style>
+            </flyleaf:PlayerDebug>
 
             <!--Loading Spinner-->
             <ProgressBar


### PR DESCRIPTION
Update FlyleafLib v3.8.7 from v3.8.6

## Changelog

- Config: Introduces Config.Video.SyncVPFilters to allow D3D11VP/FlyleafVP filters syncing
- Config: Introduces Config.Video.DeInterlace for [Auto/Progressive/Top/Bottom]
- Engine.Video: Introduces MaxLuminance/RecommendedLuminance (for SDRDisplayNits)
- Player: Improves and Fixes issues with Frame Stepping (mainly backwards)
- PlayerDebug: Updates Video Box
- Renderer: Video Filters Improvements (Separates D3D11VP/FlyleafVP filters)
- Renderer: Pixel Shader Improvements
- Renderer: DeInterlace: Adds Bob support for FlyleafVP (still defaults to D3D11VP)
- Renderer: DeInterlace: Can identify interlaced source and automatically enable it
- Renderer: DeInterlace: Playback-Rendering for both Top/Bottom fields
- Renderer: Handles Device Removed/Reset
- Renderer: Fixes an issue with Yuyv422/Yvyu422/Uyvy422 formats cause from v3.8.6
- Renderer: Fixes a backwards compatibility issue caused from v3.8.6

- FlyleafME: Updates Video Settings
- FlyleafME: Fixes a possible performance issue with PlayerDebug

[Breaking Changes]
- Deprecates Config.Video.Deinterlace/DeinterlaceBottomFirst
- Config.Video.Filters are now only for FlyleafVP. For D3D11VP use Config.Video.D3Filters

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/49a695ae25651c0f8f264cb9d744e8ff99ce59a6...d7d2606d6188ae4fe18a7f4814c6080429ef87b4