### PR TITLE
Update FlyleafLib v3.8.12

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -2285,8 +2285,16 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             if (CornerRadius != zeroCornerRadius)
                 ((Border)Surface.Content).CornerRadius = zeroCornerRadius;
 
-            Surface.WindowState = WindowState.Maximized;
+            if (Overlay != null)
+            {
+                Overlay.Hide();
+                Surface.WindowState = WindowState.Maximized;
+                Overlay.Show();
+            }
+            else
+                Surface.WindowState = WindowState.Maximized;
 
+            Player?.Activity.RefreshFullActive();
             // If it was above the borders and double click (mouse didn't move to refresh)
             Surface.Cursor = Cursors.Arrow;
             if (Overlay != null)

--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -1900,6 +1900,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (ReplicaPlayer != null)
             ReplicaPlayer.renderer.SetChildHandle(SurfaceHandle);
 
+        Surface.IsVisibleChanged
+                            += Surface_IsVisibleChanged;
         Surface.Closed      += Surface_Closed;
         Surface.Closing     += Surface_Closing;
         Surface.KeyDown     += Surface_KeyDown;
@@ -1920,6 +1922,23 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             Host_Loaded(null, null);
 
         SurfaceCreated?.Invoke(this, new());
+    }
+
+    private void Surface_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (!Surface.IsVisible || Overlay == null)
+            return;
+
+        /* Out of monitor's bound issue
+         * When hiding the surface and showing it back, windows will consider it's position/size invalid and will try to fix it without sending any position/size changed events
+         * C# ActualWidth/ActualHeight will not be updated and the overlay will not fit properly to the surface
+         * 
+         * TBR: Consider when showing the window to prevent windows changing its position/size (requires win32 API and it seems that causes more issues)?
+         */
+        RECT surf = new();
+        GetWindowRect(SurfaceHandle, ref surf);
+        SetWindowPos(OverlayHandle, IntPtr.Zero, 0, 0, (int)Math.Round((surf.Right - surf.Left) * DpiX), (int)Math.Round((surf.Bottom - surf.Top) * DpiY),
+            (uint)(SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE));
     }
 
     private void Surface_DpiChanged(object sender, DpiChangedEventArgs e)
@@ -2310,7 +2329,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     {
         if (Overlay != null)
             SetWindowPos(OverlayHandle, IntPtr.Zero, 0, 0, (int)Math.Round(Surface.ActualWidth * DpiX), (int)Math.Round(Surface.ActualHeight * DpiY),
-                (uint)(SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOACTIVATE));
+                (uint)(SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE));
     }
 
     public void ResetVisibleRect()
@@ -2364,6 +2383,8 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
                 if (isMouseBindingsSubscribedSurface)
                     SetMouseSurface();
 
+                Surface.IsVisibleChanged
+                                    -= Surface_IsVisibleChanged;
                 Surface.Closed      -= Surface_Closed;
                 Surface.Closing     -= Surface_Closing;
                 Surface.KeyDown     -= Surface_KeyDown;

--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -1559,6 +1559,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         surfaceClosed = true;
         Dispose();
     }
