### PR TITLE
Update FlyleafLib v3.8.10

### DIFF
--- a/FlyleafLib/Controls/WPF/Converters.cs
+++ b/FlyleafLib/Controls/WPF/Converters.cs
@@ -40,3 +40,24 @@ public class StringToRationalConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => new AspectRatio(value.ToString());
 }
+
+[ValueConversion(typeof(int), typeof(DeInterlace))]
+public class DeInterlaceConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)     => (DeInterlace)value;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}
+
+public class EqualityConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length < 2 || values[0] == null || values[1] == null)
+            return false;
+
+        return values[0].Equals(values[1]);
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -12,6 +12,8 @@
         <ResourceDictionary>
             <local:TicksToTimeSpanConverter x:Key="TicksToTimeSpan"/>
             <local:TicksToMilliSecondsConverter x:Key="TicksToMilliSeconds"/>
+            <local:DeInterlaceConverter x:Key="DeInterlaceConverter"/>
+            <local:EqualityConverter x:Key="EqualityConverter"/>
 
             <Style x:Key="FlowTable" TargetType="StackPanel">
                 <Setter Property="Background" Value="{Binding BoxColor, ElementName=DebugControl}"/>
@@ -49,8 +51,28 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <StackPanel>
-        <TextBlock HorizontalAlignment="Left" Background="{Binding BoxColor, ElementName=DebugControl}" Style="{StaticResource TextValue}" Padding="10" Width="690" TextWrapping="Wrap" Text="{Binding Player.Playlist.Url}"/>
-        <TextBlock HorizontalAlignment="Left" Background="{Binding BoxColor, ElementName=DebugControl}" Style="{StaticResource TextValue}" Padding="10" Width="690" TextWrapping="Wrap" Text="{Binding Player.Playlist.Selected.Title}"/>
+
+        <TextBlock x:Name="SelectedTitle" HorizontalAlignment="Left" Background="{Binding BoxColor, ElementName=DebugControl}" Padding="10" Width="690" TextWrapping="Wrap" Text="{Binding Player.Playlist.Selected.Title}">
+            <TextBlock.Style>
+                <Style BasedOn="{StaticResource TextValue}" TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Value="True">
+                            <DataTrigger.Binding>
+                                <MultiBinding Converter="{StaticResource EqualityConverter}">
+                                    <Binding Path="Player.Playlist.Url"/>
+                                    <Binding Path="Text" ElementName="SelectedTitle"/>
+                                </MultiBinding>
+                            </DataTrigger.Binding>
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+
+        <TextBlock HorizontalAlignment="Left" Background="{Binding BoxColor, ElementName=DebugControl}" Style="{StaticResource TextValue}" Padding="10" Width="690" TextWrapping="Wrap" FontSize="12" Text="{Binding Player.Playlist.Url}"/>
+
         <Grid x:Name="rootGrid">
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
@@ -63,7 +85,7 @@
 
         <StackPanel>
             <!-- Player -->
-            <StackPanel Style="{StaticResource FlowTable}" Height="320">
+            <StackPanel Style="{StaticResource FlowTable}" Height="316">
                 <TextBlock Style="{StaticResource TextHeader}" Text="Player"/>
 
                 <StackPanel Orientation="Horizontal">
@@ -112,6 +134,11 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
+                    <TextBlock Style="{StaticResource TextInfo}" Text="DeInterlace"/>
+                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Config.Video.DeInterlace}"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="Speed"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Speed, StringFormat=x{0}}"/>
                 </StackPanel>
@@ -140,7 +167,7 @@
             </StackPanel>
 
             <!-- Audio (Manual Height-->
-            <StackPanel Style="{StaticResource FlowTable}" Height="320">
+            <StackPanel Style="{StaticResource FlowTable}" Height="316">
                 <TextBlock Style="{StaticResource TextHeader}" Text="Audio"/>
 
                 <StackPanel Orientation="Horizontal">
@@ -207,7 +234,7 @@
 
         <StackPanel Grid.Column="1">
             <!-- Video -->
-            <StackPanel Style="{StaticResource FlowTable}" Height="320">
+            <StackPanel Style="{StaticResource FlowTable}" Height="316">
                 <TextBlock Style="{StaticResource TextHeader}" Text="Video"/>
 
                 <StackPanel Orientation="Horizontal">
@@ -261,10 +288,10 @@
 
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="DeInterlace"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.FieldType}"/>
+                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.FieldType, Converter={StaticResource DeInterlaceConverter}}"/>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+                <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="ZeroCopy"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.ZeroCopy}"/>
                 </StackPanel>
@@ -311,7 +338,7 @@
             </StackPanel>
 
             <!-- Stats -->
-            <StackPanel Style="{StaticResource FlowTable}" Height="172">
+            <StackPanel Style="{StaticResource FlowTable}" Height="168">
                 <TextBlock Style="{StaticResource TextHeader}" Text="Stats"/>
 
                 <StackPanel Orientation="Horizontal">

--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -292,11 +292,6 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Style="{StaticResource TextInfo}" Text="ZeroCopy"/>
-                    <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.ZeroCopy}"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal">
                     <TextBlock Style="{StaticResource TextInfo}" Text="VideoAcceleration"/>
                     <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.VideoAcceleration}"/>
                 </StackPanel>

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -706,6 +706,10 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public bool             ClearScreen                 { get; set; } = true;
 
+        /// <summary>
+        /// Cropping rectagle to crop the output frame (based on frame size)
+        /// </summary>
+        [JsonIgnore]
         public CropRect         Crop                        { get => _Crop;             set { _Crop = value; HasUserCrop = _Crop != CropRect.Empty; player?.renderer?.UpdateCropping(); } }
         internal CropRect _Crop = CropRect.Empty;
         internal bool HasUserCrop = false;

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -630,13 +630,6 @@ public class Config : NotifyPropertyChanged
         public int              MaxErrors       { get; set; } = 200;
 
         /// <summary>
-        /// Whether or not to use decoder's textures directly as shader resources
-        /// (TBR: Better performance but might need to be disabled while video input has padding or not supported by older Direct3D versions)
-        /// </summary>
-        public ZeroCopy         ZeroCopy        { get => _ZeroCopy; set { if (SetUI(ref _ZeroCopy, value) && player != null && player.Video.isOpened) player.VideoDecoder?.RecalculateZeroCopy(); } }
-        ZeroCopy _ZeroCopy = ZeroCopy.Auto;
-
-        /// <summary>
         /// Allows video accceleration even in codec's profile mismatch
         /// </summary>
         public bool             AllowProfileMismatch
@@ -692,13 +685,13 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Video aspect ratio
         /// </summary>
-        public AspectRatio      AspectRatio                 { get => _AspectRatio;  set { if (Set(ref _AspectRatio, value) && player != null && player.renderer != null && !player.renderer.SCDisposed) lock(player.renderer.lockDevice) {  player.renderer.SetViewport(); if (player.renderer.child != null) player.renderer.child.SetViewport(); } } }
+        public AspectRatio      AspectRatio                 { get => _AspectRatio;          set { if (Set(ref _AspectRatio, value))     player?.renderer?.UpdateAspectRatio(); } }
         AspectRatio    _AspectRatio = AspectRatio.Keep;
 
         /// <summary>
         /// Custom aspect ratio (AspectRatio must be set to Custom to have an effect)
         /// </summary>
-        public AspectRatio      CustomAspectRatio           { get => _CustomAspectRatio;  set { if (Set(ref _CustomAspectRatio, value) && AspectRatio == AspectRatio.Custom) { _AspectRatio = AspectRatio.Fill; AspectRatio = AspectRatio.Custom; } } }
+        public AspectRatio      CustomAspectRatio           { get => _CustomAspectRatio;    set { if (Set(ref _CustomAspectRatio, value) && AspectRatio == AspectRatio.Custom) { _AspectRatio = AspectRatio.Fill; AspectRatio = AspectRatio.Custom; } } }
         AspectRatio    _CustomAspectRatio = new(16, 9);
 
         /// <summary>
@@ -712,6 +705,10 @@ public class Config : NotifyPropertyChanged
         /// Clears the screen on stop/close/open
         /// </summary>
         public bool             ClearScreen                 { get; set; } = true;
+
+        public CropRect         Crop                        { get => _Crop;             set { _Crop = value; HasUserCrop = _Crop != CropRect.Empty; player?.renderer?.UpdateCropping(); } }
+        internal CropRect _Crop = CropRect.Empty;
+        internal bool HasUserCrop = false;
 
         /// <summary>
         /// Whether video should be allowed

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -49,12 +49,12 @@ public enum HDRtoSDRMethod : int
     Reinhard    = 3
 }
 
