### PR TITLE
Update FlyleafLib v3.8.11

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -132,8 +132,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     static int  idGenerator = 1;
     static nint NONE_STYLE = (nint) (WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE); // WS_MINIMIZEBOX required for swapchain
 
-    float   curResizeRatio;
-    float   curResizeRatioIfEnabled;
+    double  curResizeRatio;
+    double  curResizeRatioIfEnabled;
     bool    surfaceClosed, surfaceClosing, overlayClosed;
     int     panPrevX, panPrevY;
     bool    isMouseBindingsSubscribedSurface;
@@ -599,17 +599,21 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     }
     private void UpdateCurRatio()
     {
+        /* TODO (Keep ratio on resize)
+         * 1) Should 'monitor' renderer's curRatio (includes rotation logic and user cropping)
+         * 2) Should resize based on Viewport's logic (rounding/ceiling) to avoid 1 pixel more or less for width/height
+         * 3) Consider default ratio (16:9) as config?
+         */
+
         if (!KeepRatioOnResize || IsFullScreen)
             return;
 
-        if (Player != null && Player.Video.AspectRatio.Value > 0)
-            curResizeRatio = Player.Video.AspectRatio.Value;
-        else if (ReplicaPlayer != null && ReplicaPlayer.Video.AspectRatio.Value > 0)
-            curResizeRatio = ReplicaPlayer.Video.AspectRatio.Value;
-        else
-            curResizeRatio = (float)(16.0/9.0);
+        var player = Player ?? ReplicaPlayer;
 
-        curResizeRatioIfEnabled = curResizeRatio;
+        if (player != null && player.renderer != null && player.renderer.DAR.Value > 0)
+            curResizeRatioIfEnabled = curResizeRatio = player.renderer.DAR.Value;
+        else
+            curResizeRatioIfEnabled = curResizeRatio = 16.0 / 9.0;
 
         Rect screen;
 
@@ -1112,7 +1116,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     }
     private void Player_Video_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (KeepRatioOnResize && e.PropertyName == nameof(Player.Video.AspectRatio) && Player.Video.AspectRatio.Value > 0)
+        if (KeepRatioOnResize && e.PropertyName == nameof(Player.Video.AspectRatio))
             UpdateCurRatio();
     }
     private void ReplicaPlayer_Video_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/FlyleafLib/Engine/Engine.Audio.cs