+    public void CloseCanceled() => surfaceClosing = false; // TBR: Better way of handling Closing/Canceled
     private void Surface_Closing(object sender, CancelEventArgs e) => surfaceClosing = true;
     private void Overlay_Closed(object sender, EventArgs e)
     {

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -750,10 +750,10 @@ public class Config : NotifyPropertyChanged
         public int              MaxVerticalResolution       => MaxVerticalResolutionCustom == 0 ? (MaxVerticalResolutionAuto != 0 ? MaxVerticalResolutionAuto : 1080) : MaxVerticalResolutionCustom;
 
         /// <summary>
-        /// Sets NVidia Super Resolution (D3D11VP only)
+        /// Sets Nvidia Super Resolution (D3D11VP only)
         /// </summary>
-        public bool             SuperResolutionNVidia       { get => _SuperResolutionNVidia;        set { Set(ref _SuperResolutionNVidia, value); player?.renderer?.UpdateSuperResNVidia(value); } }
-        internal bool _SuperResolutionNVidia;
+        public bool             SuperResolutionNvidia       { get => _SuperResolutionNvidia;        set { Set(ref _SuperResolutionNvidia, value); player?.renderer?.UpdateSuperResNvidia(value); } }
+        internal bool _SuperResolutionNvidia;
 
         /// <summary>
         /// Sets Intel Super Resolution (D3D11VP only)

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -750,10 +750,16 @@ public class Config : NotifyPropertyChanged
         public int              MaxVerticalResolution       => MaxVerticalResolutionCustom == 0 ? (MaxVerticalResolutionAuto != 0 ? MaxVerticalResolutionAuto : 1080) : MaxVerticalResolutionCustom;
 
         /// <summary>
-        /// Sets NVidia Super Resolution (experimental)
+        /// Sets NVidia Super Resolution (D3D11VP only)
         /// </summary>
-        public bool             NVidiaSuperResolution       { get => _NVidiaSuperResolution;        set { Set(ref _NVidiaSuperResolution, value); player?.renderer?.UpdateNVidiaSuperRes(value); } }
-        internal bool _NVidiaSuperResolution;
+        public bool             SuperResolutionNVidia       { get => _SuperResolutionNVidia;        set { Set(ref _SuperResolutionNVidia, value); player?.renderer?.UpdateSuperResNVidia(value); } }
+        internal bool _SuperResolutionNVidia;
+
+        /// <summary>
+        /// Sets Intel Super Resolution (D3D11VP only)
+        /// </summary>
+        public bool             SuperResolutionIntel        { get => _SuperResolutionIntel;         set { Set(ref _SuperResolutionIntel, value); player?.renderer?.UpdateSuperResIntel(value); } }
+        internal bool _SuperResolutionIntel;
 
         /// <summary>
         /// In case of no hardware accelerated or post process accelerated pixel formats will use FFmpeg's SwsScale
@@ -772,11 +778,8 @@ public class Config : NotifyPropertyChanged
 
         /// <summary>
         /// Whether to use embedded video processor with custom pixel shaders or D3D11<br/>
-        /// (Currently D3D11 works only on video accelerated / hardware surfaces)<br/>
-        /// * FLVP supports HDR to SDR, D3D11 does not<br/>
-        /// * FLVP supports Pan Move/Zoom, D3D11 does not<br/>
-        /// * D3D11 possible performs better with color conversion and filters, FLVP supports only brightness/contrast filters<br/>
-        /// * D3D11 supports deinterlace (bob)
+        /// * FLVP supports HDR to SDR, hardware/software frames and more formats<br/>
+        /// * D3D11 uses less power, supports only hardware frames, deinterlace, super resolution and more accurate filters based on gpu
         /// </summary>
         public VideoProcessors  VideoProcessor              { get => _VideoProcessor;   set { if (Set(ref _VideoProcessor, value))  player?.renderer?.UpdateVideoProcessor(); } }
         VideoProcessors _VideoProcessor = VideoProcessors.Auto;
@@ -793,6 +796,9 @@ public class Config : NotifyPropertyChanged
         public Vortice.DXGI.PresentFlags
                                 PresentFlags                { get; set; } = Vortice.DXGI.PresentFlags.DoNotWait;
 
+        /// <summary>
+        /// Sets DeInterlace (D3D11VP only)
+        /// </summary>
         public DeInterlace      DeInterlace                 { get => _DeInterlace;      set { if (Set(ref _DeInterlace, value))     player?.renderer?.UpdateDeinterlace(); } }
         DeInterlace _DeInterlace = DeInterlace.Auto;
 

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -740,7 +740,7 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Custom max vertical resolution that will be used from the input/stream suggester plugins
         /// </summary>
-        public int              MaxVerticalResolutionCustom { get => _MaxVerticalResolutionCustom; set => Set(ref _MaxVerticalResolutionCustom, value); }
+        public int              MaxVerticalResolutionCustom { get => _MaxVerticalResolutionCustom;  set => Set(ref _MaxVerticalResolutionCustom, value); }
         int _MaxVerticalResolutionCustom;
 
         /// <summary>
@@ -748,6 +748,12 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         [JsonIgnore]
         public int              MaxVerticalResolution       => MaxVerticalResolutionCustom == 0 ? (MaxVerticalResolutionAuto != 0 ? MaxVerticalResolutionAuto : 1080) : MaxVerticalResolutionCustom;
+
+        /// <summary>
+        /// Sets NVidia Super Resolution (experimental)
+        /// </summary>
+        public bool             NVidiaSuperResolution       { get => _NVidiaSuperResolution;        set { Set(ref _NVidiaSuperResolution, value); player?.renderer?.UpdateNVidiaSuperRes(value); } }
+        internal bool _NVidiaSuperResolution;
 
         /// <summary>
         /// In case of no hardware accelerated or post process accelerated pixel formats will use FFmpeg's SwsScale

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.11</Version>
+    <Version>3.8.12</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -110,12 +110,7 @@ unsafe public partial class Renderer
             }
 
             var oldVP       = videoProcessor;
