### PR TITLE
Update FlyleafLib v3.8.14

### DIFF
--- a/FlyleafLib/Controls/IHostPlayer.cs
+++ b/FlyleafLib/Controls/IHostPlayer.cs
@@ -5,5 +5,7 @@ public interface IHostPlayer
     bool Player_CanHideCursor();
     bool Player_GetFullScreen();
     void Player_SetFullScreen(bool value);
+    void Player_RatioChanged(double keepRatio);
+    bool Player_HandlesRatioResize(int width, int height);
     void Player_Disposed();
 }

--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -85,7 +85,7 @@
 
             <StackPanel>
                 <!-- Player -->
-                <StackPanel Style="{StaticResource FlowTable}" Height="300">
+                <StackPanel Style="{StaticResource FlowTable}" Height="310">
                     <TextBlock Style="{StaticResource TextHeader}" Text="Player"/>
 
                     <StackPanel Orientation="Horizontal">
@@ -224,7 +224,7 @@
 
             <StackPanel Grid.Column="1">
                 <!-- Video -->
-                <StackPanel Style="{StaticResource FlowTable}" Height="300">
+                <StackPanel Style="{StaticResource FlowTable}" Height="310">
                     <TextBlock Style="{StaticResource TextHeader}" Text="Video"/>
 
                     <StackPanel Orientation="Horizontal">
@@ -279,6 +279,11 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource TextInfo}" Text="Deinterlace"/>
                         <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.FieldType, Converter={StaticResource DeInterlaceConverter}}"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Style="{StaticResource TextInfo}" Text="Super Resolution"/>
+                        <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.renderer.SuperResolution}"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -890,12 +890,10 @@ public class Config : NotifyPropertyChanged
         internal void SetEnabled(bool enabled)      => Set(ref _Enabled, enabled, true, nameof(Enabled));
 
         /// <summary>
-        /// Whether to process samples with Filters or SWR (experimental)<br/>
-        /// 1. Requires FFmpeg avfilter lib<br/>
-        /// 2. Currently SWR performs better if you dont need filters<br/>
+        /// Uses FFmpeg filters instead of Swr (better speed quality and support for extra filters, requires avfilter-X.dll)
         /// </summary>
         public bool             FiltersEnabled      { get => _FiltersEnabled; set { if (Set(ref _FiltersEnabled, value && Engine.Config.FFmpegLoadProfile != LoadProfile.Main)) player?.AudioDecoder.SetupFiltersOrSwr(); } }
-        bool _FiltersEnabled = false;
+        bool _FiltersEnabled = true;
 
         /// <summary>
         /// List of filters for post processing the audio samples (experimental)<br/>

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -756,16 +756,10 @@ public class Config : NotifyPropertyChanged
         public int              MaxVerticalResolution       => MaxVerticalResolutionCustom == 0 ? (MaxVerticalResolutionAuto != 0 ? MaxVerticalResolutionAuto : 1080) : MaxVerticalResolutionCustom;
 
         /// <summary>
-        /// Sets Nvidia Super Resolution (D3D11VP only)
+        /// Sets Super Resolution (Nvidia / Intel - D3D11VP only)
         /// </summary>
-        public bool             SuperResolutionNvidia       { get => _SuperResolutionNvidia;        set { Set(ref _SuperResolutionNvidia, value); player?.renderer?.UpdateSuperResNvidia(value); } }
-        internal bool _SuperResolutionNvidia;
-
-        /// <summary>
-        /// Sets Intel Super Resolution (D3D11VP only)
-        /// </summary>
-        public bool             SuperResolutionIntel        { get => _SuperResolutionIntel;         set { Set(ref _SuperResolutionIntel, value); player?.renderer?.UpdateSuperResIntel(value); } }
-        internal bool _SuperResolutionIntel;
+        public bool             SuperResolution             { get => _SuperResolution;  set { if (Set(ref _SuperResolution, value)) player?.renderer?.UpdateSuperRes(); } }
+        internal bool _SuperResolution;
 
         /// <summary>
         /// Forces SwsScale instead of FlyleafVP for non HW decoded frames

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -136,7 +136,7 @@ public class VideoEngine
                 SystemMemory    = adapterdesc.DedicatedSystemMemory.Value,
                 VideoMemory     = adapterdesc.DedicatedVideoMemory.Value,
                 SharedMemory    = adapterdesc.SharedSystemMemory.Value,
-                Vendor          = VendorIdStr(adapterdesc.VendorId),
+                Vendor          = (GPUVendor)adapterdesc.VendorId,
                 Description     = adapterdesc.Description,
                 Id              = adapterdesc.DeviceId,
                 Luid            = adapterdesc.Luid,
@@ -165,26 +165,5 @@ public class VideoEngine
         }
 
         return null;
-    }
-
-    private static string VendorIdStr(uint vendorId)
-    {
-        switch (vendorId)
-        {
-            case 0x1002:
-                return "ATI";
-            case 0x10DE:
-                return "NVIDIA";
-            case 0x1106:
-                return "VIA";
-            case 0x8086:
-                return "Intel";
-            case 0x5333:
-                return "S3 Graphics";
-            case 0x4D4F4351:
-                return "Qualcomm";
-            default:
-                return "Unknown";
-        }
     }
 }

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -144,23 +144,33 @@ public class GPUOutput
 
 public class GPUAdapter
 {
-    public int      MaxHeight       { get; internal set; }
-    public nuint    SystemMemory    { get; internal set; }
-    public nuint    VideoMemory     { get; internal set; }
-    public nuint    SharedMemory    { get; internal set; }
+    public int              MaxHeight       { get; internal set; }
+    public nuint            SystemMemory    { get; internal set; }
+    public nuint            VideoMemory     { get; internal set; }
+    public nuint            SharedMemory    { get; internal set; }
 
-
-    public uint     Id              { get; internal set; }
-    public string   Vendor          { get; internal set; }
-    public string   Description     { get; internal set; }
-    public long     Luid            { get; internal set; }
-    public bool     HasOutput       { get; internal set; }
-    public List<GPUOutput>
-                    Outputs         { get; internal set; }
+    public uint             Id              { get; internal set; }
+    public GPUVendor        Vendor          { get; internal set; }
+    public string           Description     { get; internal set; }
+    public long             Luid            { get; internal set; }
+    public bool             HasOutput       { get; internal set; }
+    public List<GPUOutput>  Outputs         { get; internal set; }
 
     public override string ToString()
         => (Vendor + " " + Description).PadRight(40) + $"[ID: {Id,-6}, LUID: {Luid,-6}, DVM: {GetBytesReadable(VideoMemory),-8}, DSM: {GetBytesReadable(SystemMemory),-8}, SSM: {GetBytesReadable(SharedMemory)}]";
 }