-public enum DeInterlace : int
+public enum DeInterlace // Must match with VideoFrameFormat
 {
-    Auto        = -2,
-    Progressive = -1,
-    TopField    =  0,
-    BottomField =  1
+    Progressive,
+    TopField,
+    BottomField,
+    Auto
 }
 public enum VideoProcessors
 {

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -68,6 +68,14 @@ public enum ZeroCopy : int
     Enabled     = 1,
     Disabled    = 2
 }
+[Flags]
+public enum Cropping
+{
+    None,
+    Stream,
+    Codec,
+    Texture
+}
 public enum ColorSpace : int
 {
     None        = 0,
@@ -169,37 +177,37 @@ public enum VideoFilters
 
 public struct AspectRatio : IEquatable<AspectRatio>
 {
-    public static readonly AspectRatio Keep     = new(-1, 1);
-    public static readonly AspectRatio Fill     = new(-2, 1);
-    public static readonly AspectRatio Custom   = new(-3, 1);
+    public static readonly AspectRatio Keep     = new(-1,   1);
+    public static readonly AspectRatio Fill     = new(-2,   1);
+    public static readonly AspectRatio Custom   = new(-3,   1);
     public static readonly AspectRatio Invalid  = new(-999, 1);
 
-    public static readonly List<AspectRatio> AspectRatios = new()
-    {
+    public static readonly List<AspectRatio> AspectRatios =
+    [
         Keep,
         Fill,
         Custom,
-        new AspectRatio(1, 1),
-        new AspectRatio(4, 3),
-        new AspectRatio(16, 9),
-        new AspectRatio(16, 10),
-        new AspectRatio(2.35f, 1),
-    };
+        new(1,      1),
+        new(4,      3),
+        new(16,     9),
+        new(16,     10),
+        new(2.35f,  1),
+    ];
 
-    public static implicit operator AspectRatio(string value) => new AspectRatio(value);
+    public static implicit operator AspectRatio(string value) => new(value);
 
     public float Num { get; set; }
     public float Den { get; set; }
 
     public float Value
     {
-        get => Num / Den;
-        set  { Num = value; Den = 1; }
+        readonly get => Num / Den;
+        set { Num = value; Den = 1; }
     }
 
     public string ValueStr
     {
-        get => ToString();
+        readonly get => ToString();
         set => FromString(value);
     }
 
@@ -207,9 +215,9 @@ public struct AspectRatio : IEquatable<AspectRatio>
     public AspectRatio(float num, float den) { Num = num; Den = den; }
     public AspectRatio(string value) { Num = Invalid.Num; Den = Invalid.Den; FromString(value); }
 
-    public bool Equals(AspectRatio other) => Num == other.Num && Den == other.Den;
-    public override bool Equals(object obj) => obj is AspectRatio o && Equals(o);
-    public override int GetHashCode() => HashCode.Combine(Num, Den);
+    public readonly bool Equals(AspectRatio other) => Num == other.Num && Den == other.Den;
+    public override readonly bool Equals(object obj) => obj is AspectRatio o && Equals(o);
+    public override readonly int GetHashCode() => HashCode.Combine(Num, Den);
     public static bool operator ==(AspectRatio a, AspectRatio b) => a.Equals(b);
     public static bool operator !=(AspectRatio a, AspectRatio b) => !(a == b);
 
@@ -242,7 +250,34 @@ public struct AspectRatio : IEquatable<AspectRatio>
         else
             { Num = Invalid.Num; Den = Invalid.Den; }
     }
-    public override string ToString() => this == Keep ? "Keep" : (this == Fill ? "Fill" : (this == Custom ? "Custom" : (this == Invalid ? "Invalid" : $"{Num}:{Den}")));
+    public override readonly string ToString() => this == Keep ? "Keep" : (this == Fill ? "Fill" : (this == Custom ? "Custom" : (this == Invalid ? "Invalid" : $"{Num}:{Den}")));
+}
+
+public struct CropRect(uint top = 0, uint left= 0, uint bottom= 0, uint right= 0) : IEquatable<CropRect>
+{
+    public static readonly CropRect Empty;
+
+    public uint             Top     = top;
+    public uint             Left    = left;
+    public uint             Bottom  = bottom;
+    public uint             Right   = right;
+
+    public readonly uint    Width   => Right - Left;
+    public readonly uint    Height  => Bottom - Top;
+    public readonly bool    IsEmpty => Top == 0 && Left == 0 && Bottom == 0 && Right == 0;
+
+    public static bool operator ==(CropRect a, CropRect b)
+        => a.Top == b.Top && a.Bottom == b.Bottom && a.Left == b.Left && a.Right == b.Right;
+    public static bool operator !=(CropRect left, CropRect right)
+        => !(left == right);
+    public readonly bool Equals(CropRect other)
+        => this == other;
+    public override readonly bool Equals(object obj)
+        => obj is CropRect other && this == other;
+    public override readonly int GetHashCode()
+        => HashCode.Combine(Top, Bottom, Left, Right);
+    public override readonly string ToString()
+        => $"[Top: {Top}, Left: {Left}, Bottom: {Bottom}, Right: {Right}]";
 }
 
 class PlayerStats
@@ -252,6 +287,7 @@ class PlayerStats
     public long AudioBytes      { get; set; }
     public long FramesDisplayed { get; set; }
 }
+
 public class NotifyPropertyChanged : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler PropertyChanged;

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.9</Version>
+    <Version>3.8.10</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -916,6 +916,7 @@ public unsafe class VideoDecoder : DecoderBase
     /// Performs accurate seeking to the requested VideoFrame and returns it
     /// </summary>
     /// <param name="frameNumber">Zero based frame index</param>
+    /// <param name="backwards">Workaround for VFR for backwards frame stepping</param>
     /// <returns>The requested VideoFrame or null on failure</returns>
     public VideoFrame GetFrame(int frameNumber, bool backwards = false)
     {

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -993,9 +993,6 @@ public unsafe class VideoDecoder : DecoderBase
                     (backwards && curFrameNumber + 2 >= frameNumber && GetFrameNumber2((long)(frame->pts * VideoStream.Timebase) + VideoStream.FrameDuration + (VideoStream.FrameDuration / 2)) - curFrameNumber > 1))
                     // At least return a previous frame in case of Tb inaccuracy and don't stuck at the same frame
                 {
-                    if (backwards && curFrameNumber + 2 >= frameNumber && GetFrameNumber2((long)(frame->pts * VideoStream.Timebase) + VideoStream.FrameDuration + (VideoStream.FrameDuration / 2)) - curFrameNumber > 1)
-                        Log.Debug("");
-
                     var mFrame = Renderer.FillPlanes(frame);
                     if (mFrame != null)
                         return mFrame;

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -1,14 +1,7 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 using System.Windows.Data;
 
 using static FlyleafLib.Config;
-using static FlyleafLib.Logger;
 
 using FlyleafLib.MediaFramework.MediaProgram;
 using FlyleafLib.MediaFramework.MediaStream;

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -767,6 +767,12 @@ public unsafe class Demuxer : RunThreadBase
         if (fmtCtx->start_time_realtime != NoTs)
             StartRealTime = EPOCH.AddMicroseconds(fmtCtx->start_time_realtime);
 
+        if (Engine.Config.FFmpegHLSLiveSeek && Duration == 0 && Name == "hls" && Environment.Is64BitProcess) // HLSContext cast is not safe
+        {
+            hlsCtx = (HLSContext*)fmtCtx->priv_data;
+            StartTime = 0;
+        }
+
         Metadata.Clear();
         AVDictionaryEntry* b = null;
         while (true)
@@ -866,7 +872,7 @@ public unsafe class Demuxer : RunThreadBase
         Duration = fmtCtx->duration > 0 ? fmtCtx->duration * 10 : 0;
 
         // Try to fill duration when missing (not analyzed mainly) | Considers CFR
-        if (Duration == 0 && !analyzed)
+        if (Duration == 0 && !analyzed && hlsCtx == null)
         {
             foreach(var videoStream in VideoStreams)
                 if (videoStream.TotalFrames > 0 && videoStream.FrameDuration > 0)
@@ -902,14 +908,6 @@ public unsafe class Demuxer : RunThreadBase
         {
             for (int i = 0; i < fmtCtx->nb_streams; i++)
                 AVStreamToStream[i].UpdateDuration();
-        }
-
-        // TBR: Possible we can get Apple HTTP Live Streaming/hls with HLSPlaylist->finished with Duration != 0
-        if (Engine.Config.FFmpegHLSLiveSeek && Duration == 0 && Name == "hls" && Environment.Is64BitProcess) // HLSContext cast is not safe
-        {
-            hlsCtx = (HLSContext*)fmtCtx->priv_data;
-            StartTime = 0;
-            //UpdateHLSTime(); Maybe with default 0 playlist
         }
 
         IsLive = Duration == 0 || hlsCtx != null;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -252,7 +252,6 @@ public unsafe partial class Renderer
                     ByteWidth       = (uint)(sizeof(PSBufferType) + (16 - (sizeof(PSBufferType) % 16)))
                 });
                 context.PSSetConstantBuffer(0, psBuffer);