-            var fieldType   = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : (VideoFrameFormat)Config.Video.DeInterlace;
-            VideoProcessor  = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
-                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)) ?
-                VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
-
-            FieldType = fieldType != VideoFrameFormat.Progressive && videoProcessor == VideoProcessors.Flyleaf ? VideoFrameFormat.Progressive : fieldType;
+            VideoProcessor  = GetVP();
 
             if (oldVP != videoProcessor)
             {
@@ -152,7 +147,6 @@ unsafe public partial class Renderer
                     vd1.CreateVideoProcessorOutputView(backBuffer, vpe, vpovd, out vpov);
                     vc.VideoProcessorSetStreamColorSpace(vp, 0, inputColorSpace);
                     vc.VideoProcessorSetOutputColorSpace(vp, outputColorSpace);
-                    vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
 
                     if (child != null)
                     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -57,14 +57,14 @@ unsafe public partial class Renderer
     };
 
     [StructLayout(LayoutKind.Sequential)]
-    struct SuperResNVidia(bool enable)
+    struct SuperResNvidia(bool enable)
     {
         uint version = 0x1;
         uint method  = 0x2;
         uint enabled = enable ? 1u : 0u;
     }
-    static SuperResNVidia   SuperResEnabledNVidia   = new(true);
-    static SuperResNVidia   SuperResDisabledNVidia  = new(false);
+    static SuperResNvidia   SuperResEnabledNvidia   = new(true);
+    static SuperResNvidia   SuperResDisabledNvidia  = new(false);
     static Guid             GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
 
     [StructLayout(LayoutKind.Sequential)]
@@ -274,8 +274,8 @@ unsafe public partial class Renderer
                 vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
                 vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
 
-                if (Config.Video.SuperResolutionNVidia)
-                    UpdateSuperResNVidia(true);
+                if (Config.Video.SuperResolutionNvidia)
+                    UpdateSuperResNvidia(true);
 
                 if (Config.Video.SuperResolutionIntel)
                     UpdateSuperResIntel(true);
@@ -305,7 +305,7 @@ unsafe public partial class Renderer
 
         if (VideoDecoder.VideoAccelerated && VideoStream.ColorSpace != ColorSpace.Bt2020 && vc != null && (
                 Config.Video.VideoProcessor == VideoProcessors.D3D11 ||
-                Config.Video.SuperResolutionNVidia || Config.Video.SuperResolutionIntel ||
+                Config.Video.SuperResolutionNvidia || Config.Video.SuperResolutionIntel ||
                 (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)))
         {
             FieldType = fieldType;
@@ -527,7 +527,7 @@ unsafe public partial class Renderer
         Present();
     }
 
-    internal void UpdateSuperResNVidia(bool enabled)
+    internal void UpdateSuperResNvidia(bool enabled)
     {
         if (vc == null)
             return;
@@ -535,12 +535,12 @@ unsafe public partial class Renderer
         try
         {
             if (enabled)
-                fixed (SuperResNVidia* ptr = &SuperResEnabledNVidia)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNVidia), (nint)ptr);
+                fixed (SuperResNvidia* ptr = &SuperResEnabledNvidia)
+                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
             else
-                fixed (SuperResNVidia* ptr = &SuperResDisabledNVidia)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNVidia), (nint)ptr);
-        } catch (Exception e) { Log.Error($"UpdateNVidiaSuperRes() failed: {e.Message}"); } // Never fails?*
+                fixed (SuperResNvidia* ptr = &SuperResDisabledNvidia)
+                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
+        } catch (Exception e) { Log.Error($"UpdateNvidiaSuperRes() failed: {e.Message}"); } // Never fails?*
     }
 
     internal unsafe void UpdateSuperResIntel(bool enabled)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -57,15 +57,29 @@ unsafe public partial class Renderer
     };
 
     [StructLayout(LayoutKind.Sequential)]
-    struct NVidiaSuperRes(bool enable)
+    struct SuperResNVidia(bool enable)
     {
         uint version = 0x1;
         uint method  = 0x2;
         uint enabled = enable ? 1u : 0u;
     }
-    static NVidiaSuperRes   NVidiaSuperResEnabled   = new(true);
-    static NVidiaSuperRes   NVidiaSuperResDisabled  = new(false);
-    static Guid             GUID_NVIDIA_SUPERRES    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
+    static SuperResNVidia   SuperResEnabledNVidia   = new(true);
+    static SuperResNVidia   SuperResDisabledNVidia  = new(false);
+    static Guid             GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SuperResIntel
+    {
+        public IntelFunction    function;
+        public IntPtr           param;
+    }
+    enum IntelFunction : uint
+    {
+        kIntelVpeFnVersion  = 0x01,
+        kIntelVpeFnMode     = 0x20,
+		kIntelVpeFnScaling  = 0x37
+    }
+    static Guid             GUID_SUPERRES_INTEL     = Guid.Parse("edd1d4b9-8659-4cbc-a4d6-9831a2163ac3");
 
     VideoColor                          D3D11VPBackgroundColor;
     ID3D11VideoDevice1                  vd1;