+++ b/FlyleafLib/Engine/Engine.Audio.cs
@@ -59,17 +59,14 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
 
     public void RefreshCapDevices()
     {
-        UI(() =>
+        lock (lockCapDevices)
         {
-            lock (lockCapDevices)
-            {
-                Engine.Audio.CapDevices.Clear();
+            Engine.Audio.CapDevices.Clear();
 
-                var devices = MediaFactory.MFEnumAudioDeviceSources();
-                    foreach (var device in devices)
-                        try { Engine.Audio.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
-            }
-        });
+            var devices = MediaFactory.MFEnumAudioDeviceSources();
+                foreach (var device in devices)
+                    try { Engine.Audio.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
+        }
     }
 
     private void EnumerateDevices()

--- a/FlyleafLib/Engine/Engine.Audio.cs
+++ b/FlyleafLib/Engine/Engine.Audio.cs
@@ -44,7 +44,7 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
 
     public event PropertyChangedEventHandler PropertyChanged;
 
-    public AudioEngine()
+    public AudioEngine() // We consider from UI here
     {
         if (Engine.Config.DisableAudio)
         {
@@ -59,14 +59,17 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
 
     public void RefreshCapDevices()
     {
-        lock (lockCapDevices)
+        UI(() =>
         {
-            Engine.Audio.CapDevices.Clear();
+            lock (lockCapDevices)
+            {
+                Engine.Audio.CapDevices.Clear();
 
-            var devices = MediaFactory.MFEnumAudioDeviceSources();
-                foreach (var device in devices)
-                    try { Engine.Audio.CapDevices.Add(new AudioDevice(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
-        }
+                var devices = MediaFactory.MFEnumAudioDeviceSources();
+                    foreach (var device in devices)
+                        try { Engine.Audio.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
+            }
+        });
     }
 
     private void EnumerateDevices()
@@ -166,7 +169,7 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
                 {
                     CurrentDevice.Id    = defaultDevice.Id;
                     CurrentDevice.Name  = defaultDevice.FriendlyName;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentDevice)));
+                    PropertyChanged?.Invoke(this, new(nameof(CurrentDevice)));
                 }
 
                 // Fall back to DefaultDevice *Non-UI thread otherwise will freeze (not sure where and why) during xaudio.Dispose()

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -42,17 +42,14 @@ public class VideoEngine
 
     public void RefreshCapDevices()
     {
-        UI(() =>
+        lock (lockCapDevices)
         {
-            lock (lockCapDevices)
-            {
-                Engine.Video.CapDevices.Clear();
+            Engine.Video.CapDevices.Clear();
 
-                var devices = MediaFactory.MFEnumVideoDeviceSources();
-                    foreach (var device in devices)
-                    try { Engine.Video.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
-            }
-        });
+            var devices = MediaFactory.MFEnumVideoDeviceSources();
+                foreach (var device in devices)
+                try { Engine.Video.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
+        }
     }
 
     private Dictionary<long, GPUAdapter> GetAdapters()

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -31,7 +31,7 @@ public class VideoEngine
 
     private readonly object lockCapDevices = new();
 
-    internal VideoEngine()
+    internal VideoEngine() // We consider from UI here
     {
         if (DXGI.CreateDXGIFactory1(out Factory).Failure)
             throw new InvalidOperationException("Cannot create IDXGIFactory1");
@@ -42,14 +42,17 @@ public class VideoEngine
 
     public void RefreshCapDevices()
     {
-        lock (lockCapDevices)
+        UI(() =>
         {
-            Engine.Video.CapDevices.Clear();
+            lock (lockCapDevices)
+            {
+                Engine.Video.CapDevices.Clear();
 
-            var devices = MediaFactory.MFEnumVideoDeviceSources();
-                foreach (var device in devices)
-                try { Engine.Video.CapDevices.Add(new VideoDevice(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
-        }
+                var devices = MediaFactory.MFEnumVideoDeviceSources();
+                    foreach (var device in devices)
+                    try { Engine.Video.CapDevices.Add(new(device.FriendlyName, device.SymbolicLink)); } catch(Exception) { }
+            }
+        });
     }
 
     private Dictionary<long, GPUAdapter> GetAdapters()

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -103,25 +103,28 @@ public static class Engine
 
     private static void StartInternal(EngineConfig config = null, bool async = false)
     {
-        lock (lockEngine)
+        if (Application.Current == null)
+            _ = new Application();
+
+        UIInvokeIfRequired(() =>
         {
-            if (isLoading)
-                return;
+            lock (lockEngine)
+            {
+                if (isLoading)
+                    return;
 
-            isLoading = true;
+                isLoading = true;
 
-            Config = config ?? new EngineConfig();
+                Config = config ?? new EngineConfig();
 
-            if (Application.Current == null)
-                _ = new Application();
+                StartInternalUI();
 
-            StartInternalUI();
-
-            if (async)
-                Task.Run(() => StartInternalNonUI());
-            else
-                StartInternalNonUI();
-        }
+                if (async)
+                    Task.Run(() => StartInternalNonUI());
+                else
+                    StartInternalNonUI();
+            }
+        });
     }
 
     private static void StartInternalUI()

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -42,7 +42,7 @@ public static class Engine
     /// <summary>
     /// List of active Players
     /// </summary>
-    public static List<Player>      Players         { get; private set; }
+    public static List<Player>      Players         { get; private set; } = [];
 
     public static event EventHandler
                     Loaded;
@@ -138,6 +138,7 @@ public static class Engine
         SetOutput();
         Log     = new("[FlyleafEngine] ");
         Audio   = new();
+        Video   = new();
     }
 
     private static void StartInternalNonUI()
@@ -146,13 +147,10 @@ public static class Engine
         Log.Info($"FlyleafLib {version.Major }.{version.Minor}.{version.Build}");
 
         FFmpeg  = new();
-        Video   = new();
         Plugins = new();
-        Players = [];
-
         IsLoaded= true;
 
-        if (Config.FFmpegLoadProfile == LoadProfile.All) // Cap Devices (TBR: if UI required)
+        if (Config.FFmpegLoadProfile == LoadProfile.All)
         {
             Audio.RefreshCapDevices();
             Video.RefreshCapDevices();

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -196,10 +196,10 @@ public struct AspectRatio : IEquatable<AspectRatio>
 
     public static implicit operator AspectRatio(string value) => new(value);
 
-    public float Num { get; set; }
-    public float Den { get; set; }
+    public double Num { get; set; }
+    public double Den { get; set; }
 
-    public float Value
+    public double Value
     {
         readonly get => Num / Den;
         set { Num = value; Den = 1; }
@@ -211,8 +211,8 @@ public struct AspectRatio : IEquatable<AspectRatio>
         set => FromString(value);
     }
 
-    public AspectRatio(float value) : this(value, 1) { }
-    public AspectRatio(float num, float den) { Num = num; Den = den; }
+    public AspectRatio(double value) : this(value, 1) { }
+    public AspectRatio(double num, double den) { Num = num; Den = den; }
     public AspectRatio(string value) { Num = Invalid.Num; Den = Invalid.Den; FromString(value); }
 
     public readonly bool Equals(AspectRatio other) => Num == other.Num && Den == other.Den;
@@ -240,11 +240,11 @@ public struct AspectRatio : IEquatable<AspectRatio>
             if (values.Length < 2)
                         values = newvalue.ToString().Split('/');
 
-            Num = float.Parse(values[0], NumberStyles.Any, CultureInfo.InvariantCulture);
-            Den = float.Parse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture);
+            Num = double.Parse(values[0], NumberStyles.Any, CultureInfo.InvariantCulture);
+            Den = double.Parse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture);
         }
 
-        else if (float.TryParse(newvalue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out float result))
+        else if (double.TryParse(newvalue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
             { Num = result; Den = 1; }
 
         else

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.10</Version>
+    <Version>3.8.11</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -146,7 +146,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
                         stream.Demuxer.EnableStream(stream);
 
                     Status = Status.Stopped;
-                    CodecChanged?.Invoke(this);
+                    //CodecChanged?.Invoke(this); // We call this when we successfully decode one frame
                 }
 
                 return null;

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -614,15 +614,16 @@ public unsafe class VideoDecoder : DecoderBase
             codecChanged    = false;
             startPts        = VideoStream.StartTimePts;
             skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
-            CodecChanged?.Invoke(this);
-
+            
             DisposeFrame(Renderer.LastFrame);
             if (VideoStream.PixelFormat == AVPixelFormat.None || !Renderer.ConfigPlanes(frame))
             {
                 Log.Error("[Pixel Format] Unknown");
+                CodecChanged?.Invoke(this);
                 return -1234;
             }
 
+            CodecChanged?.Invoke(this);
             return ret;
         }
     }

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -622,7 +622,8 @@ public unsafe class Demuxer : RunThreadBase
             if (fmtCtx->pb != null)
                 fmtCtx->pb->eof_reached = 0;
 
-            FillInfo();
+            lock (lockStreams)
+                FillInfo();
 
             if (Type == MediaType.Video && VideoStreams.Count == 0 && AudioStreams.Count == 0)
                 return error = $"No audio / video stream found";
@@ -779,66 +780,63 @@ public unsafe class Demuxer : RunThreadBase
         bool subsHasEng = false;
         AVStreamToStream= [];
 
-        lock (lockStreams)
+        for (int i = 0; i < fmtCtx->nb_streams; i++)
         {
-            for (int i = 0; i < fmtCtx->nb_streams; i++)
+            var stream = fmtCtx->streams[i];
+            stream->discard = AVDiscard.All;
+            if (stream->codecpar->codec_id == AVCodecID.None)
             {
-                var stream = fmtCtx->streams[i];
-                stream->discard = AVDiscard.All;
-                if (stream->codecpar->codec_id == AVCodecID.None)
-                {
-                    AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
-                    Log.Info($"#[Invalid #{i}] No codec");
-                    continue;
-                }
+                AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
+                Log.Info($"#[Invalid #{i}] No codec");
+                continue;
+            }
 
-                switch (stream->codecpar->codec_type)
-                {
-                    case AVMediaType.Audio:
-                        AudioStreams.Add(new(this, stream));
-                        AVStreamToStream.Add(stream->index, AudioStreams[^1]);
-                        audioHasEng = AudioStreams[^1].Language == Language.English;
+            switch (stream->codecpar->codec_type)
+            {
+                case AVMediaType.Audio:
+                    AudioStreams.Add(new(this, stream));
+                    AVStreamToStream.Add(stream->index, AudioStreams[^1]);
+                    audioHasEng = AudioStreams[^1].Language == Language.English;
 
-                        break;
+                    break;
 
-                    case AVMediaType.Video:
-                        if ((stream->disposition & DispositionFlags.AttachedPic) != 0)
-                        {
-                            AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
-                            Log.Info($"Excluding image stream #{i}");
-                        }
-
-                        // TBR: When AllowFindStreamInfo = false we can get valid pixel format during decoding (in case of remuxing only this might crash, possible check if usedecoders?)
-                        else if (((AVPixelFormat)stream->codecpar->format) == AVPixelFormat.None && Config.AllowFindStreamInfo)
-                        {
-                            AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
-                            Log.Info($"Excluding invalid video stream #{i}");
-                        }
-                        else
-                        {
-                            VideoStreams.Add(new(this, stream));
-                            AVStreamToStream.Add(stream->index, VideoStreams[^1]);
-                        }
-
-                        break;
-
-                    case AVMediaType.Subtitle:
-                        SubtitlesStreamsAll.Add(new(this, fmtCtx->streams[i]));
-                        AVStreamToStream.Add(stream->index, SubtitlesStreamsAll[^1]);
-                        subsHasEng = SubtitlesStreamsAll[^1].Language == Language.English;
-                        break;
-
-                    case AVMediaType.Data:
-                        DataStreams.Add(new(this, stream));
-                        AVStreamToStream.Add(stream->index, DataStreams[^1]);
-
-                        break;
-
-                    default:
+                case AVMediaType.Video:
+                    if ((stream->disposition & DispositionFlags.AttachedPic) != 0)
+                    {
                         AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
-                        Log.Info($"#[Unknown #{i}] {stream->codecpar->codec_type}");
-                        break;
-                }
+                        Log.Info($"Excluding image stream #{i}");
+                    }
+
+                    // TBR: When AllowFindStreamInfo = false we can get valid pixel format during decoding (in case of remuxing only this might crash, possible check if usedecoders?)
+                    else if (((AVPixelFormat)stream->codecpar->format) == AVPixelFormat.None && Config.AllowFindStreamInfo)
+                    {
+                        AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
+                        Log.Info($"Excluding invalid video stream #{i}");
+                    }
+                    else
+                    {
+                        VideoStreams.Add(new(this, stream));
+                        AVStreamToStream.Add(stream->index, VideoStreams[^1]);
+                    }
+
+                    break;
+
+                case AVMediaType.Subtitle:
+                    SubtitlesStreamsAll.Add(new(this, fmtCtx->streams[i]));
+                    AVStreamToStream.Add(stream->index, SubtitlesStreamsAll[^1]);
+                    subsHasEng = SubtitlesStreamsAll[^1].Language == Language.English;
+                    break;
+
+                case AVMediaType.Data:
+                    DataStreams.Add(new(this, stream));
+                    AVStreamToStream.Add(stream->index, DataStreams[^1]);
+
+                    break;
+
+                default:
+                    AVStreamToStream.Add(stream->index, new MiscStream(this, stream));
+                    Log.Info($"#[Unknown #{i}] {stream->codecpar->codec_type}");
+                    break;
             }
         }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -400,7 +400,8 @@ public unsafe partial class Renderer
             ReportLiveObjects();
             #endif
 
-            curRatio = 1.0f;
+            DAR         = new(0, 1);
+            curRatio    = 1.0f;
             if (CanInfo) Log.Info("Disposed");
         }
     }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -463,7 +463,11 @@ unsafe public partial class Renderer
 
             VisibleWidth    = textWidth  - (cropRect.Left + cropRect.Right);
             VisibleHeight   = textHeight - (cropRect.Top  + cropRect.Bottom);
-            keepRatio       = (double)(VisibleWidth * VideoStream.SAR.Num) / (VisibleHeight * VideoStream.SAR.Den);
+
+            int x, y;
+            _ = av_reduce(&x, &y, VisibleWidth * VideoStream.SAR.Num, VisibleHeight * VideoStream.SAR.Den, 1024 * 1024);
+            DAR = new(x, y);
+            keepRatio = DAR.Value;
 
             if (Config.Video.AspectRatio == AspectRatio.Keep)
                 curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;


### PR DESCRIPTION
Update FlyleafLib v3.8.11 from v3.8.10

## Changelog
- Engine: Fixes possible issues with ObservableCollections and EnableCollectionSynchronization
- FlyleafHost.Wpf: Fixes an issue with KeepRatioOnResize (after crop DAR)
- VideoDecoder: Adds D3D11/AV1 FFmpeg bug workaround

[Breaking Changes]
- Globals.AspectRatio: Changes floats to doubles

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/954268219302a9b44ce33698e128e3d89c5d4e33...c7873a25bbcd41ad92cef2510c612d67b8547875