-                psBufferData.fieldType = FieldType;
 
                 // subs
                 ShaderBGRA = ShaderCompiler.CompilePS(Device, "bgra", @"color = float4(Texture1.Sample(Sampler, input.Texture).rgba);", null);
@@ -500,13 +499,8 @@ public unsafe partial class Renderer
         public float saturation;    //  0.0  to 2.0     (1.0 default)
 
         public float uvOffset;
-        public float yoffset;
         public HDRtoSDRMethod tonemap;
         public float hdrtone;
-        public DeInterlace fieldType;
-
-        private float _pad1;
-        private float _pad2;
 
         public PSBufferType()
         {
@@ -514,9 +508,7 @@ public unsafe partial class Renderer
             contrast    = 1;
             hue         = 0;
             saturation  = 1;
-
             tonemap     = HDRtoSDRMethod.Hable;
-            fieldType   = DeInterlace.Progressive;
         }
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -8,7 +8,6 @@ using Vortice.Direct3D11;
 using Vortice.DXGI;
 using Vortice.DXGI.Debug;
 
-using static FlyleafLib.Logger;
 using ID3D11Device = Vortice.Direct3D11.ID3D11Device;
 using ID3D11DeviceContext = Vortice.Direct3D11.ID3D11DeviceContext;
 
@@ -99,12 +98,12 @@ public unsafe partial class Renderer
     ID3D11PixelShader   ShaderBGRA;
 
     ID3D11Buffer        psBuffer;
-    PSBufferType        psBufferData = new();
+    PSBufferType        psBufferData    = new();
 
     ID3D11Buffer        vsBuffer;
-    VSBufferType        vsBufferData;
+    VSBufferType        vsBufferData    = new();
 
-    internal object     lockDevice = new();
+    internal object     lockDevice      = new();
     bool                isFlushing;
 
     public void Initialize(bool swapChain = true)
@@ -515,6 +514,10 @@ public unsafe partial class Renderer
     [StructLayout(LayoutKind.Sequential)]
     struct VSBufferType
     {
-        public Matrix4x4 mat;
+        public Matrix4x4    mat;
+        public Vector4      cropRegion;
+        
+        public VSBufferType()
+            => cropRegion = new(0, 0, 1, 1);
     }
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -1,6 +1,7 @@
 ﻿using SharpGen.Runtime;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
+using Vortice.Mathematics;
 
 using FlyleafLib.MediaFramework.MediaDecoder;
 using FlyleafLib.MediaFramework.MediaFrame;
@@ -147,13 +148,15 @@ public unsafe partial class Renderer
 
             if (overlayTexture != null)
             {
+                Viewport view = GetViewport;
+
                 // Don't stretch the overlay (reduce height based on ratiox) | Sub's stream size might be different from video size (fix y based on percentage)
-                var ratiox = (double)GetViewport.Width / overlayTextureOriginalWidth;
+                var ratiox = (double)view.Width / overlayTextureOriginalWidth;
                 var ratioy = (double)overlayTextureOriginalPosY / overlayTextureOriginalHeight;
 
                 context.OMSetBlendState(blendStateAlpha);
                 context.PSSetShaderResources(0, overlayTextureSRVs);
-                context.RSSetViewport((float) (GetViewport.X + (overlayTextureOriginalPosX * ratiox)), (float) (GetViewport.Y + (GetViewport.Height * ratioy)), (float) (overlayTexture.Description.Width * ratiox), (float) (overlayTexture.Description.Height * ratiox));
+                context.RSSetViewport((float) (view.X + (overlayTextureOriginalPosX * ratiox)), (float) (view.Y + (view.Height * ratioy)), (float) (overlayTexture.Description.Width * ratiox), (float) (overlayTexture.Description.Height * ratiox));
                 context.PSSetShader(ShaderBGRA);
                 context.Draw(6, 0);
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -5,6 +5,7 @@ using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DirectComposition;
 using Vortice.DXGI;
+using Vortice.Mathematics;
 
 using static FlyleafLib.Utils.NativeMethods;
 
@@ -77,7 +78,7 @@ public partial class Renderer
 
             ControlHandle   = handle;
             RECT rect       = new();
-            GetWindowRect(ControlHandle,ref rect);
+            GetWindowRect(ControlHandle, ref rect);
             ControlWidth    = rect.Right  - rect.Left;
             ControlHeight   = rect.Bottom - rect.Top;
 
@@ -236,8 +237,6 @@ public partial class Renderer
         p.X -= (SideXPixels / 2 + PanXOffset);
         p.Y -= (SideYPixels / 2 + PanYOffset);
     }
-    public bool IsPointWithInViewPort(Point p)
-        => p.X >= GetViewport.X && p.X < GetViewport.X + GetViewport.Width && p.Y >= GetViewport.Y && p.Y < GetViewport.Y + GetViewport.Height;
 
     public static double GetCenterPoint(double zoom, double offset)
         => zoom == 1 ? offset : offset / (zoom - 1); // possible bug when zoom = 1 (noticed in out of bounds zoom out)
@@ -262,47 +261,36 @@ public partial class Renderer
          * CP = VP / (ZP - 1) (when UP = ZP)
          */
 
-        if (!IsPointWithInViewPort(p))
+        Viewport view = GetViewport;
+
+        if (!(p.X >= view.X && p.X < view.X + view.Width && p.Y >= view.Y && p.Y < view.Y + view.Height)) // Point out of view
         {
             SetZoom(zoom);
             return;
         }
 