+
+public enum GPUVendor : uint
+{
+    Unknown,
+    ATI         = 0x1002,
+    Intel       = 0x8086,
+    Nvidia      = 0x10DE,
+    Qualcomm    = 0x4D4F4351,
+    S3Graphics  = 0x5333,
+    VIA         = 0x1106,
+}
+
 public enum VideoFilters
 {
     // Ensure we have the same values with Vortice.Direct3D11.VideoProcessorFilterCaps (d3d11.h) | we can extended if needed with other values
@@ -201,7 +211,7 @@ public struct AspectRatio : IEquatable<AspectRatio>
 
     public double Value
     {
-        readonly get => Num / Den;
+        readonly get => Den == 0 ? 0 : Num / Den;
         set { Num = value; Den = 1; }
     }
 
@@ -224,13 +234,13 @@ public struct AspectRatio : IEquatable<AspectRatio>
     public void FromString(string value)
     {
         if (value == "Keep")
-            { Num = Keep.Num; Den = Keep.Den; return; }
+            { Num = Keep.Num;       Den = Keep.Den;     return; }
         else if (value == "Fill")
-            { Num = Fill.Num; Den = Fill.Den; return; }
+            { Num = Fill.Num;       Den = Fill.Den;     return; }
         else if (value == "Custom")
-            { Num = Custom.Num; Den = Custom.Den; return; }
+            { Num = Custom.Num;     Den = Custom.Den;   return; }
         else if (value == "Invalid")
-            { Num = Invalid.Num; Den = Invalid.Den; return; }
+            { Num = Invalid.Num;    Den = Invalid.Den;  return; }
 
         string newvalue = value.ToString().Replace(',', '.');
 

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.13</Version>
+    <Version>3.8.14</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -230,7 +230,7 @@ public unsafe partial class DecoderContext : PluginHandler
 
             VideoDecoder.Flush();
             if (ms == 0)
-                VideoDecoder.keyPacketRequired = false; // TBR
+                VideoDecoder.keyFrameRequired = VideoDecoder.keyPacketRequired = false; // TBR
 
             if (AudioStream != null && AudioDecoder.OnVideoDemuxer)
             {
@@ -672,7 +672,10 @@ public unsafe partial class DecoderContext : PluginHandler
             if (codecType == AVMediaType.Video && VideoDecoder.keyPacketRequired)
             {
                 if (packet->flags.HasFlag(PktFlags.Key) || packet->pts == VideoDecoder.startPts)
+                {
                     VideoDecoder.keyPacketRequired = false;
+                    VideoDecoder.keyFrameRequired  = true;
+                }
                 else
                 {
                     if (CanWarn) Log.Warn("Ignoring non-key packet");
@@ -752,6 +755,12 @@ public unsafe partial class DecoderContext : PluginHandler
                     {
                         ret = avcodec_receive_frame(VideoDecoder.CodecCtx, frame);
                         if (ret != 0) { av_frame_unref(frame); break; }
+
+                        if (VideoDecoder.keyFrameRequired)
+                        {
+                            if (!frame->flags.HasFlag(FrameFlags.Key)) { av_frame_unref(frame); continue; }
+                            VideoDecoder.keyFrameRequired = false;
+                        }
 
                         if (frame->best_effort_timestamp != AV_NOPTS_VALUE)
                             frame->pts = frame->best_effort_timestamp;

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
@@ -128,7 +128,7 @@ public unsafe partial class AudioDecoder
             ret = avfilter_graph_config(filterGraph, null);
 
             // CRIT TBR:!!!
-            var tb = 1000 * 10000.0 / sinkTimebase.Den; // Ensures we have at least 20-70ms samples to avoid audio crackling and av sync issues
+            var tb = 1000 * 10000.0 / sinkTimebase.Den; // TBR: DONT CHANGE values will affect Screamer | Ensures we have at least 20-70ms samples to avoid audio crackling and av sync issues
             ((FilterLink*)abufferSinkCtx->inputs[0])->min_samples = (int) (20 * 10000 / tb);
             ((FilterLink*)abufferSinkCtx->inputs[0])->max_samples = (int) (70 * 10000 / tb);
 

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
@@ -6,6 +6,9 @@ namespace FlyleafLib.MediaFramework.MediaDecoder;
 
 /* TODO
  *
+ * Sample Rate Pre-Convert (Output)
+ * Change to fixed 48KHz and let ffmpeg filters do the convert if required (xaudio2 might cause latency while doing it)
+ *
  * Circular Buffer
  * - Safe re-allocation and check also actual frames in queue (as now during draining we can overwrite them)
  * - Locking with Audio.AddSamples during re-allocation and re-write old data to the new buffer and update the pointers in queue

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -192,14 +192,17 @@ public unsafe partial class Renderer
                     {
                         string dump = $"GPU Adapter\r\n{GPUAdapter}\r\n";
 
-                        for (int i=0; i<GPUAdapter.Outputs.Count; i++)
+                        for (int i = 0; i < GPUAdapter.Outputs.Count; i++)
                             dump += $"[Output #{i+1}] {GPUAdapter.Outputs[i]}\r\n";
 
                         Log.Debug(dump);
                     }
                 }
                 else
+                {
+                    GPUAdapter = new();
                     Log.Debug($"GPU Adapter: Unknown (Possible WARP without Luid)");
+                }
 
                 tempDevice.Dispose();
                 adapter.Dispose();
@@ -466,6 +469,7 @@ public unsafe partial class Renderer
             Flush();
             VideoDecoder.Open(stream); // Should Re-ConfigPlanes()
             VideoDecoder.keyPacketRequired = !VideoDecoder.isIntraOnly;
+            VideoDecoder.keyFrameRequired  = false;
             if (running)
                 VideoDecoder.Start();
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -416,7 +416,7 @@ unsafe public partial class Renderer
                     else if (VideoStream.ColorType == ColorType.RGB)
                     {
                         // [RGB0]32 | [RGBA]32 | [RGBA]64
-                        if (VideoStream.PixelPlanes == 1 && (
+                        if (VideoStream.PixelPlanes == 1 && ( // Possible Alpha
                             VideoStream.PixelFormat == AVPixelFormat._0RGB  ||
                             VideoStream.PixelFormat == AVPixelFormat.Rgb0   ||
                             VideoStream.PixelFormat == AVPixelFormat._0BGR  ||
@@ -508,7 +508,7 @@ unsafe public partial class Renderer
                         }
 
                         // GBR(A)
-                        else if (VideoStream.PixelPlanes > 2) // TBR: Usually transfer func 'Linear' for > 8-bit which requires pow (*?)
+                        else if (VideoStream.PixelPlanes > 2) // Possible Alpha | TBR: Usually transfer func 'Linear' for > 8-bit which requires pow (*?)
                         {
                             curPSCase = PSCase.RGBPlanar;
                             curPSUniqueId += ((int)curPSCase).ToString();
@@ -654,7 +654,7 @@ unsafe public partial class Renderer
 
             //AV_PIX_FMT_FLAG_ALPHA (currently used only for RGBA?)
             //context.OMSetBlendState(curPSCase == PSCase.RGBPacked || (curPSCase == PSCase.RGBPlanar && VideoStream.PixelPlanes == 4) ? blendStateAlpha : null);
-            context.OMSetBlendState(curPSCase == PSCase.RGBPacked ? blendStateAlpha : null);
+            context.OMSetBlendState(VideoStream.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Alpha) ? blendStateAlpha : null);
 
             Log.Debug($"Prepared planes for {VideoStream.PixelFormatStr} with {videoProcessor} [{curPSCase}]");
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -73,8 +73,7 @@ public unsafe partial class Renderer
         if (SCDisposed)
             return;
 
-        // NOTE: We don't have TimeBeginPeriod, FpsForIdle will not be accurate
-        lock (lockPresentTask)
+        lock (lockPresentTask) // NOTE: We don't have TimeBeginPeriod, FpsForIdle will not be accurate
         {
             if ((Config.Player.player == null || !Config.Player.player.requiresBuffering) && VideoDecoder.IsRunning && (VideoStream == null || VideoStream.FPS > 10)) // With slow FPS we need to refresh as fast as possible
                 return;
@@ -109,10 +108,9 @@ public unsafe partial class Renderer
     }
     internal void PresentInternal(VideoFrame frame, bool forceWait = true)
     {
-        if (SCDisposed)
+        if (!canRenderPresent)
             return;
 
-        // TBR: Replica performance issue with D3D11 (more zoom more gpu overload)
         if (frame.srvs == null) // videoProcessor can be FlyleafVP but the player can send us a cached frame from prev videoProcessor D3D11VP (check frame.srv instead of videoProcessor)
         {
             if (frame.avFrame != null)
@@ -126,48 +124,48 @@ public unsafe partial class Renderer
                 vd1.CreateVideoProcessorInputView(frame.textures[0], vpe, vpivd, out vpiv);
             }
 
-            if (vpiv != null)
-            {
-                vpsa[0].InputSurface = vpiv;
-                vc.VideoProcessorBlt(vp, vpov, 0, 1, vpsa);
-                swapChain.Present(Config.Video.VSync, forceWait ? PresentFlags.None : Config.Video.PresentFlags);
+            if (vpiv == null)
+                return;
 
-                vpiv.Dispose();
-            }
+            vpsa[0].InputSurface = vpiv;
+            vc.VideoProcessorBlt(vp, vpov, 0, 1, vpsa);
+            vpiv.Dispose();
         }
         else
         {
             context.OMSetRenderTargets(backBufferRtv);
             context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
-            context.RSSetViewport(GetViewport);
             context.PSSetShaderResources(0, frame.srvs);
             context.Draw(6, 0);
-
-            if (use2d)
-                Config.Video.OnD2DDraw(this, context2d);
-
-            if (overlayTexture != null)
-            {
-                Viewport view = GetViewport;
-
-                // Don't stretch the overlay (reduce height based on ratiox) | Sub's stream size might be different from video size (fix y based on percentage)
-                var ratiox = (double)view.Width / overlayTextureOriginalWidth;
-                var ratioy = (double)overlayTextureOriginalPosY / overlayTextureOriginalHeight;
-
-                context.OMSetBlendState(blendStateAlpha);
-                context.PSSetShaderResources(0, overlayTextureSRVs);
-                context.RSSetViewport((float) (view.X + (overlayTextureOriginalPosX * ratiox)), (float) (view.Y + (view.Height * ratioy)), (float) (overlayTexture.Description.Width * ratiox), (float) (overlayTexture.Description.Height * ratiox));
-                context.PSSetShader(ShaderBGRA);
-                context.Draw(6, 0);
-
-                // restore context
-                context.PSSetShader(ShaderPS);
-                context.OMSetBlendState(curPSCase == PSCase.RGBPacked ? blendStateAlpha : null);
-            }
-
-            swapChain.Present(Config.Video.VSync, forceWait ? PresentFlags.None : Config.Video.PresentFlags);
         }
 
+        if (use2d)
+            Config.Video.OnD2DDraw(this, context2d);
+
+        if (overlayTexture != null) // Bitmap Subs
+        {
+            Viewport view = GetViewport;
+
+            // TODO: Bad quality for scaling subs (consider using different shader/sampler) | Don't stretch the overlay (reduce height based on ratiox) | Sub's stream size might be different from video size (fix y based on percentage)
+            var ratiox = (double)view.Width / overlayTextureOriginalWidth;
+            var ratioy = (double)overlayTextureOriginalPosY / overlayTextureOriginalHeight;
+
+            if (videoProcessor == VideoProcessors.D3D11)
+                context.OMSetRenderTargets(backBufferRtv);
+
+            context.OMSetBlendState(blendStateAlpha);
+            context.PSSetShaderResources(0, overlayTextureSRVs);
+            context.RSSetViewport((float) (view.X + (overlayTextureOriginalPosX * ratiox)), (float) (view.Y + (view.Height * ratioy)), (float) (overlayTexture.Description.Width * ratiox), (float) (overlayTexture.Description.Height * ratiox));
+            context.PSSetShader(ShaderBGRA);
+            context.Draw(6, 0);
+
+            // restore context
+            context.PSSetShader(ShaderPS);
+            context.OMSetBlendState(VideoStream.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Alpha) ? blendStateAlpha : null);
+            context.RSSetViewport(GetViewport);
+        }
+
+        swapChain.Present(Config.Video.VSync, forceWait ? PresentFlags.None : Config.Video.PresentFlags);
         child?.PresentInternal(frame);
     }
 
@@ -274,6 +272,7 @@ public unsafe partial class Renderer
                     PresentInternal(LastFrame);
                 else if (Config.Video.ClearScreen)
                 {
+                    context.OMSetRenderTargets(backBufferRtv);
                     context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
                     swapChain.Present(Config.Video.VSync, PresentFlags.None);
                 }
@@ -298,11 +297,12 @@ public unsafe partial class Renderer
     {
         lock (lockDevice)
         {
-            if (SCDisposed)
+            if (!canRenderPresent)
                 return;
 
             ClearOverlayTexture();
             VideoDecoder.DisposeFrame(LastFrame);
+            context.OMSetRenderTargets(backBufferRtv);
             context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
             swapChain.Present(Config.Video.VSync, PresentFlags.None);
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PresentOffline.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PresentOffline.cs
@@ -133,6 +133,8 @@ public partial class Renderer
 
                 if (videoProcessor == VideoProcessors.D3D11)
                     SetViewport();
+                else
+                    context.RSSetViewport(GetViewport);
             }
 
             context.CopyResource(singleStage, singleGpu);
@@ -221,6 +223,8 @@ public partial class Renderer
 
                 if (videoProcessor == VideoProcessors.D3D11)
                     SetViewport();
+                else
+                    context.RSSetViewport(GetViewport);
             }
 
             context.CopyResource(singleStage, singleGpu);

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -13,8 +13,11 @@ using ID3D11Texture2D = Vortice.Direct3D11.ID3D11Texture2D;
 
 namespace FlyleafLib.MediaFramework.MediaRenderer;
 
-public partial class Renderer
+unsafe public partial class Renderer
 {
+    internal bool           forceViewToControl; // Makes sure that viewport will fill the exact same size with the control (mainly for keep ratio on resize)
+    bool                    canRenderPresent;   // Don't render / present during minimize (or invalid size)
+
     ID3D11Texture2D         backBuffer;
     ID3D11RenderTargetView  backBufferRtv;
     IDXGISwapChain1         swapChain;
@@ -22,12 +25,11 @@ public partial class Renderer
     IDCompositionVisual     dCompVisual;
     IDCompositionTarget     dCompTarget;
 
-    const Int32         WM_NCDESTROY= 0x0082;
-    const Int32         WM_SIZE     = 0x0005;
-    const Int32         WS_EX_NOREDIRECTIONBITMAP
-                                    = 0x00200000;
-    SubclassWndProc     wndProcDelegate;
-    IntPtr              wndProcDelegatePtr;
+    const uint              WM_NCDESTROY                = 0x0082;
+    const uint              WM_SIZE                     = 0x0005;
+    const int               WS_EX_NOREDIRECTIONBITMAP   = 0x00200000;
+    SubclassWndProc         wndProcDelegate;
+    IntPtr                  wndProcDelegatePtr;
 
     // Support Windows 8+
     private SwapChainDescription1 GetSwapChainDesc(int width, int height, bool isComp = false, bool alpha = false)
@@ -185,6 +187,7 @@ public partial class Renderer
                 return;
 
             SCDisposed = true;
+            canRenderPresent = false;
 
             // Clear Screan
             if (!Disposed && swapChain != null)
@@ -285,12 +288,14 @@ public partial class Renderer
     {
         int x, y, newWidth, newHeight, xZoomPixels, yZoomPixels;
 
+        var shouldFill = Config.Player.player?.Host?.Player_HandlesRatioResize(ControlWidth, ControlHeight);
+
         if (curRatio < fillRatio)
         {
             newHeight   = (int)(ControlHeight * zoom);
-            newWidth    = (int)(newHeight * curRatio);
+            newWidth    = (shouldFill.HasValue && shouldFill.Value) ? (int)(ControlWidth * zoom) : (int)(newHeight * curRatio);
 
-            SideXPixels = (int) (ControlWidth - (ControlHeight * curRatio));
+            SideXPixels = ((int) (ControlWidth - (ControlHeight * curRatio))) & ~1;
             SideYPixels = 0;
 
             y = PanYOffset;
@@ -302,9 +307,9 @@ public partial class Renderer
         else
         {
             newWidth    = (int)(ControlWidth * zoom);
-            newHeight   = (int)(newWidth / curRatio);
+            newHeight   = (shouldFill.HasValue && shouldFill.Value) || curRatio == fillRatio ? (int)(ControlHeight * zoom) : (int)(newWidth / curRatio);
 
-            SideYPixels = (int) (ControlHeight - (ControlWidth / curRatio));
+            SideYPixels = ((int) (ControlHeight - (ControlWidth / curRatio))) & ~1;
             SideXPixels = 0;
 
             x = PanXOffset;
@@ -314,18 +319,30 @@ public partial class Renderer
             yZoomPixels = newHeight - (ControlHeight - SideYPixels);
         }
 
-        GetViewport = new(x - xZoomPixels * (float)zoomCenter.X, y - yZoomPixels * (float)zoomCenter.Y, newWidth, newHeight);
-        ViewportChanged?.Invoke(this, new());
-
+        GetViewport = new((int)(x - xZoomPixels * (float)zoomCenter.X), (int)(y - yZoomPixels * (float)zoomCenter.Y), newWidth, newHeight);
+        
         if (videoProcessor == VideoProcessors.D3D11)
         {
             Viewport view = GetViewport;
+
+            if (!Config.Video.SuperResolution)
+                DisableSuperRes();
+            else
+            {
+                if (view.Width > VisibleWidth && view.Height > VisibleHeight)
+                    EnableSuperRes();
+                else
+                    DisableSuperRes();
+            }
 
             int right   = (int)(view.X + view.Width);
             int bottom  = (int)(view.Y + view.Height);
 
             if (view.Width < 1 || view.Y >= ControlHeight || view.X >= ControlWidth || bottom <= 0 || right <= 0)
+            {
+                canRenderPresent = false;
                 return;
+            }
 
             RawRect dst = new(
                     Math.Max((int)view.X, 0),
@@ -407,16 +424,26 @@ public partial class Renderer
             vc.VideoProcessorSetStreamDestRect  (vp, 0, true, dst);
             vc.VideoProcessorSetOutputTargetRect(vp, true, new(0, 0, ControlWidth, ControlHeight));
         }
+        else
+            context.RSSetViewport(GetViewport);
+
+        canRenderPresent = true;
 
         if (refresh)
             Present();
+
+        ViewportChanged?.Invoke(this, new());
     }
+    
     public void ResizeBuffers(int width, int height)
     {
         lock (lockDevice)
         {
-            if (SCDisposed)
+            if (SCDisposed || width <= 0 || height <= 0)
+            {
+                canRenderPresent = false;
                 return;
+            }
 
             if (use2d)
             {
@@ -427,21 +454,21 @@ public partial class Renderer
 
             ControlWidth    = width;
             ControlHeight   = height;
-            fillRatio = ControlWidth / (double)ControlHeight;
+            fillRatio       = ControlWidth / (double)ControlHeight;
             if (Config.Video.AspectRatio == AspectRatio.Fill)
                 curRatio = fillRatio;
 
             backBufferRtv.Dispose();
-            vpov?.Dispose();
-            backBuffer.Dispose();
+            vpov        ?.Dispose();
+            backBuffer   .Dispose();
+
             swapChain.ResizeBuffers(0, (uint)ControlWidth, (uint)ControlHeight, Format.Unknown, SwapChainFlags.None);
+
             UpdateCornerRadius();
-            backBuffer = swapChain.GetBuffer<ID3D11Texture2D>(0);
-            backBufferRtv = Device.CreateRenderTargetView(backBuffer);
+            backBuffer      = swapChain.GetBuffer<ID3D11Texture2D>(0);
+            backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
             if (videoProcessor == VideoProcessors.D3D11)
                 vd1.CreateVideoProcessorOutputView(backBuffer, vpe, vpovd, out vpov);
-
-            SetViewport();
 
             if (use2d)
             {
@@ -449,6 +476,8 @@ public partial class Renderer
                 bitmap2d = context2d.CreateBitmapFromDxgiSurface(surface, bitmapProps2d);
                 context2d.Target = bitmap2d;
             }
+            
+            SetViewport(); // TBR: Presents async (for performance especial in resize)
         }
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -56,31 +56,6 @@ unsafe public partial class Renderer
         Step        = filter.Multiplier
     };
 
-    [StructLayout(LayoutKind.Sequential)]
-    struct SuperResNvidia(bool enable)
-    {
-        uint version = 0x1;
-        uint method  = 0x2;
-        uint enabled = enable ? 1u : 0u;
-    }
-    static SuperResNvidia   SuperResEnabledNvidia   = new(true);
-    static SuperResNvidia   SuperResDisabledNvidia  = new(false);
-    static Guid             GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
-
-    [StructLayout(LayoutKind.Sequential)]
-    struct SuperResIntel
-    {
-        public IntelFunction    function;
-        public IntPtr           param;
-    }
-    enum IntelFunction : uint
-    {
-        kIntelVpeFnVersion  = 0x01,
-        kIntelVpeFnMode     = 0x20,
-		kIntelVpeFnScaling  = 0x37
-    }
-    static Guid             GUID_SUPERRES_INTEL     = Guid.Parse("edd1d4b9-8659-4cbc-a4d6-9831a2163ac3");
-
     VideoColor                          D3D11VPBackgroundColor;
     ID3D11VideoDevice1                  vd1;
     ID3D11VideoProcessor                vp;
@@ -115,10 +90,10 @@ unsafe public partial class Renderer
     {
         try
         {
-            vpcd.InputWidth = 1;
-            vpcd.InputHeight= 1;
-            vpcd.OutputWidth = vpcd.InputWidth;
-            vpcd.OutputHeight= vpcd.InputHeight;
+            vpcd.InputWidth     = 1;
+            vpcd.InputHeight    = 1;
+            vpcd.OutputWidth    = vpcd.InputWidth;
+            vpcd.OutputHeight   = vpcd.InputHeight;
 
             outputColorSpace = new VideoProcessorColorSpace()
             {
@@ -270,15 +245,15 @@ unsafe public partial class Renderer
             }
             else
             {
+                if (SuperResolution)
+                {
+                    SuperResolution = false;
+                    RaiseUI(nameof(SuperResolution));
+                }
+
                 UpdateBackgroundColor();
                 vc.VideoProcessorSetStreamAutoProcessingMode(vp, 0, false);
                 vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
-
-                if (Config.Video.SuperResolutionNvidia)
-                    UpdateSuperResNvidia(true);
-
-                if (Config.Video.SuperResolutionIntel)
-                    UpdateSuperResIntel(true);
             }
 
             lock (Config.Video.lockFilters)
@@ -305,7 +280,7 @@ unsafe public partial class Renderer
 
         if (VideoDecoder.VideoAccelerated && VideoStream.ColorSpace != ColorSpace.Bt2020 && vc != null && (
                 Config.Video.VideoProcessor != VideoProcessors.Flyleaf ||
-                Config.Video.SuperResolutionNvidia || Config.Video.SuperResolutionIntel ||
+                Config.Video.SuperResolution ||
                 (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)))
         {
             FieldType = fieldType;
@@ -371,26 +346,21 @@ unsafe public partial class Renderer
 
     void UpdateRotation(uint angle, bool refresh = true)
     {
-        _RotationAngle = angle;
-
-        uint newRotation = _RotationAngle;
-
+        _RotationAngle      = angle;
+        uint newRotation    = _RotationAngle;
         if (VideoStream != null)
-            newRotation += (uint)VideoStream.Rotation;
+            newRotation    += (uint)VideoStream.Rotation;
+        newRotation        %= 360;
 
-        if (rotationLinesize)
-            newRotation += 180;
+        bool newVflip       = hasLinesizeVFlip ^ _VFlip;
+        bool hvFlipChanged  = actualHFlip != _HFlip || actualVFlip != newVflip;
 
-        newRotation %= 360;
-
-        if (Disposed || (actualRotation == newRotation && actualHFlip == _HFlip && actualVFlip == _VFlip))
+        if (Disposed || (actualRotation == newRotation && !hvFlipChanged))
             return;
 
-        bool hvFlipChanged = (actualHFlip || actualVFlip) != (_HFlip || _VFlip);
-
         actualRotation  = newRotation;
+        actualVFlip     = newVflip;
         actualHFlip     = _HFlip;
-        actualVFlip     = _VFlip;
 
         if (actualRotation < 45 || actualRotation == 360)
             _d3d11vpRotation = VideoProcessorRotation.Identity;
@@ -403,9 +373,9 @@ unsafe public partial class Renderer
 
         vsBufferData.mat = Matrix4x4.CreateFromYawPitchRoll(0.0f, 0.0f, (float) (Math.PI / 180 * actualRotation));
 
-        if (_HFlip || _VFlip)
+        if (actualHFlip || actualVFlip)
         {
-            vsBufferData.mat *= Matrix4x4.CreateScale(_HFlip ? -1 : 1, _VFlip ? -1 : 1, 1);
+            vsBufferData.mat *= Matrix4x4.CreateScale(actualHFlip ? -1 : 1, actualVFlip ? -1 : 1, 1);
             if (hvFlipChanged)
             {
                 // Renders both sides required for H-V Flip - TBR: consider for performance changing the vertex buffer / input layout instead?
@@ -430,7 +400,7 @@ unsafe public partial class Renderer
             child.actualRotation    = actualRotation;
             child._d3d11vpRotation  = _d3d11vpRotation;
             child._RotationAngle    = _RotationAngle;
-            child.rotationLinesize  = rotationLinesize;
+            child.hasLinesizeVFlip  = hasLinesizeVFlip;
         }
 
         vc?.VideoProcessorSetStreamRotation(vp, 0, true, _d3d11vpRotation);
@@ -443,21 +413,32 @@ unsafe public partial class Renderer
         lock (lockDevice) // TBR: Fix AspectRatio generally* Separate Enum + CustomValue (respect SAR, clarify Fit/Fill/Keep/Stretch/Original/Custom ...)
         {
             if (Config.Video.AspectRatio == AspectRatio.Keep)
+            {
                 curRatio = keepRatio;
+                if (actualRotation == 90 || actualRotation == 270)
+                    curRatio = 1 / curRatio;
+
+                Config.Player.player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
+            }
             else if (Config.Video.AspectRatio == AspectRatio.Fill)
+            {
                 curRatio = fillRatio;
+                if (actualRotation == 90 || actualRotation == 270)
+                    curRatio = 1 / curRatio;
+            }
+
+            // No SAR / Rotation respect for customs?
             else if (Config.Video.AspectRatio == AspectRatio.Custom)
                 curRatio = Config.Video.CustomAspectRatio.Value;
             else
                 curRatio = Config.Video.AspectRatio.Value;
 
-            if (actualRotation == 90 || actualRotation == 270)
-                curRatio = 1 / curRatio;
+            Config.Player.player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
 
             if (refresh)
                 SetViewport();
 
-            child?.UpdateAspectRatio(refresh);
+            child?.UpdateAspectRatio(refresh); // TBR: should just pass the curRatio to child?
         }
     }
 
@@ -507,11 +488,17 @@ unsafe public partial class Renderer
             DAR = new(x, y);
             keepRatio = DAR.Value;
 
-            if (Config.Video.AspectRatio == AspectRatio.Keep)
-                curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;
+            Config.Player.player?.Video.SetUISize((int)VisibleWidth, (int)VisibleHeight, DAR);
 
-            if (refresh)
+            if (Config.Video.AspectRatio == AspectRatio.Keep)
+            {
+                curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;
+                Config.Player.player?.Host?.Player_RatioChanged(curRatio);
+            }
+            else if (refresh)
                 SetViewport();
+
+            // TBR: child?
         }
     }
 
@@ -527,53 +514,106 @@ unsafe public partial class Renderer
         Present();
     }
 
-    /* TODO (Super Resolution)
-     * 1) Combine both in one (check vendor)
-     * 2) It will be enabled based on output window and based on viewport's size (enable/disable manually when actually needed)
-     */
-    internal void UpdateSuperResNvidia(bool enabled)
-    {
-        if (vc == null)
-            return;
+    #region Super Resolution
+    public bool SuperResolution { get; private set; }
 
-        try
+    [StructLayout(LayoutKind.Sequential)]
+    struct SuperResNvidia(bool enable)
+    {
+        uint version = 0x1;
+        uint method  = 0x2;
+        uint enabled = enable ? 1u : 0u;
+    }
+    static SuperResNvidia   SuperResEnabledNvidia   = new(true);
+    static SuperResNvidia   SuperResDisabledNvidia  = new(false);
+    static Guid             GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SuperResIntel
+    {
+        public IntelFunction    function;
+        public IntPtr           param;
+    }
+    enum IntelFunction : uint
+    {
+        kIntelVpeFnVersion  = 0x01,
+        kIntelVpeFnMode     = 0x20,
+		kIntelVpeFnScaling  = 0x37
+    }
+    static Guid             GUID_SUPERRES_INTEL     = Guid.Parse("edd1d4b9-8659-4cbc-a4d6-9831a2163ac3");
+
+    internal void UpdateSuperRes()
+    {
+        lock (lockDevice)
         {
-            if (enabled)
-                fixed (SuperResNvidia* ptr = &SuperResEnabledNvidia)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
+            if (vc == null)
+                return;
+
+            if (!Config.Video.SuperResolution)
+                DisableSuperRes();
             else
-                fixed (SuperResNvidia* ptr = &SuperResDisabledNvidia)
-                    vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
-        } catch (Exception e) { Log.Error($"UpdateNvidiaSuperRes() failed: {e.Message}"); } // Never fails?*
+            {
+                var viewport = GetViewport;
+                if (viewport.Width > VisibleWidth && viewport.Height > VisibleHeight)
+                    EnableSuperRes();
+                else
+                    DisableSuperRes();
+            }
+        }
     }
 
-    internal unsafe void UpdateSuperResIntel(bool enabled)
+    void EnableSuperRes()
     {
-        if (vc == null)
+        if (SuperResolution)
             return;
 
-        try
-        {
-            IntPtr          paramPtr    = Marshal.AllocHGlobal(sizeof(uint));
-            SuperResIntel   intel       = new() { param = paramPtr };
-            GCHandle        handle      = GCHandle.Alloc(intel, GCHandleType.Pinned);
-            
-            intel.function = IntelFunction.kIntelVpeFnVersion;
-            Marshal.WriteInt32(paramPtr, 3); // kIntelVpeVersion3
-            vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+        SuperResolution = true;
+        RaiseUI(nameof(SuperResolution));
 
-            intel.function = IntelFunction.kIntelVpeFnMode;
-            Marshal.WriteInt32(paramPtr, enabled ? 1 : 0); // kIntelVpeModePreproc : kIntelVpeModeNone
-            vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
-
-            intel.function = IntelFunction.kIntelVpeFnScaling;
-            Marshal.WriteInt32(paramPtr, enabled ? 2 : 0); // kIntelVpeScalingSuperResolution : kIntelVpeScalingDefault
-            vc.VideoProcessorSetStreamExtension(vp, 0,  GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
-
-            handle.Free();
-            Marshal.FreeHGlobal(paramPtr);
-        } catch (Exception e) { Log.Error($"UpdateIntelSuperRes() failed: {e.Message}"); } // Never fails?*
+        if (GPUAdapter.Vendor == GPUVendor.Nvidia)
+            fixed (SuperResNvidia* ptr = &SuperResEnabledNvidia)
+                vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
+        else if (GPUAdapter.Vendor == GPUVendor.Intel)
+            UpdateSuperResIntel(true);
     }
+
+    void DisableSuperRes()
+    {
+        if (!SuperResolution)
+            return;
+
+        SuperResolution = false;
+        RaiseUI(nameof(SuperResolution));
+
+        if (GPUAdapter.Vendor == GPUVendor.Nvidia)
+            fixed (SuperResNvidia* ptr = &SuperResDisabledNvidia)
+                vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
+        else if (GPUAdapter.Vendor == GPUVendor.Intel)
+            UpdateSuperResIntel(false);
+    }
+
+    void UpdateSuperResIntel(bool enabled)
+    {
+        IntPtr          paramPtr    = Marshal.AllocHGlobal(sizeof(uint));
+        SuperResIntel   intel       = new() { param = paramPtr };
+        GCHandle        handle      = GCHandle.Alloc(intel, GCHandleType.Pinned);
+
+        intel.function = IntelFunction.kIntelVpeFnVersion;
+        Marshal.WriteInt32(paramPtr, 3); // kIntelVpeVersion3
+        vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+        intel.function = IntelFunction.kIntelVpeFnMode;
+        Marshal.WriteInt32(paramPtr, enabled ? 1 : 0); // kIntelVpeModePreproc : kIntelVpeModeNone
+        vc.VideoProcessorSetOutputExtension(vp,     GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+        intel.function = IntelFunction.kIntelVpeFnScaling;
+        Marshal.WriteInt32(paramPtr, enabled ? 2 : 0); // kIntelVpeScalingSuperResolution : kIntelVpeScalingDefault
+        vc.VideoProcessorSetStreamExtension(vp, 0,  GUID_SUPERRES_INTEL, (uint)sizeof(SuperResIntel), handle.AddrOfPinnedObject());
+
+        handle.Free();
+        Marshal.FreeHGlobal(paramPtr);
+    }
+    #endregion
 }
 
 internal class VideoProcessorCapsCache

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -304,7 +304,7 @@ unsafe public partial class Renderer
         var fieldType = Config.Video.DeInterlace == DeInterlace.Auto ? VideoStream.FieldOrder : (VideoFrameFormat)Config.Video.DeInterlace;
 
         if (VideoDecoder.VideoAccelerated && VideoStream.ColorSpace != ColorSpace.Bt2020 && vc != null && (
-                Config.Video.VideoProcessor == VideoProcessors.D3D11 ||
+                Config.Video.VideoProcessor != VideoProcessors.Flyleaf ||
                 Config.Video.SuperResolutionNvidia || Config.Video.SuperResolutionIntel ||
                 (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)))
         {
@@ -527,6 +527,10 @@ unsafe public partial class Renderer
         Present();
     }
 
+    /* TODO (Super Resolution)
+     * 1) Combine both in one (check vendor)
+     * 2) It will be enabled based on output window and based on viewport's size (enable/disable manually when actually needed)
+     */
     internal void UpdateSuperResNvidia(bool enabled)
     {
         if (vc == null)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.cs
@@ -15,15 +15,7 @@ using ID3D11Device = Vortice.Direct3D11.ID3D11Device;
 namespace FlyleafLib.MediaFramework.MediaRenderer;
 
 /* TODO
- * 1) Attach on every frame video output configuration so we will not have to worry for video codec change etc.
- *      this will fix also dynamic video stream change
- *      we might have issue with bufRef / ffmpeg texture array on zero copy
- *
- * 2) Use different context/video processor for off rendering so we dont have to reset pixel shaders/viewports etc (review also rtvs for extractor)
- *
- * 3) Add Crop (Left/Right/Top/Bottom) -on Source- support per pixels (easy implemantation with D3D11VP, FlyleafVP requires more research)
- *
- * 4) Improve A/V Sync
+ * Improve A/V Sync
  *
  *  a. vsync / vblack
  *  b. Present can cause a delay (based on device load), consider using more buffers for high frame rates that could minimize the delay
@@ -36,11 +28,11 @@ namespace FlyleafLib.MediaFramework.MediaRenderer;
 
 public partial class Renderer : NotifyPropertyChanged, IDisposable
 {
-    public Config           Config          { get; private set;}
+    public Config           Config          { get; private set; }
     public int              ControlWidth    { get; private set; }
     public int              ControlHeight   { get; private set; }
     internal nint           ControlHandle;
-
+    
     internal Action<IDXGISwapChain2>
                             SwapChainWinUIClbk;
 
@@ -60,6 +52,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     public uint             VisibleWidth    { get; private set; }
     public uint             VisibleHeight   { get; private set; }
     public AspectRatio      DAR             { get; set; }
+    public double           CurRatio        => curRatio;
     double curRatio, keepRatio, fillRatio;
     CropRect cropRect; // + User's Cropping
     uint textWidth, textHeight; // Padded (Codec/Texture)
@@ -104,7 +97,7 @@ public partial class Renderer : NotifyPropertyChanged, IDisposable
     public uint             Rotation        { get => _RotationAngle;            set => UpdateRotation(value); }
     uint _RotationAngle;
     VideoProcessorRotation _d3d11vpRotation  = VideoProcessorRotation.Identity;
-    bool rotationLinesize; // if negative should be vertically flipped
+    bool hasLinesizeVFlip; // if negative should be vertically flipped
 
     public bool             HFlip           { get => _HFlip;                    set { _HFlip = value; UpdateRotation(_RotationAngle); } }
     bool _HFlip;

--- a/FlyleafLib/MediaPlayer/Commands.cs
+++ b/FlyleafLib/MediaPlayer/Commands.cs
@@ -356,8 +356,8 @@ public class Commands
             player.OpenAsync((PlaylistItem)input);
         else if (input is ExternalStream)
             player.OpenAsync((ExternalStream)input);
-        else if (input is System.IO.Stream)
-            player.OpenAsync((System.IO.Stream)input);
+        else if (input is Stream)
+            player.OpenAsync((Stream)input);
         else
             player.OpenAsync(input.ToString());
     }

--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -183,17 +183,17 @@ unsafe partial class Player
 
             if (CanInfo) Log.Info($"Opening {url_iostream}");
 
-            Initialize(Status.Opening);
+            Initialize(Status.Opening, false); // TBR: (false) Avoid initializing the decoder twice (might cause issues)
             var args2 = decoder.Open(url_iostream, defaultPlaylistItem, defaultVideo, defaultAudio, defaultSubtitles);
 
-            args.Url = args2.Url;
-            args.IOStream = args2.IOStream;
-            args.Error = args2.Error;
+            args.Url        = args2.Url;
+            args.IOStream   = args2.IOStream;
+            args.Error      = args2.Error;
 
             if (!args.Success)
             {
-                status = Status.Failed;
-                lastError = args.Error;
+                status      = Status.Failed;
+                lastError   = args.Error;
             }
             else if (CanPlay)
             {
@@ -595,6 +595,8 @@ unsafe partial class Player
     /// <returns></returns>
     public StreamOpenedArgs Open(StreamBase stream, bool resync = true, bool defaultAudio = true)
     {
+        // TBR: There is no logic of Initiliaze (at least as a switch?*) or close of the current stream
+
         StreamOpenedArgs args = new();
 
         try

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -540,8 +540,8 @@ unsafe partial class Player
                 {
                     Audio.AddSamples(aFrame);
 
-                    // Audio Desync - Large Buffer | ASampleBytes (S16 * 2 Channels = 4) * TimeBase * 2 -frames duration-
-                    if (Audio.GetBufferedDuration() > Math.Max(50 * 10000, (aFrame.dataLen / 4) * Audio.Timebase * 2))
+                    // Audio Desync - Large Buffer | ASampleBytes (S16 * 2 Channels = 4) * TimeBase * 2 -frames duration- (TBR: Related to min/max samples on AudioDecoder filters - 2frames * 70ms max)
+                    if (Audio.GetBufferedDuration() > 140 * 10000) //Math.Max(140 * 10000, (aFrame.dataLen / 4) * Audio.Timebase * 2))
                     {
                         if (CanDebug)
                             Log.Debug($"Audio desynced by {(int)(audioBufferedDuration / 10000)}ms, clearing buffers");

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -601,6 +601,8 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     }
     private void Reset()
     {
+        // TODO: Consider partial reset on opening and full reset in case of open failed (otherwise let it overwrite)
+
         ResetMe();
         Video.Reset();
         Audio.Reset();

--- a/FlyleafLib/Themes/Generic.xaml
+++ b/FlyleafLib/Themes/Generic.xaml
@@ -22,7 +22,6 @@
 
         <Setter Property="AttachedResize" Value="None"/>
         <Setter Property="DetachedResize" Value="Surface"/>
-        <Setter Property="ResizeSensitivity" Value="6"/>
         <Setter Property="KeepRatioOnResize" Value="False"/>
 
         <Setter Property="AttachedDragMove" Value="SurfaceOwner"/>

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -57,6 +57,22 @@ public static partial class Utils
         [DllImport("user32.dll")]
         public static extern int ShowCursor(bool bShow);
 
+        [DllImport("user32.dll")]
+        public static extern int GetCursorPos(out POINT lpPoint);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT : IEquatable<POINT>
+        {
+            public int X;
+            public int Y;
+
+            public static bool operator ==(POINT left, POINT right) => left.X == right.X && left.Y == right.Y;
+            public static bool operator !=(POINT left, POINT right) => !(left == right);
+            public override bool Equals(object obj)                 => obj is POINT other && this == other;
+            public bool Equals(POINT other)                         => this == other;
+            public override int GetHashCode()                       => HashCode.Combine(X, Y);
+        }
+
         [DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
         public static extern uint TimeBeginPeriod(uint uMilliseconds);
 
@@ -85,6 +101,9 @@ public static partial class Utils
 
         [DllImport("user32.dll")]
         public static extern bool GetWindowRect(IntPtr hwnd, ref RECT rectangle);
+
+        [DllImport("user32.dll")]
+        public static extern bool GetClientRect(IntPtr hwnd, ref RECT rectangle);
 
         [DllImport("user32.dll")]
         public static extern bool GetWindowInfo(IntPtr hwnd, ref WINDOWINFO pwi);
@@ -122,12 +141,13 @@ public static partial class Utils
                 => cbSize = (UInt32)Marshal.SizeOf(typeof(WINDOWINFO));
 
         }
+        [StructLayout(LayoutKind.Sequential)]
         public struct RECT
         {
-            public int Left     { get; set; }
-            public int Top      { get; set; }
-            public int Right    { get; set; }
-            public int Bottom   { get; set; }
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
         }
 
         [Flags]

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -88,14 +88,8 @@
                         <TextBlock
                             Width="180"
                             Text="Super Resolution" />
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Nvidia" VerticalAlignment="Center" Margin="0 0 6 0" />
-                            <ToggleButton
-                                IsChecked="{Binding FL.PlayerConfig.Video.SuperResolutionNvidia}" />
-                            <TextBlock Text="Intel" VerticalAlignment="Center" Margin="2 0 6 0" />
-                            <ToggleButton
-                                IsChecked="{Binding FL.PlayerConfig.Video.SuperResolutionIntel}" />
-                        </StackPanel>
+                        <ToggleButton
+                            IsChecked="{Binding FL.PlayerConfig.Video.SuperResolution}" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/LLPlayer/Services/FlyleafLoader.cs
+++ b/LLPlayer/Services/FlyleafLoader.cs
@@ -123,7 +123,6 @@ public static class FlyleafLoader
         Config config = new();
         config.Demuxer.FormatOptToUnderlying =
             true; // Mainly for HLS to pass the original query which might includes session keys
-        config.Audio.FiltersEnabled = true; // To allow embedded atempo filter for speed
         config.Video.GPUAdapter = ""; // Set it empty so it will include it when we save it
         config.Subtitles.SearchLocal = true;
         config.Subtitles.TranslateTargetLanguage = Language.Get(Utils.OriginalCulture).ToTargetLanguage() ?? TargetLanguage.EnglishAmerican; // try to set native language


### PR DESCRIPTION
Update FlyleafLib v3.8.14 from v3.8.13

## Changelog
- Renderer: Fixes an issue with alpha channel (wrongly was blending RGB(0), also tries to support more formats)
- Renderer: Fixes an issue with negative linesize (use VFlip instead of 180 rotation)
- Renderer: Fixes an issue with viewport that could cause a half pixel off
- Renderer: Disables rendering when window is minimized
- Renderer.D3D11VP: Fixes a critical issue when window is minimized
- Renderer.D3D11VP: Adds Bitmap Subtitles support
- Renderer.D3D11VP: Adds Custom 2D Graphics support
- Renderer.D3D11VP: Improves Super Resolution (enable only when actually required)
- Player.Audio: Fixes an issue with Audio that it could cause crackling
- VideoDecoder: Handles broken formats with no key frame after key packet
- FlyleafHost.Wpf: Performance and Stability Improvements (DPI/Resize/Ratio)
- PlayerDebug.Wpf: Adds Super Resolution
- FlyleafME.Settings.Video: Merges Nvidia/Intel Super Resolution

[Breaking Changes]
- Config.Audio: Defaults FiltersEnabled to true (stable enough now)
- Config.Video: SuperResolutionNvidia and SuperResolutionIntel renamed/merged to SuperResolution
- GPUAdapter: Changes Vendor from string to GPUVendor enum
- Renderer: Defaults VideoProcessor to D3D11 (less power consumption)
- FlyleafHost.Wpf: Changes Is* (readonlys and ResizeSensitivity) Dependency Properties to Simple Properties


New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/a1126fdb6f7ecfe049748b596d5a1b6bd45e75d6...57fd5f25534c28d88ca02a1dd207b9c9add9e0c5