@@ -198,7 +212,7 @@ unsafe public partial class Renderer
 
             if (CanDebug)
             {
-                dump += $"\n[Video Processor Input Format Caps]\r\n";
+                dump += $"\n[Video Processor Auto Stream Caps]\r\n";
                 foreach (VideoProcessorAutoStreamCaps cap in Enum.GetValues(typeof(VideoProcessorAutoStreamCaps)))
                     dump += $"{cap,-25} {((vpCaps.AutoStreamCaps & cap) != 0 ? "yes" : "no")}\r\n";
             }
@@ -260,8 +274,11 @@ unsafe public partial class Renderer
                 vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
                 vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
 
-                if (Config.Video.NVidiaSuperResolution)
-                    UpdateNVidiaSuperRes(true);
+                if (Config.Video.SuperResolutionNVidia)
+                    UpdateSuperResNVidia(true);
+
+                if (Config.Video.SuperResolutionIntel)
+                    UpdateSuperResIntel(true);
             }
 
             lock (Config.Video.lockFilters)
@@ -281,6 +298,25 @@ unsafe public partial class Renderer
 
         vc = null;
     }
+
+    VideoProcessors GetVP()
+    {
+        var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : (VideoFrameFormat)Config.Video.DeInterlace;
+
+        if (VideoDecoder.VideoAccelerated && VideoStream.ColorSpace != ColorSpace.Bt2020 && vc != null && (
+                Config.Video.VideoProcessor == VideoProcessors.D3D11 ||
+                Config.Video.SuperResolutionNVidia || Config.Video.SuperResolutionIntel ||
+                (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)))
+        {
+            FieldType = fieldType;
+            vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
+            return VideoProcessors.D3D11;
+        }
+
+        FieldType = VideoFrameFormat.Progressive;
+        return VideoProcessors.Flyleaf;
+    }
+
     internal void UpdateBackgroundColor()
     {
         D3D11VPBackgroundColor.Rgba.R = Scale(Config.Video.BackgroundColor.R, 0, 255, 0, 100) / 100.0f;
@@ -291,35 +327,19 @@ unsafe public partial class Renderer
 
         Present();
     }
+
     internal void UpdateDeinterlace()
     {
         lock (lockDevice)
         {
-            if (Disposed || parent != null)
+            if (Disposed || VideoStream == null || parent != null)
                 return;
 
-            var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? (VideoStream != null ? VideoStream.FieldOrder : VideoFrameFormat.Progressive) : (VideoFrameFormat)Config.Video.DeInterlace;
-            var newVp = !D3D11VPFailed && VideoDecoder.VideoAccelerated &&
-                (Config.Video.VideoProcessor == VideoProcessors.D3D11 || (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)) ?
-                VideoProcessors.D3D11 : VideoProcessors.Flyleaf;
-
-            if (videoProcessor == VideoProcessors.Flyleaf)
-                FieldType = VideoFrameFormat.Progressive;
-            else
-            {
-                FieldType = fieldType;
-                vc.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType);
-            }
-
-            if (newVp != VideoProcessor)
+            if (GetVP() != VideoProcessor)
                 ConfigPlanes();
         }
     }
-    internal VideoFrameFormat GetFieldType()
-    {
-        lock (lockDevice)
-            return !Disposed ? vc.VideoProcessorGetStreamFrameFormat(vp, 0) : VideoFrameFormat.Progressive;
-    }
+
     internal void SetFieldType(VideoFrameFormat fieldType)
     {
         lock (lockDevice)
@@ -327,6 +347,7 @@ unsafe public partial class Renderer
                 vc.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType);
                 //TBR: vpsa[0].InputFrameOrField = fieldType == DeInterlace.BottomField ? 1u : 0u; // TBR
     }
+
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {
         if(parent != null)
@@ -347,6 +368,7 @@ unsafe public partial class Renderer
             Present();
         }
     }
+
     void UpdateRotation(uint angle, bool refresh = true)
     {
         _RotationAngle = angle;
@@ -415,6 +437,7 @@ unsafe public partial class Renderer
 
         UpdateAspectRatio(refresh);
     }