-        Point viewport = new(GetViewport.X, GetViewport.Y);
+        Point viewport = new(view.X, view.Y);
         RemoveViewportOffsets(ref viewport);
         RemoveViewportOffsets(ref p);
 
         // Finds the required center point so that p will have the same pixel after zoom
         Point zoomCenter = new(
-            GetCenterPoint(zoom, ((p.X - viewport.X) / (this.zoom / zoom)) - p.X) / (GetViewport.Width / this.zoom),
-            GetCenterPoint(zoom, ((p.Y - viewport.Y) / (this.zoom / zoom)) - p.Y) / (GetViewport.Height / this.zoom));
+            GetCenterPoint(zoom, ((p.X - viewport.X) / (this.zoom / zoom)) - p.X) / (view.Width / this.zoom),
+            GetCenterPoint(zoom, ((p.Y - viewport.Y) / (this.zoom / zoom)) - p.Y) / (view.Height / this.zoom));
 
         SetZoomAndCenter(zoom, zoomCenter);
     }
 
     public void SetViewport(bool refresh = true)
     {
-        float ratio;
         int x, y, newWidth, newHeight, xZoomPixels, yZoomPixels;
 
-        if (Config.Video.AspectRatio == AspectRatio.Keep)
-            ratio = curRatio;
-        else ratio = Config.Video.AspectRatio == AspectRatio.Fill
-            ? ControlWidth / (float)ControlHeight
-            : Config.Video.AspectRatio == AspectRatio.Custom ? Config.Video.CustomAspectRatio.Value : Config.Video.AspectRatio.Value;
-
-        if (ratio <= 0)
-            ratio = 1;
-
-        if (actualRotation == 90 || actualRotation == 270)
-            ratio = 1 / ratio;
-
-        if (ratio < ControlWidth / (float) ControlHeight)
+        if (curRatio < fillRatio)
         {
             newHeight   = (int)(ControlHeight * zoom);
-            newWidth    = (int)(newHeight * ratio);
+            newWidth    = (int)(newHeight * curRatio);
 
-            SideXPixels = newWidth > ControlWidth && false ? 0 : (int) (ControlWidth - (ControlHeight * ratio)); // TBR
+            SideXPixels = (int) (ControlWidth - (ControlHeight * curRatio));
             SideYPixels = 0;
 
             y = PanYOffset;
@@ -314,9 +302,9 @@ public partial class Renderer
         else
         {
             newWidth    = (int)(ControlWidth * zoom);
-            newHeight   = (int)(newWidth / ratio);
+            newHeight   = (int)(newWidth / curRatio);
 
-            SideYPixels = newHeight > ControlHeight && false ? 0 : (int) (ControlHeight - (ControlWidth / ratio));
+            SideYPixels = (int) (ControlHeight - (ControlWidth / curRatio));
             SideXPixels = 0;
 
             x = PanXOffset;
@@ -331,63 +319,93 @@ public partial class Renderer
 
         if (videoProcessor == VideoProcessors.D3D11)
         {
-            RawRect src, dst;
+            Viewport view = GetViewport;
 
-            if (GetViewport.Width < 1 || GetViewport.X + GetViewport.Width <= 0 || GetViewport.X >= ControlWidth || GetViewport.Y + GetViewport.Height <= 0 || GetViewport.Y >= ControlHeight)
-            { // Out of screen
-                src = new RawRect();
-                dst = new RawRect();
+            int right   = (int)(view.X + view.Width);
+            int bottom  = (int)(view.Y + view.Height);
+
+            if (view.Width < 1 || view.Y >= ControlHeight || view.X >= ControlWidth || bottom <= 0 || right <= 0)
+                return;
+
+            RawRect dst = new(
+                    Math.Max((int)view.X, 0),
+                    Math.Max((int)view.Y, 0),
+                    Math.Min(right, ControlWidth),
+                    Math.Min(bottom, ControlHeight));
+
+            double croppedWidth     = VideoRect.Right   - (cropRect.Right  + cropRect.Left);
+            double croppedHeight    = VideoRect.Bottom  - (cropRect.Bottom + cropRect.Top);
+            int dstWidth    = dst.Right  - dst.Left;
+            int dstHeight   = dst.Bottom - dst.Top;
+
+            int     cropLeft,   cropTop,    cropRight,  cropBottom;
+            int     srcLeft,    srcTop,     srcRight,   srcBottom;
+            double  scaleX,     scaleY,     scaleXRot,  scaleYRot;
+
+            if (_RotationAngle == 0)
+            {
+                cropLeft    = view.X < 0 ? (int)(-view.X) : 0;
+                cropTop     = view.Y < 0 ? (int)(-view.Y) : 0;
+
+                scaleX      = croppedWidth  / view.Width;
+                scaleY      = croppedHeight / view.Height;
+
+                srcLeft     = (int)(cropRect.Left + cropLeft * scaleX);
+                srcTop      = (int)(cropRect.Top  + cropTop  * scaleY);
+                srcRight    = srcLeft + (int)(dstWidth  * scaleX);
+                srcBottom   = srcTop  + (int)(dstHeight * scaleY);
+            }
+            else if (_RotationAngle == 180)
+            {
+                cropRight   = right  > ControlWidth  ? right  - ControlWidth  : 0;
+                cropBottom  = bottom > ControlHeight ? bottom - ControlHeight : 0;
+
+                scaleX      = croppedWidth  / view.Width;
+                scaleY      = croppedHeight / view.Height;
+
+                srcLeft     = (int)(cropRect.Left + cropRight  * scaleX);
+                srcTop      = (int)(cropRect.Top  + cropBottom * scaleY);
+                srcRight    = srcLeft + (int)(dstWidth  * scaleX);
+                srcBottom   = srcTop  + (int)(dstHeight * scaleY);
+            }
+            else if (_RotationAngle == 90)
+            {
+                cropTop     = view.Y < 0 ? (int)(-view.Y) : 0;
+                cropRight   = right > ControlWidth ? right - ControlWidth : 0;
+
+                scaleXRot   = croppedWidth  / view.Height;
+                scaleYRot   = croppedHeight / view.Width;
+
+                srcLeft     = (int)(cropRect.Left + cropTop    * scaleXRot);
+                srcTop      = (int)(cropRect.Top  + cropRight  * scaleYRot);
+                srcRight    = srcLeft + (int)(dstHeight * scaleXRot);
+                srcBottom   = srcTop  + (int)(dstWidth  * scaleYRot);
+            }
+            else if (_RotationAngle == 270)
+            {
+                cropLeft    = view.X < 0 ? (int)(-view.X) : 0;
+                cropBottom  = bottom > ControlHeight ? bottom - ControlHeight : 0;
+
+                scaleXRot   = croppedWidth  / view.Height;
+                scaleYRot   = croppedHeight / view.Width;
+
+                srcLeft     = (int)(cropRect.Left + cropBottom * scaleXRot);
+                srcTop      = (int)(cropRect.Top  + cropLeft   * scaleYRot);
+                srcRight    = srcLeft + (int)(dstHeight * scaleXRot);
+                srcBottom   = srcTop  + (int)(dstWidth  * scaleYRot);
             }
             else
-            {
-                int cropLeft    = GetViewport.X < 0 ? (int) GetViewport.X * -1 : 0;
-                int cropRight   = GetViewport.X + GetViewport.Width > ControlWidth ? (int) (GetViewport.X + GetViewport.Width - ControlWidth) : 0;
-                int cropTop     = GetViewport.Y < 0 ? (int) GetViewport.Y * -1 : 0;
-                int cropBottom  = GetViewport.Y + GetViewport.Height > ControlHeight ? (int) (GetViewport.Y + GetViewport.Height - ControlHeight) : 0;
+                srcLeft = srcTop = srcRight = srcBottom = 0;
 
-                dst = new RawRect(
-                    Math.Max((int)GetViewport.X, 0),
-                    Math.Max((int)GetViewport.Y, 0),
-                    Math.Min((int)GetViewport.Width + (int)GetViewport.X, ControlWidth),
-                    Math.Min((int)GetViewport.Height + (int)GetViewport.Y, ControlHeight));
-
-                if (_RotationAngle == 90)
-                {
-                    src = new RawRect(
-                        (int) (cropTop * (VideoRect.Right / GetViewport.Height)),
-                        (int) (cropRight * (VideoRect.Bottom / GetViewport.Width)),
-                        VideoRect.Right - (int) (cropBottom * VideoRect.Right / GetViewport.Height),
-                        VideoRect.Bottom - (int) (cropLeft * VideoRect.Bottom / GetViewport.Width));
-                }
-                else if (_RotationAngle == 270)
-                {
-                    src = new RawRect(
-                        (int) (cropBottom * VideoRect.Right / GetViewport.Height),
-                        (int) (cropLeft * VideoRect.Bottom / GetViewport.Width),
-                        VideoRect.Right - (int) (cropTop * VideoRect.Right / GetViewport.Height),
-                        VideoRect.Bottom - (int) (cropRight * VideoRect.Bottom / GetViewport.Width));
-                }
-                else if (_RotationAngle == 180)
-                {
-                    src = new RawRect(
-                        (int) (cropRight * VideoRect.Right / GetViewport.Width),
-                        (int) (cropBottom * VideoRect.Bottom /GetViewport.Height),
-                        VideoRect.Right - (int) (cropLeft * VideoRect.Right / GetViewport.Width),
-                        VideoRect.Bottom - (int) (cropTop * VideoRect.Bottom / GetViewport.Height));
-                }
-                else
-                {
-                    src = new RawRect(
-                        (int) (cropLeft * VideoRect.Right / GetViewport.Width),
-                        (int) (cropTop * VideoRect.Bottom / GetViewport.Height),
-                        VideoRect.Right - (int) (cropRight * VideoRect.Right / GetViewport.Width),
-                        VideoRect.Bottom - (int) (cropBottom * VideoRect.Bottom / GetViewport.Height));
-                }
-            }
+            RawRect src = new(
+                Math.Max(srcLeft, 0),
+                Math.Max(srcTop , 0),
+                Math.Min(srcRight , VideoRect.Right),
+                Math.Min(srcBottom, VideoRect.Bottom));
 
             vc.VideoProcessorSetStreamSourceRect(vp, 0, true, src);
             vc.VideoProcessorSetStreamDestRect  (vp, 0, true, dst);
-            vc.VideoProcessorSetOutputTargetRect(vp, true, new RawRect(0, 0, ControlWidth, ControlHeight));
+            vc.VideoProcessorSetOutputTargetRect(vp, true, new(0, 0, ControlWidth, ControlHeight));
         }
 
         if (refresh)
@@ -407,8 +425,11 @@ public partial class Renderer
                 bitmap2d = null;
             }
 
-            ControlWidth = width;
-            ControlHeight = height;
+            ControlWidth    = width;
+            ControlHeight   = height;
+            fillRatio = ControlWidth / (double)ControlHeight;
+            if (Config.Video.AspectRatio == AspectRatio.Fill)
+                curRatio = fillRatio;
 
             backBufferRtv.Dispose();
             vpov?.Dispose();

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -286,7 +286,7 @@ unsafe public partial class Renderer
 
             var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? (VideoStream != null ? VideoStream.FieldOrder : VideoFrameFormat.Progressive) : (VideoFrameFormat)Config.Video.DeInterlace;
             var newVp = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
-                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || fieldType != VideoFrameFormat.Progressive) ?
+                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)) ?
                 VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
 
             if (videoProcessor == VideoProcessors.Flyleaf)
@@ -306,8 +306,6 @@ unsafe public partial class Renderer
         lock (lockDevice)
             return !Disposed ? vc.VideoProcessorGetStreamFrameFormat(vp, 0) : VideoFrameFormat.Progressive;
     }
-
-
     internal void SetFieldType(VideoFrameFormat fieldType)
     {
         lock (lockDevice)
@@ -397,13 +395,82 @@ unsafe public partial class Renderer
             child._d3d11vpRotation  = _d3d11vpRotation;
             child._RotationAngle    = _RotationAngle;
             child.rotationLinesize  = rotationLinesize;
-            child.SetViewport();
         }
 
         vc?.VideoProcessorSetStreamRotation(vp, 0, true, _d3d11vpRotation);
 
-        if (refresh)
-            SetViewport();
+        UpdateAspectRatio(refresh);
+    }
+    internal void UpdateAspectRatio(bool refresh = true)
+    {
+        lock (lockDevice) // TBR: Fix AspectRatio generally* Separate Enum + CustomValue (respect SAR, clarify Fit/Fill/Keep/Stretch/Original/Custom ...)
+        {
+            if (Config.Video.AspectRatio == AspectRatio.Keep)
+                curRatio = keepRatio;
+            else if (Config.Video.AspectRatio == AspectRatio.Fill)
+                curRatio = fillRatio;
+            else if (Config.Video.AspectRatio == AspectRatio.Custom)
+                curRatio = Config.Video.CustomAspectRatio.Value;
+            else
+                curRatio = Config.Video.AspectRatio.Value;
+
+            if (actualRotation == 90 || actualRotation == 270)
+                curRatio = 1 / curRatio;
+
+            if (refresh)
+                SetViewport();
+
+            child?.UpdateAspectRatio(refresh);
+        }
+    }
+    internal void UpdateCropping(bool refresh = true)
+    {
+        /* TODO (SW)
+         *
+         * 1) Visible vs Padded
+         *  When we fix texture arrays and texture width/height to use padded properly,
+         *  we will need to ensure cropping pixels are in the same logic with vertex shader
+         *
+         * 2) Chroma Location + Crop Calculation/Adjustments
+         *  PSInput additional uv coords (both vertex/pixel shaders) and use new coords for sampling
+         *      float2 Texture  : TEXCOORD;
+         *
+         *  e.g. UV Chroma (Semi-Planar) Crop +- (0.5f / (W|H / 2f))?
+         */
+
+        lock (lockDevice)
+        {
+            cropRect = VideoStream.cropRect;
+
+            if (Config.Video.HasUserCrop)
+            {
+                cropRect.Top    += Config.Video._Crop.Top;
+                cropRect.Left   += Config.Video._Crop.Left;
+                cropRect.Right  += Config.Video._Crop.Right;
+                cropRect.Bottom += Config.Video._Crop.Bottom;
+            }
+
+            vsBufferData.cropRegion = new()
+            {
+                X = cropRect.Left / (float)textWidth,
+                Y = cropRect.Top  / (float)textHeight,
+                Z = (textWidth  - cropRect.Right)  / (float)textWidth, //1.0f - (right  / (float)textWidth),
+                W = (textHeight - cropRect.Bottom) / (float)textHeight //1.0f - (bottom / (float)textHeight)
+            };
+
+            if (parent == null)
+                context.UpdateSubresource(vsBufferData, vsBuffer);
+
+            VisibleWidth    = textWidth  - (cropRect.Left + cropRect.Right);
+            VisibleHeight   = textHeight - (cropRect.Top  + cropRect.Bottom);
+            keepRatio       = (double)(VisibleWidth * VideoStream.SAR.Num) / (VisibleHeight * VideoStream.SAR.Den);
+
+            if (Config.Video.AspectRatio == AspectRatio.Keep)
+                curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;
+
+            if (refresh)
+                SetViewport();
+        }
     }
     internal void UpdateVideoProcessor()
     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -246,6 +246,7 @@ unsafe public partial class Renderer
             {
                 UpdateBackgroundColor();
                 vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
+                vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
             }
 
             lock (Config.Video.lockFilters)
@@ -283,30 +284,36 @@ unsafe public partial class Renderer
             if (Disposed || parent != null)
                 return;
 
-            FieldType = Config.Video.DeInterlace == DeInterlace.Auto ? (VideoStream != null ? VideoStream.FieldOrder : DeInterlace.Progressive) : Config.Video.DeInterlace;
-            vc?.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType == DeInterlace.Progressive ? VideoFrameFormat.Progressive : (FieldType == DeInterlace.BottomField ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
-
-            var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : Config.Video.DeInterlace;
+            var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? (VideoStream != null ? VideoStream.FieldOrder : VideoFrameFormat.Progressive) : (VideoFrameFormat)Config.Video.DeInterlace;
             var newVp = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
-                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || fieldType != DeInterlace.Progressive) ?
+                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || fieldType != VideoFrameFormat.Progressive) ?
                 VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
+
+            if (videoProcessor == VideoProcessors.Flyleaf)
+                FieldType = VideoFrameFormat.Progressive;
+            else
+            {
+                FieldType = fieldType;
+                vc.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType);
+            }
 
             if (newVp != VideoProcessor)
                 ConfigPlanes();
         }
     }
-    internal void SetFieldType(DeInterlace fieldType)
+    internal VideoFrameFormat GetFieldType()
     {
         lock (lockDevice)
-        {
-            if (Disposed)
-                return;
+            return !Disposed ? vc.VideoProcessorGetStreamFrameFormat(vp, 0) : VideoFrameFormat.Progressive;
+    }
 
-            //vpsa[0].InputFrameOrField = fieldType == DeInterlace.BottomField ? 1u : 0u; // TBR
-            vc?.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType == DeInterlace.Progressive ? VideoFrameFormat. Progressive : (fieldType == DeInterlace.BottomField ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.InterlacedTopFieldFirst));
-            psBufferData.fieldType = fieldType;
-            context.UpdateSubresource(psBufferData, psBuffer);
-        }
+
+    internal void SetFieldType(VideoFrameFormat fieldType)
+    {
+        lock (lockDevice)
+            if (!Disposed)
+                vc.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType);
+                //TBR: vpsa[0].InputFrameOrField = fieldType == DeInterlace.BottomField ? 1u : 0u; // TBR
     }
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -105,9 +105,8 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     public bool             VFlip           { get => _VFlip;                    set { _VFlip = value; lock (lockDevice) UpdateRotation(_RotationAngle); } }
     bool _VFlip;
 
-    public DeInterlace      FieldType       { get => _DeInterlace;              private  set => SetUI(ref _DeInterlace, value); }
-    DeInterlace _DeInterlace = DeInterlace.Progressive;
-    public DeInterlace      CurFieldType    { get => psBufferData.fieldType;    internal set { if (value != psBufferData.fieldType) SetFieldType(value); } }
+    public VideoFrameFormat FieldType       { get => _FieldType;                private  set => SetUI(ref _FieldType, value); }
+    VideoFrameFormat _FieldType = VideoFrameFormat.Progressive;
 
     public VideoProcessors  VideoProcessor  { get => videoProcessor;            private  set => SetUI(ref videoProcessor, value); }
     VideoProcessors videoProcessor = VideoProcessors.Flyleaf;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -57,6 +57,13 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     public Viewport         GetViewport     { get; private set; }
     public event EventHandler ViewportChanged;
 
+    public uint             VisibleWidth    { get; private set; }
+    public uint             VisibleHeight   { get; private set; }
+    public AspectRatio      DAR             { get; set; }
+    double curRatio, keepRatio, fillRatio;
+    CropRect cropRect; // + User's Cropping
+    uint textWidth, textHeight; // Padded (Codec/Texture)
+
     public CornerRadius     CornerRadius    { get => cornerRadius;              set { if (cornerRadius == value) return; cornerRadius = value; UpdateCornerRadius(); } }
     CornerRadius cornerRadius = new(0);
     CornerRadius zeroCornerRadius = new(0);
@@ -94,15 +101,15 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
         }
     }
 
-    public uint             Rotation        { get => _RotationAngle;            set { lock (lockDevice) UpdateRotation(value); } }
+    public uint             Rotation        { get => _RotationAngle;            set => UpdateRotation(value); }
     uint _RotationAngle;
     VideoProcessorRotation _d3d11vpRotation  = VideoProcessorRotation.Identity;
     bool rotationLinesize; // if negative should be vertically flipped
 