+
     internal void UpdateAspectRatio(bool refresh = true)
     {
         lock (lockDevice) // TBR: Fix AspectRatio generally* Separate Enum + CustomValue (respect SAR, clarify Fit/Fill/Keep/Stretch/Original/Custom ...)
@@ -437,6 +460,7 @@ unsafe public partial class Renderer
             child?.UpdateAspectRatio(refresh);
         }
     }
+
     internal void UpdateCropping(bool refresh = true)
     {
         /* TODO (SW)
@@ -490,6 +514,7 @@ unsafe public partial class Renderer
                 SetViewport();
         }
     }
+
     internal void UpdateVideoProcessor()
     {
         if(parent != null)
@@ -502,18 +527,48 @@ unsafe public partial class Renderer
         Present();
     }
 
-    internal void UpdateNVidiaSuperRes(bool enabled)
+    internal void UpdateSuperResNVidia(bool enabled)
     {
+        if (vc == null)
+            return;
+
         try
         {
             if (enabled)
-                fixed (NVidiaSuperRes* ptr = &NVidiaSuperResEnabled)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_NVIDIA_SUPERRES, (uint)sizeof(NVidiaSuperRes), (nint)ptr);
+                fixed (SuperResNVidia* ptr = &SuperResEnabledNVidia)
+                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNVidia), (nint)ptr);
             else
-                fixed (NVidiaSuperRes* ptr = &NVidiaSuperResDisabled)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_NVIDIA_SUPERRES, (uint)sizeof(NVidiaSuperRes), (nint)ptr);
-        }
-        catch (Exception e) { Log.Error($"SetNVidiaSuperRes() failed: {e.Message}"); } // Never fails?*
+                fixed (SuperResNVidia* ptr = &SuperResDisabledNVidia)
+                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNVidia), (nint)ptr);
+        } catch (Exception e) { Log.Error($"UpdateNVidiaSuperRes() failed: {e.Message}"); } // Never fails?*
+    }
+
+    internal unsafe void UpdateSuperResIntel(bool enabled)
+    {
+        if (vc == null)
+            return;
+
+        try
+        {
+            IntPtr          paramPtr    = Marshal.AllocHGlobal(sizeof(uint));
+            SuperResIntel   intel       = new() { param = paramPtr };
+            GCHandle        handle      = GCHandle.Alloc(intel, GCHandleType.Pinned);
+            
+            intel.function = IntelFunction.kIntelVpeFnVersion;
+            Marshal.WriteInt32(paramPtr, 3); // kIntelVpeVersion3
+            vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+            intel.function = IntelFunction.kIntelVpeFnMode;
+            Marshal.WriteInt32(paramPtr, enabled ? 1 : 0); // kIntelVpeModePreproc : kIntelVpeModeNone
+            vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+            intel.function = IntelFunction.kIntelVpeFnScaling;
+            Marshal.WriteInt32(paramPtr, enabled ? 2 : 0); // kIntelVpeScalingSuperResolution : kIntelVpeScalingDefault
+            vc.VideoProcessorSetStreamExtension(vp, 0,  GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+            handle.Free();
+            Marshal.FreeHGlobal(paramPtr);
+        } catch (Exception e) { Log.Error($"UpdateIntelSuperRes() failed: {e.Message}"); } // Never fails?*
     }
 }
 

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -509,7 +509,7 @@ unsafe partial class Player
                 ? (int)((((dFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000)
                 : int.MaxValue;
 
-            sleepMs = Math.Min(vDistanceMs, aDistanceMs) - 1;
+            sleepMs = Math.Min(dDistanceMs, Math.Min(vDistanceMs, aDistanceMs)) - 1;
             if (sleepMs < 0 || sleepMs == int.MaxValue)
                 sleepMs = 0;
 

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -605,6 +605,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         Video.Reset();
         Audio.Reset();
         Subtitles.Reset();
+        Data.Reset();
         UIAll();
     }
     private void Initialize(Status status = Status.Stopped, bool andDecoder = true, bool isSwitch = false)


### PR DESCRIPTION
Update FlyleafLib v3.8.12 from v3.8.11

## Changelog
- Renderer.D3D11VP: Adds SuperResolution support (Nvidia/Intel)
- Renderer: Improves VideoProcessor selection based on input
- Config.Video: Introduces SuperResolutionNVidia and SuperResolutionIntel
- Player: Fixes a sync issue with Data streams
- FlyleafHost.Wpf: Improves transition from normal to fullscreen
- FlyleafHost.Wpf: Introduces CloseCanceled to properly cancel the process when required
- FlyleafHost.Wpf: Fixes an issue when hiding and showing back a window which was out of screen bounds (invalid pos/size for windows)

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/c7873a25bbcd41ad92cef2510c612d67b8547875...d63dfedff1f02b51d5193eed7a9dec2cbf590ee3