-    public bool             HFlip           { get => _HFlip;                    set { _HFlip = value; lock (lockDevice) UpdateRotation(_RotationAngle); } }
+    public bool             HFlip           { get => _HFlip;                    set { _HFlip = value; UpdateRotation(_RotationAngle); } }
     bool _HFlip;
 
-    public bool             VFlip           { get => _VFlip;                    set { _VFlip = value; lock (lockDevice) UpdateRotation(_RotationAngle); } }
+    public bool             VFlip           { get => _VFlip;                    set { _VFlip = value; UpdateRotation(_RotationAngle); } }
     bool _VFlip;
 
     public VideoFrameFormat FieldType       { get => _FieldType;                private  set => SetUI(ref _FieldType, value); }

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
@@ -29,17 +29,15 @@ Texture2D		Texture4		: register(t3);
 struct ConfigData
 {
     int coefsIndex;
+
     float brightness;
     float contrast;
     float hue;
     float saturation;
+
     float uvOffset;
-    float yoffset;
     int tonemap;
     float hdrtone;
-    int fieldType;
-
-    float2 padding;
 };
 
 cbuffer         Config          : register(b0)
@@ -234,7 +232,7 @@ inline float3 ToneHable(float3 x)
 
     return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
 }
-static const float3 HABLE_DEFAULT = ToneHable(11.2); // whitepoint (TBR: if should be 4.8 and possible expose to config)
+static const float3 HABLE_DEFAULT = ToneHable(11.2);
 
 inline float3 ToneReinhard(float3 x)
 {

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.VertexShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.VertexShader.cs
@@ -6,6 +6,7 @@ internal static partial class ShaderCompiler
 cbuffer cBuf : register(b0)
 {
     matrix mat;
+    float4 cropRegion;
 }
 
 struct VSInput
@@ -24,8 +25,8 @@ PSInput main(VSInput vsi)
 {
     PSInput psi;
 
-    psi.Position = mul(vsi.Position, mat);
-    psi.Texture  = vsi.Texture;
+    psi.Position    = mul(vsi.Position, mat);
+    psi.Texture     = lerp(cropRegion.xy, cropRegion.zw, vsi.Texture);
 
     return psi;
 }

--- a/FlyleafLib/MediaFramework/MediaStream/StreamBase.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/StreamBase.cs
@@ -177,7 +177,7 @@ public abstract unsafe class StreamBase : NotifyPropertyChanged
         if (this is AudioStream audio)
             dump += $"\r\n\t[Format  ] {audio.SampleRate} Hz, {audio.ChannelLayoutStr}, {audio.SampleFormatStr}";
         else if (this is VideoStream video)
-            dump += $"\r\n\t[Format  ] {video.PixelFormat} ({cp->color_primaries}, {video.ColorSpace}, {video.ColorTransfer}, {cp->chroma_location}, {video.ColorRange}, {video.FieldOrder}), {video.Width}x{video.Height} @ {DoubleToTimeMini(video.FPS)} fps [SAR1: {video.SAR} DAR: {video.AspectRatio}]";
+            dump += $"\r\n\t[Format  ] {video.PixelFormat} ({cp->color_primaries}, {video.ColorSpace}, {video.ColorTransfer}, {cp->chroma_location}, {video.ColorRange}, {video.FieldOrder}), {video.Width}x{video.Height} @ {DoubleToTimeMini(video.FPS)} fps [SAR: {video.SAR} DAR: {video.GetDAR()} Crop: {video.Cropping}]";
 
         if (Metadata.Count > 0)
             dump += $"\r\n{GetDumpMetadata(Metadata, "language")}";

--- a/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
@@ -1,4 +1,6 @@
-﻿using FlyleafLib.MediaFramework.MediaDecoder;
+﻿using Vortice.Direct3D11;
+
+using FlyleafLib.MediaFramework.MediaDecoder;
 using FlyleafLib.MediaFramework.MediaDemuxer;
 
 namespace FlyleafLib.MediaFramework.MediaStream;
@@ -17,7 +19,7 @@ public unsafe class VideoStream : StreamBase
     public ColorType                    ColorType           { get; set; }
     public AVColorTransferCharacteristic
                                         ColorTransfer       { get; set; }
-    public DeInterlace                  FieldOrder          { get; set; }
+    public VideoFrameFormat             FieldOrder          { get; set; }
     public double                       Rotation            { get; set; }
     public double                       FPS                 { get; set; }
     public long                         FrameDuration       { get ;set; }
@@ -84,7 +86,7 @@ public unsafe class VideoStream : StreamBase
             TotalFrames     = (int)(Duration / FrameDuration);
         }
 
-        FieldOrder      = cp->field_order == AVFieldOrder.Tt ? DeInterlace.TopField : (cp->field_order == AVFieldOrder.Bb ? DeInterlace.BottomField : DeInterlace.Progressive);
+        FieldOrder      = cp->field_order == AVFieldOrder.Tt ? VideoFrameFormat.InterlacedTopFieldFirst : (cp->field_order == AVFieldOrder.Bb ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.Progressive);
         ColorTransfer   = cp->color_trc;
 
         if (cp->color_range == AVColorRange.Mpeg)
@@ -147,9 +149,9 @@ public unsafe class VideoStream : StreamBase
         }
 
         if (frame->flags.HasFlag(FrameFlags.Interlaced))
-            FieldOrder = frame->flags.HasFlag(FrameFlags.TopFieldFirst) ? DeInterlace.TopField : DeInterlace.BottomField;
+            FieldOrder = frame->flags.HasFlag(FrameFlags.TopFieldFirst) ? VideoFrameFormat.InterlacedTopFieldFirst : VideoFrameFormat.InterlacedBottomFieldFirst;
         else
-            FieldOrder = codecCtx->field_order == AVFieldOrder.Tt ? DeInterlace.TopField : (codecCtx->field_order == AVFieldOrder.Bb ? DeInterlace.BottomField : DeInterlace.Progressive);
+            FieldOrder = codecCtx->field_order == AVFieldOrder.Tt ? VideoFrameFormat.InterlacedTopFieldFirst : (codecCtx->field_order == AVFieldOrder.Bb ? VideoFrameFormat.InterlacedBottomFieldFirst : VideoFrameFormat.Progressive);
 
         if (ColorTransfer == AVColorTransferCharacteristic.Unspecified) // TBR: AVStream has AribStdB67 and Frame/CodecCtx has Bt2020_10 (priority to stream?)*
         {
@@ -217,7 +219,7 @@ public unsafe class VideoStream : StreamBase
         }
 
         // FPS2 / FrameDuration2 (DeInterlace)
-        if (FieldOrder != DeInterlace.Progressive)
+        if (FieldOrder != VideoFrameFormat.Progressive)
         {
             FPS2 = FPS;
             FrameDuration2 = FrameDuration;

--- a/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
@@ -12,13 +12,13 @@ public unsafe class VideoStream : StreamBase
      * Chroma Location (when we add support in renderer)
      */
 
-    public AspectRatio                  AspectRatio         { get; set; }
     public AVRational                   SAR                 { get; set; }
     public ColorRange                   ColorRange          { get; set; }
     public ColorSpace                   ColorSpace          { get; set; }
     public ColorType                    ColorType           { get; set; }
     public AVColorTransferCharacteristic
                                         ColorTransfer       { get; set; }
+    public Cropping                     Cropping            { get; set; }
     public VideoFrameFormat             FieldOrder          { get; set; }
     public double                       Rotation            { get; set; }
     public double                       FPS                 { get; set; }
@@ -39,6 +39,9 @@ public unsafe class VideoStream : StreamBase
     public uint                         Width               { get; set; }
     public bool                         FixTimestamps       { get; set; }
 
+    internal CropRect cropStreamRect, cropFrameRect, cropRect; // Stream Crop + Codec Padding + Texture Padding
+    bool hasStreamCrop;
+
     public VideoStream(Demuxer demuxer, AVStream* st) : base(demuxer, st)
         => Type = MediaType.Video;
 
@@ -58,15 +61,9 @@ public unsafe class VideoStream : StreamBase
         if (PixelFormat != AVPixelFormat.None)
             AnalysePixelFormat();
 
-        Width           = (uint)cp->width;
-        Height          = (uint)cp->height;
-        SAR             = av_guess_sample_aspect_ratio(null, AVStream, null);
-        if (SAR.Num != 0)
-        {
-            int x, y;
-            _ = av_reduce(&x, &y, Width * SAR.Num, Height * SAR.Den, 1024 * 1024);
-            AspectRatio = new(x, y);
-        }
+        Width   = (uint)cp->width;
+        Height  = (uint)cp->height;
+        SAR     = av_guess_sample_aspect_ratio(null, AVStream, null);
 
         if (Demuxer.FormatContext->iformat->flags.HasFlag(FmtFlags.Notimestamps))
             FixTimestamps = true;
@@ -101,16 +98,33 @@ public unsafe class VideoStream : StreamBase
         else if (cp->color_space == AVColorSpace.Bt2020Ncl || cp->color_space == AVColorSpace.Bt2020Cl)
             ColorSpace = ColorSpace.Bt2020;
 
-        AVPacketSideData* pktSideData;
-        if ((pktSideData = av_packet_side_data_get(cp->coded_side_data, cp->nb_coded_side_data, AVPacketSideDataType.Displaymatrix)) != null && pktSideData->data != null)
+        if (cp->nb_coded_side_data == 0)
+            return;
+
+        var rotData = av_packet_side_data_get(cp->coded_side_data, cp->nb_coded_side_data, AVPacketSideDataType.Displaymatrix);
+        if (rotData != null && rotData->data != null)
         {
-            double rotation = -Math.Round(av_display_rotation_get((int*)pktSideData->data));
-            Rotation = rotation - (360*Math.Floor(rotation/360 + 0.9/360));
+            double rotation = -Math.Round(av_display_rotation_get((int*)rotData->data));
+            Rotation = rotation - (360 * Math.Floor(rotation / 360 + 0.9 / 360));
+        }
+
+        var cropData= av_packet_side_data_get(cp->coded_side_data, cp->nb_coded_side_data, AVPacketSideDataType.FrameCropping);
+        if (cropData != null && cropData->size == 16)
+        {
+            var cropByes = new ReadOnlySpan<byte>(cropData->data, 16).ToArray();
+            cropStreamRect = new(
+                top:    BitConverter.ToUInt32(cropByes, 0),
+                bottom: BitConverter.ToUInt32(cropByes, 4),
+                left:   BitConverter.ToUInt32(cropByes, 8),
+                right:  BitConverter.ToUInt32(cropByes, 12)
+                );
+
+            hasStreamCrop = cropStreamRect != CropRect.Empty;
         }
     }
 
     // >= Second time fill from Decoder / Frame | TBR: We could avoid re-filling it when re-enabling a stream ... when same PixelFormat (VideoAcceleration)
-    public void Refresh(VideoDecoder decoder, AVFrame* frame)
+    public void Refresh(VideoDecoder decoder, AVFrame* frame) // TBR: Can be filled multiple times from different Codecs
     {
         var codecCtx= decoder.CodecCtx;
         var format  = decoder.VideoAccelerated && codecCtx->sw_pix_fmt != AVPixelFormat.None ? codecCtx->sw_pix_fmt : codecCtx->pix_fmt;
@@ -131,22 +145,70 @@ public unsafe class VideoStream : StreamBase
         if (codecCtx->bit_rate > 0)
             BitRate = codecCtx->bit_rate; // for logging only
 
-        if (SAR.Num == 0 || decoder.codecChanged)
+        if (SAR.Num == 0)
         {
-            Width   = (uint)frame->width;
-            Height  = (uint)frame->height;
-
             if (frame->sample_aspect_ratio.Num != 0)
                 SAR = frame->sample_aspect_ratio;
             else if (codecCtx->sample_aspect_ratio.Num != 0)
                 SAR = codecCtx->sample_aspect_ratio;
             else if (SAR.Num == 0)
                 SAR = new(1, 1);
-
-            int x, y;
-            _ = av_reduce(&x, &y, Width * SAR.Num, Height * SAR.Den, 1024 * 1024);
-            AspectRatio = new(x, y);
         }
+
+        cropRect = CropRect.Empty;
+
+        // Stream's Crop
+        if (hasStreamCrop)
+        {
+            Cropping =  Cropping.Stream;
+
+            cropRect.Top    += cropStreamRect.Top;
+            cropRect.Bottom += cropStreamRect.Bottom;
+            cropRect.Left   += cropStreamRect.Left;
+            cropRect.Right  += cropStreamRect.Right;
+
+        }
+        else
+            Cropping = Cropping.None;
+
+        // Codec's Crop (Frame)
+        cropFrameRect = new(
+            top:    (uint)frame->crop_top,
+            bottom: (uint)frame->crop_bottom,
+            left:   (uint)frame->crop_left,
+            right:  (uint)frame->crop_right
+            );
+
+        if (cropFrameRect != CropRect.Empty)
+        {
+            Cropping |= Cropping.Codec;
+
+            cropRect.Top    += cropFrameRect.Top;
+            cropRect.Bottom += cropFrameRect.Bottom;
+            cropRect.Left   += cropFrameRect.Left;
+            cropRect.Right  += cropFrameRect.Right;
+        }
+
+        // HW Texture's Crop
+        if (decoder.VideoAccelerated)
+        {
+            var desc = decoder.textureFFmpeg.Description;
+
+            if (desc.Width > codecCtx->coded_width)
+            {
+                cropRect.Right += (uint)(desc.Width - codecCtx->coded_width);
+                Cropping |= Cropping.Texture;
+            }
+
+            if (desc.Height > codecCtx->coded_height)
+            {
+                cropRect.Bottom += (uint)(desc.Height - codecCtx->coded_height);
+                Cropping |= Cropping.Texture;
+            }
+        }
+
+        Width   = (uint)(frame->width  - (cropRect.Left + cropRect.Right));
+        Height  = (uint)(frame->height - (cropRect.Top  + cropRect.Bottom));
 
         if (frame->flags.HasFlag(FrameFlags.Interlaced))
             FieldOrder = frame->flags.HasFlag(FrameFlags.TopFieldFirst) ? VideoFrameFormat.InterlacedTopFieldFirst : VideoFrameFormat.InterlacedBottomFieldFirst;
@@ -174,7 +236,7 @@ public unsafe class VideoStream : StreamBase
             else if (ColorRange == ColorRange.None)
                 ColorRange = ColorType == ColorType.YUV && !PixelFormatStr.Contains('j') ? ColorRange.Limited : ColorRange.Full; // yuvj family defaults to full
         }
-        
+
         if (ColorTransfer == AVColorTransferCharacteristic.AribStdB67)
             HDRFormat = HDRFormat.HLG;
         else if (ColorTransfer == AVColorTransferCharacteristic.Smpte2084)
@@ -207,7 +269,7 @@ public unsafe class VideoStream : StreamBase
             else if (ColorSpace == ColorSpace.None)
                 ColorSpace = Height > 576 ? ColorSpace.Bt709 : ColorSpace.Bt601;
         }
-        
+
         // We consider that FPS can't change (only if it was missing we fill it)
         if (FPS == 0.0)
         {
@@ -232,10 +294,10 @@ public unsafe class VideoStream : StreamBase
             FrameDuration2 = FrameDuration / 2;
         }
 
-        AVFrameSideData* frameSideData;
-        if ((frameSideData = av_frame_get_side_data(frame, AVFrameSideDataType.Displaymatrix)) != null && frameSideData->data != null)
+        var rotData = av_frame_get_side_data(frame, AVFrameSideDataType.Displaymatrix);
+        if (rotData != null && rotData->data != null)
         {
-            var rotation = -Math.Round(av_display_rotation_get((int*)frameSideData->data));
+            var rotation = -Math.Round(av_display_rotation_get((int*)rotData->data));
             Rotation = rotation - (360*Math.Floor(rotation/360 + 0.9/360));
         }
 
@@ -261,5 +323,12 @@ public unsafe class VideoStream : StreamBase
 
             PixelPlanes++;
         }
+    }
+
+    public AspectRatio GetDAR()
+    {
+        int x, y;
+        _ = av_reduce(&x, &y, Width * SAR.Num, Height * SAR.Den, 1024 * 1024);
+        return new(x, y);
     }
 }

--- a/FlyleafLib/MediaPlayer/Audio.cs
+++ b/FlyleafLib/MediaPlayer/Audio.cs
@@ -20,6 +20,9 @@ public class Audio : NotifyPropertyChanged
     public ObservableCollection<AudioStream>
                     Streams         => decoder?.VideoDemuxer.AudioStreams; // TBR: We miss AudioDemuxer embedded streams
 
+    public int      StreamIndex     { get => streamIndex;       internal set => Set(ref _StreamIndex, value); }
+    int _StreamIndex, streamIndex = -1;
+
     /// <summary>
     /// Whether the input has audio and it is configured
     /// </summary>
@@ -168,6 +171,7 @@ public class Audio : NotifyPropertyChanged
 
         uiAction = () =>
         {
+            StreamIndex     = streamIndex;
             IsOpened        = IsOpened;
             Codec           = Codec;
             BitRate         = BitRate;
@@ -294,6 +298,7 @@ public class Audio : NotifyPropertyChanged
 
     internal void Reset()
     {
+        streamIndex     = -1;
         codec           = null;
         bitRate         = 0;
         bits            = 0;
@@ -309,6 +314,7 @@ public class Audio : NotifyPropertyChanged
     {
         if (decoder.AudioStream == null) { Reset(); return; }
 
+        streamIndex     = decoder.AudioStream.StreamIndex;
         codec           = decoder.AudioStream.Codec;
         bits            = decoder.AudioStream.Bits;
         channels        = decoder.AudioStream.Channels;

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -99,7 +99,8 @@ partial class Player
                     sFrames[i] = null;
                 }
 
-                renderer.CurFieldType = renderer.FieldType;
+                if (renderer.FieldType != Vortice.Direct3D11.VideoFrameFormat.Progressive)
+                    renderer.SetFieldType(renderer.FieldType);
 
                 if (Status == Status.Stopped)
                     decoder?.Initialize();

--- a/FlyleafLib/MediaPlayer/Subtitles.cs
+++ b/FlyleafLib/MediaPlayer/Subtitles.cs
@@ -470,6 +470,9 @@ public class Subtitle : NotifyPropertyChanged
     public bool EnabledASR { get => _enabledASR; private set => Set(ref field, value); }
     private bool _enabledASR;
 
+    public int StreamIndex { get => _streamIndex; private set => Set(ref field, value); }
+    private int _streamIndex = -1;
+
     /// <summary>
     /// Whether the input has subtitles and it is configured
     /// </summary>
@@ -491,6 +494,7 @@ public class Subtitle : NotifyPropertyChanged
     {
         UI(() =>
         {
+            StreamIndex = StreamIndex;
             IsOpened = IsOpened;
             Codec = Codec;
             IsBitmap = IsBitmap;
@@ -500,6 +504,7 @@ public class Subtitle : NotifyPropertyChanged
 
     internal void Reset()
     {
+        _streamIndex = -1;
         _codec = null;
         _isOpened = false;
         _isBitmap = false;
@@ -531,6 +536,7 @@ public class Subtitle : NotifyPropertyChanged
             return;
         }
 
+        _streamIndex = subStream.StreamIndex;
         _codec = subStream.Codec;
         _isOpened = !Decoder.SubtitlesDecoders[_subIndex].Disposed;
         _isBitmap = subStream is { IsBitmap: true };

--- a/FlyleafLib/MediaPlayer/Video.cs
+++ b/FlyleafLib/MediaPlayer/Video.cs
@@ -11,6 +11,9 @@ public class Video : NotifyPropertyChanged
     public ObservableCollection<VideoStream>
                         Streams         => decoder?.VideoDemuxer.VideoStreams;
 
+    public int      StreamIndex     { get => streamIndex;       internal set => Set(ref _StreamIndex, value); }
+    int _StreamIndex, streamIndex = -1;
+
     /// <summary>
     /// Whether the input has video and it is configured
     /// </summary>
@@ -67,9 +70,6 @@ public class Video : NotifyPropertyChanged
                                         { get => videoAcceleration; internal set => Set(ref _VideoAcceleration, value); }
     internal bool   _VideoAcceleration, videoAcceleration;
 
-    public bool         ZeroCopy        { get => zeroCopy;          internal set => Set(ref _ZeroCopy, value); }
-    internal bool   _ZeroCopy, zeroCopy;
-
     public HDRFormat    HDRFormat       { get => hdrFormat;         internal set => Set(ref _HDRFormat, value); }
     internal HDRFormat _HDRFormat, hdrFormat;
 
@@ -89,6 +89,7 @@ public class Video : NotifyPropertyChanged
 
         uiAction = () =>
         {
+            StreamIndex         = streamIndex;
             IsOpened            = IsOpened;
             Codec               = Codec;
             AspectRatio         = AspectRatio;
@@ -98,7 +99,6 @@ public class Video : NotifyPropertyChanged
             Width               = Width;
             Height              = Height;
             VideoAcceleration   = VideoAcceleration;
-            ZeroCopy            = ZeroCopy;
             HDRFormat           = HDRFormat;
             ColorFormat         = ColorFormat;
 
@@ -109,18 +109,18 @@ public class Video : NotifyPropertyChanged
 
     internal void Reset()
     {
-        codec              = null;
-        aspectRatio        = new AspectRatio(0, 0);
-        bitRate            = 0;
-        fps                = 0;
-        pixelFormat        = null;
-        width              = 0;
-        height             = 0;
-        framesTotal        = 0;
-        videoAcceleration  = false;
-        zeroCopy           = false;
-        isOpened           = false;
-        hdrFormat          = HDRFormat.None;
+        streamIndex         = -1;
+        codec               = null;
+        aspectRatio         = new AspectRatio(0, 0);
+        bitRate             = 0;
+        fps                 = 0;
+        pixelFormat         = null;
+        width               = 0;
+        height              = 0;
+        framesTotal         = 0;
+        videoAcceleration   = false;
+        isOpened            = false;
+        hdrFormat           = HDRFormat.None;
         colorFormat         = "";
 
         player.UIAdd(uiAction);
@@ -129,8 +129,9 @@ public class Video : NotifyPropertyChanged
     {
         if (decoder.VideoStream == null) { Reset(); return; }
 
+        streamIndex = decoder.VideoStream.StreamIndex;
         codec       = decoder.VideoStream.Codec;
-        aspectRatio = decoder.VideoStream.AspectRatio;
+        aspectRatio = decoder.VideoStream.GetDAR();
         fps         = decoder.VideoStream.FPS;
         pixelFormat = decoder.VideoStream.PixelFormatStr;
         width       = (int)decoder.VideoStream.Width;
@@ -138,7 +139,6 @@ public class Video : NotifyPropertyChanged
         framesTotal = decoder.VideoStream.TotalFrames;
         videoAcceleration
                     = decoder.VideoDecoder.VideoAccelerated;
-        zeroCopy    = decoder.VideoDecoder.ZeroCopy;
         hdrFormat   = decoder.VideoStream.HDRFormat;
         colorFormat = $"{decoder.VideoStream.ColorSpace}\r\n{decoder.VideoStream.ColorTransfer}\r\n{decoder.VideoStream.ColorRange}";
         isOpened    =!decoder.VideoDecoder.Disposed;

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -688,7 +688,7 @@ public static partial class Utils
     private static partial Regex RxNonAlphaNumeric();
 
     #region Temp Transfer (v4)
-#nullable enable
+    #nullable enable
     static string metaSpaces = new(' ',"[Metadata] ".Length);
     public static string GetDumpMetadata(Dictionary<string, string>? metadata, string? exclude = null)
     {
@@ -793,7 +793,7 @@ public static partial class Utils
         av_free(t1);
         return ret;
     }
-#nullable restore
+    #nullable disable
     #endregion
 
     public static string TruncateString(string str, int maxLength, string suffix = "...")

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -21,12 +21,6 @@
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
 
-        <ObjectDataProvider x:Key="ZeroCopyEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="flyleaf:ZeroCopy"/>
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-
         <ObjectDataProvider x:Key="DeInterlaceEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
             <ObjectDataProvider.MethodParameters>
                 <x:Type TypeName="flyleaf:DeInterlace"/>
@@ -122,16 +116,6 @@
                             Width="100"
                             ItemsSource="{Binding Source={StaticResource VideoProcessorEnum}}"
                             SelectedItem="{Binding FL.PlayerConfig.Video.VideoProcessor}" />
-                    </StackPanel>
-
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Width="180"
-                            Text="Zero Copy" />
-                        <ComboBox
-                            Width="100"
-                            ItemsSource="{Binding Source={StaticResource ZeroCopyEnum}}"
-                            SelectedItem="{Binding FL.PlayerConfig.Decoder.ZeroCopy}" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
Update FlyleafLib v3.8.10 from v3.8.9

## Changelog
- Demuxer: Fixes an issue with HLS Live Seek (caused by 3.8.9)
- Player: Adds StreamIndex property in Audio/Video/Subtitles [Fixes #617]
- Renderer: Adds Cropping Support (Always ZeroCopy)
- Renderer: Adds User Cropping Support (Config.Video.Crop)

[Breaking Changes]
- Config.Decoder.ZeroCopy removed
- Player.Video.ZeroCopy removed

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/d7d2606d6188ae4fe18a7f4814c6080429ef87b4...954268219302a9b44ce33698e128e3d89c5d4e33