### PR TITLE
Update FlyleafLib v3.9

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -499,14 +499,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     public static readonly DependencyProperty PlayerProperty =
         DependencyProperty.Register(nameof(Player), typeof(Player), _flType, new(null, OnPlayerChanged));
 
-    public Player ReplicaPlayer
-    {
-        get => (Player)GetValue(ReplicaPlayerProperty);
-        set => SetValue(ReplicaPlayerProperty, value);
-    }
-    public static readonly DependencyProperty ReplicaPlayerProperty =
-        DependencyProperty.Register(nameof(ReplicaPlayer), typeof(Player), _flType, new(null, OnReplicaPlayerChanged));
-
     public ControlTemplate OverlayTemplate
     {
         get => (ControlTemplate)GetValue(OverlayTemplateProperty);
@@ -626,17 +618,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             return;
 
         host.SetPlayer((Player)e.OldValue);
-    }
-    private static void OnReplicaPlayerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        if (isDesignMode)
-            return;
-
-        FlyleafHost host = d as FlyleafHost;
-        if (host.Disposed)
-            return;
-
-        host.SetReplicaPlayer((Player)e.OldValue);
     }
     private static void OnIsFullScreenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -1521,21 +1502,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     #endregion
 
     #region Methods
-    public virtual void SetReplicaPlayer(Player oldPlayer)
-    {
-        if (oldPlayer != null)
-        {
-            oldPlayer.renderer.SetChildHandle(IntPtr.Zero);
-        }
-
-        if (ReplicaPlayer == null)
-            return;
-
-        if (Surface != null)
-            ReplicaPlayer.renderer.SetChildHandle(SurfaceHandle);
-
-        Player_RatioChanged(ReplicaPlayer.renderer.CurRatio);
-    }
     public virtual void SetPlayer(Player oldPlayer)
     {
         // De-assign old Player's Handle/FlyleafHost
@@ -1623,9 +1589,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
         if (Player != null)
             Player.VideoDecoder.CreateSwapChain(SurfaceHandle);
-
-        if (ReplicaPlayer != null)
-            ReplicaPlayer.renderer.SetChildHandle(SurfaceHandle);
 
         Surface.IsVisibleChanged
                             += Surface_IsVisibleChanged;
@@ -2070,7 +2033,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
             // Disposes SwapChain Only
             Player          = null;
-            ReplicaPlayer   = null;
             Disposed        = true;
 
             DataContextChanged  -= Host_DataContextChanged;

--- a/FlyleafLib/Controls/WPF/PlayerDebug.xaml
+++ b/FlyleafLib/Controls/WPF/PlayerDebug.xaml
@@ -338,12 +338,12 @@
 
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource TextInfo}" Text="Frames Displayed"/>
-                        <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.FramesDisplayed}"/>
+                        <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.FramesDisplayed, StringFormat={}{0:N0}}"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Style="{StaticResource TextInfo}" Text="Frames Dropped"/>
-                        <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.FramesDropped}"/>
+                        <TextBlock Style="{StaticResource TextValue}" Text="{Binding Player.Video.FramesDropped, StringFormat={}{0:N0}}"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -253,11 +253,6 @@ public class Config : NotifyPropertyChanged
                         KeyBindings                 { get; set; } = new KeysConfig();
 
         /// <summary>
-        /// Fps while the player is not playing
-        /// </summary>
-        public double   IdleFps                     { get; set; } = 60.0;
-
-        /// <summary>
         /// Zero Latency forces playback at the very last frame received (Live Video Only)
         /// </summary>
         public bool     ZeroLatency                 { get => _ZeroLatency; set { Set(ref _ZeroLatency, value); if (config != null) config.Decoder.LowDelay = value; if (player != null && player.IsPlaying) { player.Pause(); player.Play(); } } }
@@ -355,7 +350,8 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Refreshes CurTime in UI on every frame (can cause performance issues)
         /// </summary>
-        public bool     UICurTimePerFrame           { get; set; } = false;
+        public UIRefreshType
+                        UICurTime                   { get; set; } = UIRefreshType.PerFrameSecond;
 
         /// <summary>
         /// The upper limit of the volume amplifier
@@ -614,6 +610,7 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public int              MaxVideoFrames  { get => _MaxVideoFrames; set { if (Set(ref _MaxVideoFrames, value)) { player?.RefreshMaxVideoFrames(); } } }
         int _MaxVideoFrames = 4;
+        internal void SetMaxVideoFrames(int maxVideoFrames) { _MaxVideoFrames = maxVideoFrames; RaiseUI(nameof(MaxVideoFrames)); } // can be updated by video decoder if fails to allocate them
 
         /// <summary>
         /// Maximum audio frames to be decoded and processed for playback
@@ -782,14 +779,7 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Whether Vsync should be enabled (0: Disabled, 1: Enabled)
         /// </summary>
-        public uint             VSync                       { get; set; }
-
-        /// <summary>
-        /// Swap chain's present flags (mainly for waitable -None- or non-waitable -DoNotWait) (default: non-waitable)<br/>
-        /// Non-waitable swap chain will reduce re-buffering and audio/video desyncs
-        /// </summary>
-        public Vortice.DXGI.PresentFlags
-                                PresentFlags                { get; set; } = Vortice.DXGI.PresentFlags.DoNotWait;
+        public uint             VSync                       { get; set; } = 1;
 
         /// <summary>
         /// Sets DeInterlace (D3D11VP only)
@@ -806,15 +796,31 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// The HDR to SDR method that will be used by the pixel shader
         /// </summary>
-        public unsafe HDRtoSDRMethod
-                                HDRtoSDRMethod              { get => _HDRtoSDRMethod;   set { if (Set(ref _HDRtoSDRMethod, value))  player?.renderer?.UpdateHDRtoSDR(); }}
+        public HDRtoSDRMethod   HDRtoSDRMethod              { get => _HDRtoSDRMethod;   set { if (Set(ref _HDRtoSDRMethod, value))  player?.renderer?.UpdateHDRtoSDR(); } }
         HDRtoSDRMethod _HDRtoSDRMethod = HDRtoSDRMethod.Hable;
 
-        /// <summary>
-        /// SDR Display Peak Luminance (will be used for HDR to SDR conversion)
+       /// <summary>
+        /// SDR Display Peak Luminance - tonemap for HDR to SDR (based on Auto/Custom)
         /// </summary>
-        public unsafe float     SDRDisplayNits              { get => _SDRDisplayNits;   set { if (Set(ref _SDRDisplayNits, value))  player?.renderer?.UpdateHDRtoSDR(); } }
-        float _SDRDisplayNits = Engine.Video != null ? Engine.Video.RecommendedLuminance : 200;
+        [JsonIgnore]
+        public float SDRDisplayNits
+        {
+            get => SDRDisplayNitsCustom == 0 ? (SDRDisplayNitsAuto != 0 ? SDRDisplayNitsAuto : 200) : SDRDisplayNitsCustom;
+            set => SDRDisplayNitsCustom = value;
+        }
+
+        /// <summary>
+        /// SDR Display Peak Luminance - tonemap for HDR to SDR (Recommended)
+        /// </summary>
+        [JsonIgnore]
+        public float            SDRDisplayNitsAuto          { get => _SDRDisplayNitsAuto;   set { if (Set(ref _SDRDisplayNitsAuto, value) && _SDRDisplayNitsCustom == 0) { player?.renderer?.UpdateHDRtoSDR(); RaiseUI(nameof(SDRDisplayNits)); } } }
+        float _SDRDisplayNitsAuto;
+
+        /// <summary>
+        /// SDR Display Peak Luminance - tonemap for HDR to SDR (Custom)
+        /// </summary>
+        public float            SDRDisplayNitsCustom        { get => _SDRDisplayNitsCustom; set { if (Set(ref _SDRDisplayNitsCustom, value)) { player?.renderer?.UpdateHDRtoSDR(); RaiseUI(nameof(SDRDisplayNits)); } } }
+        float _SDRDisplayNitsCustom;
 
         /// <summary>
         /// Whether the renderer will use 10-bit swap chaing or 8-bit output
@@ -832,7 +838,7 @@ public class Config : NotifyPropertyChanged
         /// (TBR: causes slightly different colors with D3D11VP)
         /// </para>
         /// </summary>
-        public bool             SwapForceR8G8B8A8           { get; set; }
+        public bool             SwapForceR8G8B8A8           { get; set; } // TBR: Causes issues with NVidia Super Resolution (with some formats)
 
         /// <summary>
         /// Enables custom Direct2D drawing over playback frames
@@ -1416,16 +1422,11 @@ public class EngineConfig
     public string   PluginsPath             { get; set; } = "Plugins";
 
     /// <summary>
-    /// Updates Player.CurTime when the second changes otherwise on every UIRefreshInterval
-    /// </summary>
-    public bool     UICurTimePerSecond      { get; set; } = true;
-
-    /// <summary>
     /// <para>Activates Master Thread to monitor all the players and perform the required updates</para>
     /// <para>Required for Activity Mode, Stats &amp; Buffered Duration on Pause</para>
     /// </summary>
     public bool     UIRefresh               { get => _UIRefresh; set { _UIRefresh = value; if (value && Engine.IsLoaded) Engine.StartThread(); } }
-    static bool _UIRefresh;
+    static bool _UIRefresh = true;
 
     /// <summary>
     /// <para>How often should update the UI in ms (low values can cause performance issues)</para>
@@ -1467,4 +1468,12 @@ public class EngineConfig
 
         File.WriteAllText(path, JsonSerializer.Serialize(this, jsonOptions));
     }
+}
+
+public enum UIRefreshType
+{
+    PerFrame,
+    PerFrameSecond,
+    PerUIRefreshInterval,
+    PerUISecond
 }

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -640,7 +640,7 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public bool             AllowProfileMismatch
                                                 { get => _AllowProfileMismatch; set => SetUI(ref _AllowProfileMismatch, value); }
-        bool _AllowProfileMismatch;
+        bool _AllowProfileMismatch = true;
 
         /// <summary>
         /// Allows corrupted frames (Parses AV_CODEC_FLAG_OUTPUT_CORRUPT to AVCodecContext)
@@ -796,6 +796,12 @@ public class Config : NotifyPropertyChanged
         /// </summary>
         public DeInterlace      DeInterlace                 { get => _DeInterlace;      set { if (Set(ref _DeInterlace, value))     player?.renderer?.UpdateDeinterlace(); } }
         DeInterlace _DeInterlace = DeInterlace.Auto;
+
+        /// <summary>
+        /// Whether to use double rate (Bob) for DeInterlace instead normal (Weave/Blend)
+        /// </summary>
+        public bool             DoubleRate                  { get => _DoubleRate;       set => Set(ref _DoubleRate, value); }
+        bool _DoubleRate = true;
 
         /// <summary>
         /// The HDR to SDR method that will be used by the pixel shader

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -21,12 +21,6 @@ public class VideoEngine
     public Dictionary<long, GPUAdapter>
                             GPUAdapters         { get; private set; }
 
-    /// <summary>
-    /// List of GPU Outputs from default GPU Adapter (Note: will no be updated on screen connect/disconnect)
-    /// </summary>
-    public List<GPUOutput>  Screens             { get; private set; } = [];
-    public float            RecommendedLuminance{ get; set; }
-
     internal IDXGIFactory2  Factory;
 
     private readonly object lockCapDevices = new();
@@ -58,96 +52,11 @@ public class VideoEngine
 
         string dump = "";
 
-        for (uint i=0; Factory.EnumAdapters1(i, out var adapter).Success; i++)
+        for (uint i = 0; Factory.EnumAdapters(i, out var adapter).Success; i++)
         {
-            bool hasOutput = false;
-
-            List<GPUOutput> outputs = [];
-
-            int maxHeight = 0;
-            for (uint o = 0; adapter.EnumOutputs(o, out var output).Success; o++)
-            {
-                IDXGIOutput6 output6 = null;
-                GPUOutput gpout;
-
-                if (Environment.OSVersion.Version.Major >= 10)
-                    try { output6 = output.QueryInterface<IDXGIOutput6>(); } catch { }
-
-                if (output6 != null)
-                {
-                    var outdesc = output6.Description1;
-
-                    gpout = new()
-                    {
-                        Id          = GPUOutput.GPUOutputIdGenerator++,
-                        DeviceName  = outdesc.DeviceName,
-                        Left        = outdesc.DesktopCoordinates.Left,
-                        Top         = outdesc.DesktopCoordinates.Top,
-                        Right       = outdesc.DesktopCoordinates.Right,
-                        Bottom      = outdesc.DesktopCoordinates.Bottom,
-                        IsAttached  = outdesc.AttachedToDesktop,
-                        Rotation    = (int)outdesc.Rotation,
-                        MaxLuminance= outdesc.MaxLuminance
-                    };
-
-                    output6.Dispose();
-                }
-                else
-                {
-                    var outdesc = output.Description;
-
-                    gpout = new()
-                    {
-                        Id          = GPUOutput.GPUOutputIdGenerator++,
-                        DeviceName  = outdesc.DeviceName,
-                        Left        = outdesc.DesktopCoordinates.Left,
-                        Top         = outdesc.DesktopCoordinates.Top,
-                        Right       = outdesc.DesktopCoordinates.Right,
-                        Bottom      = outdesc.DesktopCoordinates.Bottom,
-                        IsAttached  = outdesc.AttachedToDesktop,
-                        Rotation    = (int)outdesc.Rotation
-                    };
-                }
-
-                if (maxHeight < gpout.Height)
-                    maxHeight = gpout.Height;
-
-                outputs.Add(gpout);
-
-                if (gpout.IsAttached)
-                {
-                    hasOutput = true;
-                    if (gpout.MaxLuminance > 0 && (RecommendedLuminance == 0 || gpout.MaxLuminance < RecommendedLuminance))
-                        RecommendedLuminance = gpout.MaxLuminance;
-                }
-
-                output.Dispose();
-            }
-
-            if (RecommendedLuminance == 0)
-                RecommendedLuminance = 200;
-
-            if (Screens.Count == 0 && outputs.Count > 0)
-                Screens = outputs;
-
-            var adapterdesc = adapter.Description1;
-            adapters[adapterdesc.Luid] = new GPUAdapter()
-            {
-                SystemMemory    = adapterdesc.DedicatedSystemMemory.Value,
-                VideoMemory     = adapterdesc.DedicatedVideoMemory.Value,
-                SharedMemory    = adapterdesc.SharedSystemMemory.Value,
-                Vendor          = (GPUVendor)adapterdesc.VendorId,
-                Description     = adapterdesc.Description,
-                Id              = adapterdesc.DeviceId,
-                Luid            = adapterdesc.Luid,
-                MaxHeight       = maxHeight,
-                HasOutput       = hasOutput,
-                Outputs         = outputs
-            };
-
-            dump += $"[#{i+1}] {adapters[adapterdesc.Luid]}\r\n";
-
-            adapter.Dispose();
+            var desc = adapter.Description;
+            adapters[desc.Luid] = GetGPUAdapter(adapter, desc);
+            dump += $"[#{i+1}] {adapters[desc.Luid]}\r\n";
         }
 
         Engine.Log.Info($"GPU Adapters\r\n{dump}");
@@ -155,15 +64,78 @@ public class VideoEngine
         return adapters;
     }
 
-    // Use instead System.Windows.Forms.Screen.FromPoint
-    public GPUOutput GetScreenFromPosition(int top, int left)
-    {
-        foreach(var screen in Screens)
+    public GPUAdapter GetGPUAdapter(IDXGIAdapter adapter, AdapterDescription desc)
+        => new()
         {
-            if (top >= screen.Top && top <= screen.Bottom && left >= screen.Left && left <= screen.Right)
-                return screen;
+            SystemMemory    = desc.DedicatedSystemMemory.Value,
+            VideoMemory     = desc.DedicatedVideoMemory.Value,
+            SharedMemory    = desc.SharedSystemMemory.Value,
+            Vendor          = (GPUVendor)desc.VendorId,
+            Description     = desc.Description,
+            Id              = desc.DeviceId,
+            Luid            = desc.Luid,
+            dxgiAdapter     = adapter
+        };
+
+    public List<GPUOutput> GetGPUOutputs(IDXGIAdapter adapter)
+    {
+        List<GPUOutput> outputs = [];
+        if (adapter == null)
+            return outputs;
+
+        for (uint i = 0; adapter.EnumOutputs(i, out var output).Success; i++)
+        {
+            IDXGIOutput6 output6 = null;
+            GPUOutput gpuOutput;
+
+            if (Environment.OSVersion.Version.Major >= 10)
+                output6 = output.QueryInterfaceOrNull<IDXGIOutput6>();
+
+            if (output6 != null)
+            {
+                var outdesc = output6.Description1;
+
+                gpuOutput = new()
+                {
+                    Hwnd        = outdesc.Monitor,
+                    DeviceName  = outdesc.DeviceName,
+                    Left        = outdesc.DesktopCoordinates.Left,
+                    Top         = outdesc.DesktopCoordinates.Top,
+                    Right       = outdesc.DesktopCoordinates.Right,
+                    Bottom      = outdesc.DesktopCoordinates.Bottom,
+                    IsAttached  = outdesc.AttachedToDesktop,
+                    Rotation    = outdesc.Rotation,
+                    MaxLuminance= outdesc.MaxLuminance
+                };
+
+                output6.Dispose();
+            }
+            else
+            {
+                var outdesc = output.Description;
+
+                gpuOutput = new()
+                {
+                    Hwnd        = outdesc.Monitor,
+                    DeviceName  = outdesc.DeviceName,
+                    Left        = outdesc.DesktopCoordinates.Left,
+                    Top         = outdesc.DesktopCoordinates.Top,
+                    Right       = outdesc.DesktopCoordinates.Right,
+                    Bottom      = outdesc.DesktopCoordinates.Bottom,
+                    IsAttached  = outdesc.AttachedToDesktop,
+                    Rotation    = outdesc.Rotation,
+                    MaxLuminance= 200
+                };
+            }
+
+            // Currently not used
+            //var devMode = DEVMODE.Get(gpuOutput.DeviceName);
+            //gpuOutput.RefreshRate = devMode.dmDisplayFrequency;
+
+            outputs.Add(gpuOutput);
+            output.Dispose();
         }
 
-        return null;
+        return outputs;
     }
 }

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -54,6 +54,7 @@ public static class Engine
     static object   lockEngine = new();
     static bool     isLoading;
     static int      timePeriod;
+    static int      threadExecutionState; // ES_CONTINUOUS
 
     /// <summary>
     /// Initializes Flyleaf's Engine (Must be called from UI thread)
@@ -68,7 +69,7 @@ public static class Engine
     public static void StartAsync(EngineConfig config = null) => StartInternal(config, true);
 
     /// <summary>
-    /// Requests timeBeginPeriod(1) - You should call TimeEndPeriod1 when not required anymore
+    /// Requests timeBeginPeriod(1)
     /// </summary>
     public static void TimeBeginPeriod1()
     {
@@ -78,8 +79,11 @@ public static class Engine
 
             if (timePeriod == 1)
             {
+                #if DEBUG
                 Log.Trace("timeBeginPeriod(1)");
-                NativeMethods.TimeBeginPeriod(1);
+                #endif
+
+                _ = NativeMethods.TimeBeginPeriod(1);
             }
         }
     }
@@ -95,8 +99,51 @@ public static class Engine
 
             if (timePeriod == 0)
             {
+                #if DEBUG
                 Log.Trace("timeEndPeriod(1)");
-                NativeMethods.TimeEndPeriod(1);
+                #endif
+
+                _ = NativeMethods.TimeEndPeriod(1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Requests SetThreadExecutionState
+    /// </summary>
+    public static void ThreadExecutionStateBegin()
+    {
+        lock (lockEngine)
+        {
+            threadExecutionState++;
+
+            if (threadExecutionState == 1)
+            {
+                #if DEBUG
+                Log.Trace("ThreadExecutionStateBegin");
+                #endif
+
+                _ = NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS | NativeMethods.EXECUTION_STATE.ES_SYSTEM_REQUIRED | NativeMethods.EXECUTION_STATE.ES_DISPLAY_REQUIRED);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stops previously requested SetThreadExecutionState
+    /// </summary>
+    public static void ThreadExecutionStateEnd()
+    {
+        lock (lockEngine)
+        {
+            threadExecutionState--;
+
+            if (threadExecutionState == 0)
+            {
+                #if DEBUG
+                Log.Trace("ThreadExecutionStateEnd");
+                #endif
+
+                _ = NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS);
             }
         }
     }
@@ -212,6 +259,7 @@ public static class Engine
     }
     internal static void MasterThread()
     {
+        // TBR: Auto Stop/Start instead of UIRefresh config (based on current Players status/mode/bufferduration/stats etc)
         Log.Info("Thread started");
 
         int curLoop     = 0;
@@ -244,26 +292,31 @@ public static class Engine
                         player.Activity.RefreshMode();
 
                         /* Every Second */
-                        if (curLoop == secondLoops)
+                        if (curLoop == secondLoops) // Calculations here to be second accurate
                         {
                             if (player.Config.Player.Stats)
                             {
-                                var curStats = player.stats;
+                                var curStats        = player.stats;
                                 // TODO: L: including Subtitles bytes?
                                 long curTotalBytes  = player.VideoDemuxer.TotalBytes + player.AudioDemuxer.TotalBytes;
                                 long curVideoBytes  = player.VideoDemuxer.VideoPackets.Bytes + player.AudioDemuxer.VideoPackets.Bytes;
                                 long curAudioBytes  = player.VideoDemuxer.AudioPackets.Bytes + player.AudioDemuxer.AudioPackets.Bytes;
 
-                                player.bitRate      = (curTotalBytes - curStats.TotalBytes) * 8 / 1000.0;
-                                player.Video.bitRate= (curVideoBytes - curStats.VideoBytes) * 8 / 1000.0;
-                                player.Audio.bitRate= (curAudioBytes - curStats.AudioBytes) * 8 / 1000.0;
+                                player.bitRate      = Math.Max(curTotalBytes - curStats.TotalBytes, 0) * 8 / 1000.0;
+                                player.Video.bitRate= Math.Max(curVideoBytes - curStats.VideoBytes, 0) * 8 / 1000.0;
+                                player.Audio.bitRate= Math.Max(curAudioBytes - curStats.AudioBytes, 0) * 8 / 1000.0;
 
                                 curStats.TotalBytes = curTotalBytes;
                                 curStats.VideoBytes = curVideoBytes;
                                 curStats.AudioBytes = curAudioBytes;
 
-                                player.Video.fpsCurrent = (player.Video.FramesDisplayed - curStats.FramesDisplayed) / curSecond;
-                                curStats.FramesDisplayed = player.Video.FramesDisplayed;
+                                // TBR: Let Fps enable even for Idle
+                                //if (player.status == Status.Playing)
+                                //{
+                                var presentCount = player.renderer.GetFrameStatistics().PresentCount; // might cause a delay, keep it last
+                                player.Video.fpsCurrent  = (presentCount - curStats.FramesDisplayed) / curSecond;
+                                curStats.FramesDisplayed = presentCount;
+                                //}
                             }
                         }
                     }
@@ -277,39 +330,43 @@ public static class Engine
                     {
                         foreach (var player in Players)
                         {
+                            var isPlaying = player.status == Status.Playing;
                             /* Every UIRefreshInterval */
+                            var config = player.Config.Player;
 
                             // Activity Mode Refresh & Hide Mouse Cursor (FullScreen only)
                             if (player.Activity.mode != player.Activity._Mode)
                                 player.Activity.SetMode();
 
-                            // CurTime / Buffered Duration (+Duration for HLS)
-                            if (!Config.UICurTimePerSecond)
-                                player.UpdateCurTime();
-                            else if (player.Status == Status.Paused)
-                            {
-                                if (player.MainDemuxer.IsRunning)
-                                    player.UpdateCurTime();
-                                else
-                                    player.UpdateBufferedDuration();
-                            }
+                            // Buffered Duration Refresh from Demuxer (TBR: RefreshType?)
+                            player.BufferedDuration = player.MainDemuxer.BufferedDuration;
+
+                            // CurTime (PerUIRefreshInterval)
+                            if (isPlaying && config.UICurTime == UIRefreshType.PerUIRefreshInterval)
+                                player.SetCurTime();
 
                             /* Every Second */
                             if (curLoop == 0)
                             {
+                                // CurTime (PerUISecond)
+                                if (config.UICurTime == UIRefreshType.PerUISecond)
+                                    player.SetCurTime();
+
                                 // Stats Refresh (BitRates / FrameDisplayed / FramesDropped / FPS)
-                                if (player.Config.Player.Stats)
+                                if (config.Stats)
                                 {
-                                    player.BitRate = player.BitRate;
-                                    player.Video.BitRate = player.Video.BitRate;
-                                    player.Audio.BitRate = player.Audio.BitRate;
+                                    player.BitRate          = player.BitRate;
+                                    player.Video.BitRate    = player.Video.BitRate;
+                                    player.Audio.BitRate    = player.Audio.BitRate;
 
-                                    player.Audio.FramesDisplayed= player.Audio.FramesDisplayed;
-                                    player.Audio.FramesDropped  = player.Audio.FramesDropped;
+                                    player.Video.FPSCurrent = player.Video.fpsCurrent;
 
-                                    player.Video.FramesDisplayed= player.Video.FramesDisplayed;
-                                    player.Video.FramesDropped  = player.Video.FramesDropped;
-                                    player.Video.FPSCurrent     = player.Video.FPSCurrent;
+                                    if (isPlaying) // Otherwise Screamers should fire the last update
+                                    {
+                                        player.Audio.FramesDisplayed= player.Audio.FramesDisplayed;
+                                        player.Audio.FramesDropped  = player.Audio.FramesDropped;
+                                        (player.Video.FramesDisplayed,player.Video.FramesDropped) = player.FramesDisplayedDropped(); // dynamic update to be closer to 'now'
+                                    }
                                 }
                             }
                         }

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -18,6 +18,8 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
+using Vortice.DXGI;
+
 namespace FlyleafLib;
 
 public enum PixelFormatType
@@ -121,30 +123,28 @@ public enum SubASREngineType
 
 public class GPUOutput
 {
-    internal static int GPUOutputIdGenerator;
-
-    public int      Id              { get; internal set; }
-    public string   DeviceName      { get; internal set; }
-    public int      Left            { get; internal set; }
-    public int      Top             { get; internal set; }
-    public int      Right           { get; internal set; }
-    public int      Bottom          { get; internal set; }
-    public int      Width           => Right- Left;
-    public int      Height          => Bottom- Top;
-    public bool     IsAttached      { get; internal set; }
-    public int      Rotation        { get; internal set; }
-    public float    MaxLuminance    { get; internal set; }
+    public nint             Hwnd            { get; internal set; }
+    public string           DeviceName      { get; internal set; }
+    public int              Left            { get; internal set; }
+    public int              Top             { get; internal set; }
+    public int              Right           { get; internal set; }
+    public int              Bottom          { get; internal set; }
+    public int              Width           => Right- Left;
+    public int              Height          => Bottom- Top;
+    public bool             IsAttached      { get; internal set; }
+    public ModeRotation     Rotation        { get; internal set; }
+    public float            MaxLuminance    { get; internal set; }
+    //public int              RefreshRate     { get; internal set; } // Currently not used
 
     public override string ToString()
     {
         int gcd = GCD(Width, Height);
-        return $"{DeviceName,-20} [Id: {Id,-4}\t, Top: {Top,-4}, Left: {Left,-4}, Width: {Width,-4}, Height: {Height,-4}, Ratio: [" + (gcd > 0 ? $"{Width/gcd}:{Height/gcd}]" : "]");
+        return $"{DeviceName,-20} [Top: {Top,-4}, Left: {Left,-4}, Width: {Width,-4}, Height: {Height,-4}, Ratio: " + (gcd > 0 ? $"{Width / gcd}:{Height / gcd}]" : "]");
     }
 }
 
 public class GPUAdapter
 {
-    public int              MaxHeight       { get; internal set; }
     public nuint            SystemMemory    { get; internal set; }
     public nuint            VideoMemory     { get; internal set; }
     public nuint            SharedMemory    { get; internal set; }
@@ -153,10 +153,12 @@ public class GPUAdapter
     public GPUVendor        Vendor          { get; internal set; }
     public string           Description     { get; internal set; }
     public long             Luid            { get; internal set; }
-    public bool             HasOutput       { get; internal set; }
-    public List<GPUOutput>  Outputs         { get; internal set; }
 
-    public override string ToString()
+    internal IDXGIAdapter   dxgiAdapter;
+
+    public List<GPUOutput>  GetGPUOutputs()    => Engine.Video.GetGPUOutputs(dxgiAdapter);
+
+    public override string  ToString()
         => (Vendor + " " + Description).PadRight(40) + $"[ID: {Id,-6}, LUID: {Luid,-6}, DVM: {GetBytesReadable(VideoMemory),-8}, DSM: {GetBytesReadable(SystemMemory),-8}, SSM: {GetBytesReadable(SharedMemory)}]";
 }
 

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.8.14</Version>
+    <Version>3.9</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.Open.cs
@@ -169,7 +169,6 @@ public partial class DecoderContext
         }
 
         ClosedAudioStream = null;
-        MainDemuxer = !VideoDemuxer.Disposed ? VideoDemuxer : AudioDemuxer;
 
         if (CanInfo) Log.Info($"[OpenAudioStream] #{(args.OldStream != null ? args.OldStream.StreamIndex.ToString() : "_")} => #{(args.Stream != null ? args.Stream.StreamIndex.ToString() : "_")}{(!args.Success ? " [Error: " + args.Error  + "]": "")}");
         OpenAudioStreamCompleted?.Invoke(this, args);
@@ -183,7 +182,6 @@ public partial class DecoderContext
         }
 
         ClosedVideoStream = null;
-        MainDemuxer = !VideoDemuxer.Disposed ? VideoDemuxer : AudioDemuxer;
 
         if (CanInfo) Log.Info($"[OpenVideoStream] #{(args.OldStream != null ? args.OldStream.StreamIndex.ToString() : "_")} => #{(args.Stream != null ? args.Stream.StreamIndex.ToString() : "_")}{(!args.Success ? " [Error: " + args.Error  + "]": "")}");
         OpenVideoStreamCompleted?.Invoke(this, args);
@@ -220,7 +218,6 @@ public partial class DecoderContext
         }
 
         ClosedAudioStream = null;
-        MainDemuxer = !VideoDemuxer.Disposed ? VideoDemuxer : AudioDemuxer;
 
         if (CanInfo) Log.Info($"[OpenExternalAudioStream] {(args.OldExtStream != null ? args.OldExtStream.Url : "None")} => {(args.ExtStream != null ? args.ExtStream.Url : "None")}{(!args.Success ? " [Error: " + args.Error  + "]": "")}");
         OpenExternalAudioStreamCompleted?.Invoke(this, args);
@@ -234,7 +231,6 @@ public partial class DecoderContext
         }
 
         ClosedVideoStream = null;
-        MainDemuxer = !VideoDemuxer.Disposed ? VideoDemuxer : AudioDemuxer;
 
         if (CanInfo) Log.Info($"[OpenExternalVideoStream] {(args.OldExtStream != null ? args.OldExtStream.Url : "None")} => {(args.ExtStream != null ? args.ExtStream.Url : "None")}{(!args.Success ? " [Error: " + args.Error  + "]": "")}");
         OpenExternalVideoStreamCompleted?.Invoke(this, args);
@@ -479,8 +475,6 @@ public partial class DecoderContext
 
             if (Config.Data.Enabled)
                 OpenSuggestedData();
-
-            MainDemuxer ??= VideoDemuxer;
 
             LoadPlaylistChapters();
 
@@ -998,11 +992,14 @@ public partial class DecoderContext
 
     private void LoadPlaylistChapters()
     {
-        if (Playlist.Selected != null && Playlist.Selected.Chapters.Count > 0 && MainDemuxer.Chapters.Count == 0)
+        if (VideoDemuxer.Disposed)
+            return;
+
+        if (Playlist.Selected != null && Playlist.Selected.Chapters.Count > 0 && VideoDemuxer.Chapters.Count == 0)
         {
             foreach (var chapter in Playlist.Selected.Chapters)
             {
-                MainDemuxer.Chapters.Add(chapter);
+                VideoDemuxer.Chapters.Add(chapter);
             }
         }
     }

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -69,7 +69,6 @@ public unsafe partial class DecoderContext : PluginHandler
     public string               Extension           => VideoDemuxer.Disposed ? AudioDemuxer.Extension : VideoDemuxer.Extension;
 
     // Demuxers
-    public Demuxer              MainDemuxer         { get; private set; }
     public Demuxer              AudioDemuxer        { get; private set; }
     public Demuxer              VideoDemuxer        { get; private set; }
     // Demuxer for external subtitles, currently not used for subtitles, just used for stream info

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.Filters.cs
@@ -7,6 +7,8 @@ namespace FlyleafLib.MediaFramework.MediaDecoder;
 
 public unsafe partial class AudioDecoder
 {
+    // TODO: Check locks (lockSpeed) - during seek and speed change (also in xaudio submit samples - we change the data len and we lose sync with submited samples vs played)
+
     AVFilterContext*        abufferCtx;
     AVFilterContext*        abufferSinkCtx;
     AVFilterGraph*          filterGraph;
@@ -286,7 +288,7 @@ public unsafe partial class AudioDecoder
 
         int ret;
 
-        if ((ret = av_buffersrc_add_frame_flags(abufferCtx, frame, AVBuffersrcFlag.KeepRef | AVBuffersrcFlag.NoCheckFormat)) < 0) // AV_BUFFERSRC_FLAG_KEEP_REF = 8, AV_BUFFERSRC_FLAG_NO_CHECK_FORMAT = 1 (we check format change manually before here)
+        if ((ret = av_buffersrc_add_frame_flags(abufferCtx, frame, AVBuffersrcFlag.KeepRef | AVBuffersrcFlag.NoCheckFormat)) < 0) // We check format change manually before here
         {
             Log.Warn($"[buffersrc] {FFmpegEngine.ErrorCodeToMsg(ret)} ({ret})");
             Status = Status.Stopping;

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -133,6 +133,27 @@ public unsafe class Demuxer : RunThreadBase
         public string   Title       { get; set; }
     }
 
+    // CurPackets Callbacks
+    internal void SetHLSDuration(long duration)
+    {
+        if (Duration != duration)
+        {
+            Duration = duration;
+            HLSDurationChanged?.Invoke(duration);
+        }
+    }
+    internal void SetHLSCurTime(long curTime)
+    {
+        if (curTime != _hlsCurTime)
+        {
+            _hlsCurTime = curTime;
+            HLSCurTimeChanged?.Invoke(curTime);
+        }
+    }
+    long _hlsCurTime; // only to check changes
+    public Action<long> HLSDurationChanged;
+    public Action<long> HLSCurTimeChanged; // Includes BufferedDurationChanged if possible?*
+
     public event EventHandler AudioLimit;
     bool audioBufferLimitFired;
     void OnAudioLimit()
@@ -761,12 +782,6 @@ public unsafe class Demuxer : RunThreadBase
         if (fmtCtx->start_time_realtime != NoTs)
             StartRealTime = EPOCH.AddMicroseconds(fmtCtx->start_time_realtime);
 
-        if (Engine.Config.FFmpegHLSLiveSeek && Duration == 0 && Name == "hls" && Environment.Is64BitProcess) // HLSContext cast is not safe
-        {
-            hlsCtx = (HLSContext*)fmtCtx->priv_data;
-            StartTime = 0;
-        }
-
         Metadata.Clear();
         AVDictionaryEntry* b = null;
         while (true)
@@ -860,22 +875,20 @@ public unsafe class Demuxer : RunThreadBase
             }
         }
 
-        Duration = fmtCtx->duration > 0 ? fmtCtx->duration * 10 : 0;
+        var duration = fmtCtx->duration > 0 ? fmtCtx->duration * 10 : 0;
 
         // Try to fill duration when missing (not analyzed mainly) | Considers CFR
-        if (Duration == 0 && !analyzed && hlsCtx == null)
+        if (duration == 0 && !analyzed && hlsCtx == null)
         {
             foreach(var videoStream in VideoStreams)
                 if (videoStream.TotalFrames > 0 && videoStream.FrameDuration > 0)
                 {
-                    Duration = videoStream.TotalFrames * videoStream.FrameDuration;
-                    for (int i = 0; i < fmtCtx->nb_streams; i++)
-                        AVStreamToStream[i].UpdateDuration();
+                    duration = videoStream.TotalFrames * videoStream.FrameDuration;
                     break;
                 }
 
             long fileSize = 0;
-            if (Duration == 0 && fmtCtx->pb != null && (fileSize = avio_size(fmtCtx->pb)) > 0)
+            if (duration == 0 && fmtCtx->pb != null && (fileSize = avio_size(fmtCtx->pb)) > 0)
             {
                 double bitrate = fmtCtx->bit_rate;
                 if (bitrate <= 0 && fmtCtx->nb_streams == 1)
@@ -888,20 +901,22 @@ public unsafe class Demuxer : RunThreadBase
                 }
 
                 if (bitrate > 0)
-                {
-                    Duration = (long)(((fileSize * 8.0) / bitrate) * 10_000_000);
-                    for (int i = 0; i < fmtCtx->nb_streams; i++)
-                        AVStreamToStream[i].UpdateDuration();
-                }
+                    duration = (long)(((fileSize * 8.0) / bitrate) * 10_000_000);
             }
         }
-        else
+
+        Duration = duration;
+
+        if (Engine.Config.FFmpegHLSLiveSeek && Duration == 0 && Name == "hls" && Environment.Is64BitProcess) // HLSContext cast is not safe
         {
-            for (int i = 0; i < fmtCtx->nb_streams; i++)
-                AVStreamToStream[i].UpdateDuration();
+            hlsCtx = (HLSContext*)fmtCtx->priv_data;
+            StartTime = 0;
         }
 
-        IsLive = Duration == 0 || hlsCtx != null; // TODO: No true for single video stream / image (fix also total frames to 1 if not animated?*)
+        IsLive = Duration == 0; // TODO: No true for single video stream / image (fix also total frames to 1 if not animated?*) | consider updating it on proper ended? (can we trust ended?)
+
+        for (int i = 0; i < fmtCtx->nb_streams; i++)
+            AVStreamToStream[i].UpdateDuration();
 
         string dumpChapters = "";
 
@@ -949,7 +964,7 @@ public unsafe class Demuxer : RunThreadBase
             }
 
             if (CanDebug)
-                dump += $"\t#{i+1:D2}: {TicksToTime2((long)(chp->start * tb) - StartTime)} - {TicksToTime2((long)(chp->end * tb) - StartTime)} | {title}\r\n";
+                dump += $"\t#{i+1:D2}: {TicksToTime((long)(chp->start * tb) - StartTime)} - {TicksToTime((long)(chp->end * tb) - StartTime)} | {title}\r\n";
 
             Chapters.Add(new Chapter()
             {
@@ -1001,9 +1016,9 @@ public unsafe class Demuxer : RunThreadBase
 
             /* Seek within current bufffered queue
              *
-             * 10 seconds because of video keyframe distances or 1 seconds for other (can be fixed also with CurTime+X seek instead of timestamps)
+             * 10 seconds because of video keyframe distances (can be fixed also with CurTime+X seek instead of timestamps)
              * For subtitles it should keep (prev packet) the last presented as it can have a lot of distance with CurTime (cur packet)
-             * It doesn't work for HLS live streams
+             * It doesn't work for HLS live streams?
              * It doesn't work for decoders buffered queue (which is small only subs might be an issue if we have large decoder queue)
              */
 
@@ -1015,7 +1030,7 @@ public unsafe class Demuxer : RunThreadBase
                 startTime = hlsStartTime;
             }
 
-            if (ticks + (VideoStream != null && forward ? (10000 * 10000) : 1000 * 10000) > CurTime + startTime && ticks < CurTime + startTime + BufferedDuration)
+            if (ticks + (VideoStream != null && forward ? (10000 * 10000) : 0) > CurTime + startTime && ticks < CurTime + startTime + BufferedDuration)
             {
                 bool found = false;
                 while (VideoPackets.Count > 0)
@@ -1023,6 +1038,9 @@ public unsafe class Demuxer : RunThreadBase
                     var packet = VideoPackets.Peek();
                     if (packet->pts != AV_NOPTS_VALUE && ticks < packet->pts * VideoStream.Timebase && (packet->flags & PktFlags.Key) != 0)
                     {
+                        if (!forward && ticks < (long) (packet->pts * VideoStream.Timebase)) // asked backward but the keyframe is forward
+                            break;
+
                         found = true;
                         ticks = (long) (packet->pts * VideoStream.Timebase);
 
@@ -1696,7 +1714,11 @@ public unsafe class Demuxer : RunThreadBase
                 return;
             }
 
-            /* AVDISCARD_ALL causes syncing issues between streams (TBR: bandwidth?)
+            /* TBR
+             * We freeze UI here on Live Streams while demuxer is holding the lock and waits for new packets
+             *  (check maybe if it has packets before?* - can we trust it? - otherwise interrupter release lock and get it back again?)
+             *
+             * AVDISCARD_ALL causes syncing issues between streams (TBR: bandwidth?)
              * 1) While switching video streams will not switch at the same timestamp
              * 2) By disabling video stream after a seek, audio will not seek properly
              * 3) HLS needs to update hlsCtx->first_time and read at least on package before seek to be accurate
@@ -1799,20 +1821,15 @@ public unsafe class Demuxer : RunThreadBase
             hlsStartTime = AV_NOPTS_VALUE;
 
             hlsCurDuration = 0;
-            long duration = 0;
-
-            for (long i=0; i<HLSPlaylist->cur_seq_no - HLSPlaylist->start_seq_no; i++)
-            {
+            for (long i = 0; i < HLSPlaylist->cur_seq_no - HLSPlaylist->start_seq_no; i++)
                 hlsCurDuration += HLSPlaylist->segments[i]->duration;
-                duration += HLSPlaylist->segments[i]->duration;
-            }
 
-            for (long i=HLSPlaylist->cur_seq_no - HLSPlaylist->start_seq_no; i<HLSPlaylist->n_segments; i++)
+            long duration = hlsCurDuration;
+            for (long i = HLSPlaylist->cur_seq_no - HLSPlaylist->start_seq_no; i < HLSPlaylist->n_segments; i++)
                 duration += HLSPlaylist->segments[i]->duration;
 
             hlsCurDuration *= 10;
-            duration *= 10;
-            Duration = duration;
+            Duration        = duration * 10;
         }
 
         if (hlsStartTime == AV_NOPTS_VALUE && CurPackets.LastTimestamp != AV_NOPTS_VALUE)
@@ -2034,19 +2051,19 @@ public unsafe class PacketQueue
             {
                 if (FirstTimestamp < demuxer.hlsStartTime)
                 {
-                    demuxer.Duration += demuxer.hlsStartTime - FirstTimestamp;
+                    demuxer.SetHLSDuration(demuxer.Duration + (demuxer.hlsStartTime - FirstTimestamp));
                     demuxer.hlsStartTime = FirstTimestamp;
                     CurTime = 0;
                 }
                 else
-                    CurTime = FirstTimestamp - demuxer.hlsStartTime;
+                    CurTime = Math.Max(FirstTimestamp - demuxer.hlsStartTime, 0);
+
+                if (this == demuxer.CurPackets)
+                    demuxer.SetHLSCurTime(CurTime);
             }
         }
         else
-            CurTime = FirstTimestamp - demuxer.StartTime;
-
-        if (CurTime < 0)
-            CurTime = 0;
+            CurTime = Math.Max(FirstTimestamp - demuxer.StartTime, 0);
 
         BufferedDuration = LastTimestamp - FirstTimestamp;
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -1,15 +1,17 @@
 ﻿using System.Numerics;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
-using Vortice;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
 using Vortice.DXGI.Debug;
 
-using ID3D11Device = Vortice.Direct3D11.ID3D11Device;
-using ID3D11DeviceContext = Vortice.Direct3D11.ID3D11DeviceContext;
+using ID3D11DeviceContext   = Vortice.Direct3D11.ID3D11DeviceContext;
+using ID3D11Device          = Vortice.Direct3D11.ID3D11Device;
+using ID2D1Device           = Vortice.Direct2D1.ID2D1Device;
+using ID2D1DeviceContext    = Vortice.Direct2D1.ID2D1DeviceContext;
+using ID2D1Bitmap1          = Vortice.Direct2D1.ID2D1Bitmap1;
+using BitmapProperties1     = Vortice.Direct2D1.BitmapProperties1;
 
 using FlyleafLib.MediaFramework.MediaDecoder;
 
@@ -39,21 +41,9 @@ public unsafe partial class Renderer
          1.0f,   1.0f,  0,      1.0f, 0.0f
     ];
 
-    static FeatureLevel[] featureLevelsAll =
-    [
-        FeatureLevel.Level_12_1,
-        FeatureLevel.Level_12_0,
-        FeatureLevel.Level_11_1,
-        FeatureLevel.Level_11_0,
-        FeatureLevel.Level_10_1,
-        FeatureLevel.Level_10_0,
-        FeatureLevel.Level_9_3,
-        FeatureLevel.Level_9_2,
-        FeatureLevel.Level_9_1
-    ];
-
     static FeatureLevel[] featureLevels =
     [
+        FeatureLevel.Level_11_1,
         FeatureLevel.Level_11_0,
         FeatureLevel.Level_10_1,
         FeatureLevel.Level_10_0,
@@ -76,35 +66,42 @@ public unsafe partial class Renderer
         blendDesc.RenderTarget[0].RenderTargetWriteMask = ColorWriteEnable.All;
     }
 
-    Vortice.Direct2D1.ID2D1Device           device2d;
-    Vortice.Direct2D1.ID2D1DeviceContext    context2d;
-    Vortice.Direct2D1.ID2D1Bitmap1          bitmap2d;
-    Vortice.Direct2D1.BitmapProperties1     bitmapProps2d = new()
+    internal ID3D11Device   Device;
+    IDXGIDevice1            dxgiDevice;
+    public GPUAdapter       GPUAdapter      => gpuAdapter;
+    IDXGIAdapter            dxgiAdapter;
+    GPUAdapter              gpuAdapter;
+    bool                    gpuForceWarp;
+
+    ID3D11DeviceContext     context;
+
+    ID3D11Buffer            vertexBuffer;
+    ID3D11InputLayout       inputLayout;
+    ID3D11RasterizerState   rasterizerState;
+    ID3D11BlendState        blendStateAlpha;
+
+    ID3D11VertexShader      ShaderVS;
+    ID3D11PixelShader       ShaderPS;
+    ID3D11PixelShader       ShaderBGRA;
+
+    ID3D11Buffer            psBuffer;
+    PSBufferType            psBufferData    = new();
+
+    ID3D11Buffer            vsBuffer;
+    VSBufferType            vsBufferData    = new();
+
+    internal object         lockDevice      = new();
+    bool                    isFlushing;
+
+    bool                    use2d;
+    ID2D1Device             device2d;
+    ID2D1DeviceContext      context2d;
+    ID2D1Bitmap1            bitmap2d;
+    BitmapProperties1       bitmapProps2d = new()
     {
         BitmapOptions   = Vortice.Direct2D1.BitmapOptions.Target | Vortice.Direct2D1.BitmapOptions.CannotDraw,
         PixelFormat     = Vortice.DCommon.PixelFormat.Premultiplied
     };
-
-    ID3D11DeviceContext context;
-
-    ID3D11Buffer        vertexBuffer;
-    ID3D11InputLayout   inputLayout;
-    ID3D11RasterizerState
-                        rasterizerState;
-    ID3D11BlendState    blendStateAlpha;
-
-    ID3D11VertexShader  ShaderVS;
-    ID3D11PixelShader   ShaderPS;
-    ID3D11PixelShader   ShaderBGRA;
-
-    ID3D11Buffer        psBuffer;
-    PSBufferType        psBufferData    = new();
-
-    ID3D11Buffer        vsBuffer;
-    VSBufferType        vsBufferData    = new();
-
-    internal object     lockDevice      = new();
-    bool                isFlushing;
 
     public void Initialize(bool swapChain = true)
     {
@@ -117,10 +114,6 @@ public unsafe partial class Renderer
                 if (!Disposed)
                     Dispose();
 
-                Disposed = false;
-
-                ID3D11Device tempDevice;
-                IDXGIAdapter1 adapter = null;
                 var creationFlags       = DeviceCreationFlags.BgraSupport /*| DeviceCreationFlags.VideoSupport*/; // Let FFmpeg failed for VA if does not support it
                 var creationFlagsWarp   = DeviceCreationFlags.None;
 
@@ -132,92 +125,53 @@ public unsafe partial class Renderer
                 }
                 #endif
 
-                // Finding User Definied adapter
-                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && !Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
+                // Config or Default (null)
+                if (!gpuForceWarp && D3D11.D3D11CreateDevice(dxgiAdapter, dxgiAdapter == null ? DriverType.Hardware : DriverType.Unknown, creationFlags, featureLevels, out Device).Failure)
+                    gpuForceWarp = true;
+
+                // Forced or Fallback to WARP
+                if (gpuForceWarp)
+                    D3D11.D3D11CreateDevice(null, DriverType.Warp, creationFlagsWarp, featureLevels, out Device).CheckError();
+
+                Disposed    = false;
+                dxgiDevice  = Device.QueryInterface<IDXGIDevice1>();
+
+                // Find Device's Adapter from GPUAdapters (Dispose extra adapter) | Until we use a single device per adapter
+                if (dxgiAdapter == null)
                 {
-                    for (uint i=0; Engine.Video.Factory.EnumAdapters1(i, out adapter).Success; i++)
+                    var gpuAdapters = Engine.Video.GPUAdapters;
+                    dxgiAdapter     = dxgiDevice.GetAdapter();
+                    var desc        = dxgiAdapter.Description;
+                    bool dxgiExists = true;
+
+                    if (!gpuAdapters.TryGetValue(desc.Luid, out gpuAdapter))
                     {
-                        if (adapter.Description1.Description == Config.Video.GPUAdapter)
-                            break;
-
-                        if (Regex.IsMatch(adapter.Description1.Description + " luid=" + adapter.Description1.Luid, Config.Video.GPUAdapter, RegexOptions.IgnoreCase))
-                            break;
-
-                        adapter.Dispose();
+                        lock(gpuAdapters)
+                            if (!gpuAdapters.TryGetValue(desc.Luid, out gpuAdapter))
+                            {
+                                dxgiExists  = false;
+                                gpuAdapter  = Engine.Video.GetGPUAdapter(dxgiAdapter, desc);
+                                gpuAdapters.Add(gpuAdapter.Luid, gpuAdapter);
+                            }
                     }
 
-                    if (adapter == null)
+                    if (dxgiExists)
                     {
-                        Log.Error($"GPU Adapter with {Config.Video.GPUAdapter} has not been found. Falling back to default.");
-                        Config.Video.GPUAdapter = null;
+                        dxgiAdapter.Dispose();
+                        dxgiAdapter = gpuAdapter.dxgiAdapter;
                     }
                 }
 
-                // Creating WARP (force by user or us after late failure)
-                if (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
-                    D3D11.D3D11CreateDevice(null, DriverType.Warp, creationFlagsWarp, featureLevels, out tempDevice).CheckError();
+                context = Device.ImmediateContext;
+                dxgiDevice.MaximumFrameLatency = Config.Video.MaxFrameLatency;
+                using (var mthread = Device.QueryInterface<ID3D11Multithread>())
+                    mthread.SetMultithreadProtected(true);
 
-                // Creating User Defined or Default
-                else
+                if (use2d)
                 {
-                    // Creates the D3D11 Device based on selected adapter or default hardware (highest to lowest features and fall back to the WARP device. see http://go.microsoft.com/fwlink/?LinkId=286690)
-                    if (D3D11.D3D11CreateDevice(adapter, adapter == null ? DriverType.Hardware : DriverType.Unknown, creationFlags, featureLevelsAll, out tempDevice).Failure)
-                        if (D3D11.D3D11CreateDevice(adapter, adapter == null ? DriverType.Hardware : DriverType.Unknown, creationFlags, featureLevels, out tempDevice).Failure)
-                        {
-                            Config.Video.GPUAdapter = "WARP";
-                            D3D11.D3D11CreateDevice(null, DriverType.Warp, creationFlagsWarp, featureLevels, out tempDevice).CheckError();
-                        }
-                }
-
-                Device = tempDevice.QueryInterface<ID3D11Device1>();
-                context= Device.ImmediateContext;
-
-                // Gets the default adapter from the D3D11 Device
-                if (adapter == null)
-                {
-                    Device.Tag = new Luid().ToString();
-                    using var deviceTmp = Device.QueryInterface<IDXGIDevice1>();
-                    using var adapterTmp = deviceTmp.GetAdapter();
-                    adapter = adapterTmp.QueryInterface<IDXGIAdapter1>();
-                }
-                else
-                    Device.Tag = adapter.Description.Luid.ToString();
-
-                if (Engine.Video.GPUAdapters.ContainsKey(adapter.Description1.Luid))
-                {
-                    GPUAdapter = Engine.Video.GPUAdapters[adapter.Description1.Luid];
-                    Config.Video.MaxVerticalResolutionAuto = GPUAdapter.MaxHeight;
-
-                    if (CanDebug)
-                    {
-                        string dump = $"GPU Adapter\r\n{GPUAdapter}\r\n";
-
-                        for (int i = 0; i < GPUAdapter.Outputs.Count; i++)
-                            dump += $"[Output #{i+1}] {GPUAdapter.Outputs[i]}\r\n";
-
-                        Log.Debug(dump);
-                    }
-                }
-                else
-                {
-                    GPUAdapter = new();
-                    Log.Debug($"GPU Adapter: Unknown (Possible WARP without Luid)");
-                }
-
-                tempDevice.Dispose();
-                adapter.Dispose();
-
-                using (var mthread    = Device.QueryInterface<ID3D11Multithread>()) mthread.SetMultithreadProtected(true);
-                using (var dxgidevice = Device.QueryInterface<IDXGIDevice1>())
-                {
-                    dxgidevice.MaximumFrameLatency = Config.Video.MaxFrameLatency;
-
-                    if (use2d)
-                    {
-                        device2d  = Vortice.Direct2D1.D2D1.D2D1CreateDevice(dxgidevice);
-                        context2d = device2d.CreateDeviceContext();
-                        Config.Video.OnD2DInitialized(this, context2d);
-                    }
+                    device2d  = Vortice.Direct2D1.D2D1.D2D1CreateDevice(dxgiDevice);
+                    context2d = device2d.CreateDeviceContext();
+                    Config.Video.OnD2DInitialized(this, context2d);
                 }
 
                 // Input Layout
@@ -265,18 +219,18 @@ public unsafe partial class Renderer
                 rasterizerState = Device.CreateRasterizerState(new(CullMode.Back, FillMode.Solid));
                 context.RSSetState(rasterizerState);
 
-                InitializeVideoProcessor();
+                if (!gpuForceWarp)
+                    InitializeVideoProcessor();
 
                 if (CanInfo) Log.Info($"Initialized with Feature Level {(int)Device.FeatureLevel >> 12}.{((int)Device.FeatureLevel >> 8) & 0xf}");
 
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
-                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || !Config.Video.GPUAdapter.Equals("WARP", StringComparison.OrdinalIgnoreCase))
+                if (!gpuForceWarp)
                 {
-                    try { if (Device != null) Log.Warn($"Device Remove Reason = {Device.DeviceRemovedReason.Description}"); } catch { } // For troubleshooting
-
-                    Log.Warn($"Initialization failed ({e.Message}). Failling back to WARP device.");
-                    Config.Video.GPUAdapter = "WARP";
+                    gpuForceWarp = true;
+                    Log.Error($"Initialization failed ({e.Message}). Failling back to WARP device.");
                     Flush();
                 }
                 else
@@ -289,41 +243,11 @@ public unsafe partial class Renderer
 
             if (swapChain)
             {
-                if (ControlHandle != IntPtr.Zero)
+                if (ControlHandle != 0)
                     InitializeSwapChain(ControlHandle);
                 else if (SwapChainWinUIClbk != null)
                     InitializeWinUISwapChain();
             }
-
-            InitializeChildSwapChain();
-        }
-    }
-    public void InitializeChildSwapChain(bool swapChain = true)
-    {
-        if (child == null )
-            return;
-
-        lock (lockDevice)
-        {
-            child.lockDevice    = lockDevice;
-            child.VideoDecoder  = VideoDecoder;
-            child.Device        = Device;
-            child.context       = context;
-            child.curRatio      = curRatio;
-            child.VideoRect     = VideoRect;
-            child.videoProcessor= videoProcessor;
-            child.InitializeVideoProcessor(); // to use the same VP we need to set it's config in each present (means we don't update VP config as is different)
-
-            if (swapChain)
-            {
-                if (child.ControlHandle != IntPtr.Zero)
-                    child.InitializeSwapChain(child.ControlHandle);
-                else if (child.SwapChainWinUIClbk != null)
-                    child.InitializeWinUISwapChain();
-            }
-
-            child.Disposed = false;
-            child.SetViewport();
         }
     }
 
@@ -334,10 +258,17 @@ public unsafe partial class Renderer
             if (Disposed)
                 return;
 
-            if (child != null)
-                DisposeChild();
-
             Disposed = true;
+
+            if (CanDebug) Log.Debug("Disposing");
+
+            lock (lockLastFrame)
+            {
+                VideoDecoder.DisposeFrame(LastFrame);
+                LastFrame = null;
+            }
+
+            DisposeSwapChain();
 
             if (use2d)
             {
@@ -346,11 +277,6 @@ public unsafe partial class Renderer
                 context2d?.Dispose();
                 device2d?.Dispose();
             }
-
-            if (CanDebug) Log.Debug("Disposing");
-
-            VideoDecoder.DisposeFrame(LastFrame);
-            RefreshLayout();
 
             DisposeVideoProcessor();
 
@@ -363,7 +289,6 @@ public unsafe partial class Renderer
             vertexBuffer?.Dispose();
             rasterizerState?.Dispose();
             blendStateAlpha?.Dispose();
-            DisposeSwapChain();
 
             overlayTexture?.Dispose();
             overlayTextureSrv?.Dispose();
@@ -396,6 +321,7 @@ public unsafe partial class Renderer
                 context.Flush();
                 context.Dispose();
                 Device.Dispose();
+                dxgiDevice.Dispose();
                 Device = null;
             }
 
@@ -408,27 +334,6 @@ public unsafe partial class Renderer
             if (CanInfo) Log.Info("Disposed");
         }
     }
-    public void DisposeChild()
-    {
-        if (child == null)
-            return;
-
-        lock (lockDevice)
-        {
-            child.DisposeSwapChain();
-            child.DisposeVideoProcessor();
-            child.Disposed = true;
-
-            if (!isFlushing)
-            {
-                child.Device        = null;
-                child.context       = null;
-                child.VideoDecoder  = null;
-                child.LastFrame     = null;
-                child               = null;
-            }
-        }
-    }
 
     public void Flush()
     {
@@ -438,43 +343,35 @@ public unsafe partial class Renderer
             var controlHandle = ControlHandle;
             var swapChainClbk = SwapChainWinUIClbk;
 
-            IntPtr controlHandleReplica = IntPtr.Zero;
-            Action<IDXGISwapChain2> swapChainClbkReplica = null;;
-            if (child != null)
-            {
-                controlHandleReplica = child.ControlHandle;
-                swapChainClbkReplica = child.SwapChainWinUIClbk;
-            }
-
             Dispose();
             ControlHandle = controlHandle;
             SwapChainWinUIClbk = swapChainClbk;
-            if (child != null)
-            {
-                child.ControlHandle = controlHandleReplica;
-                child.SwapChainWinUIClbk = swapChainClbkReplica;
-            }
+
             Initialize();
             isFlushing = false;
         }
     }
 
-    void HandleDeviceReset()
+    void HandleDeviceLost()
     {
-        if (VideoDecoder != null && VideoStream != null)
+        Thread.Sleep(100);
+
+        var stream = VideoDecoder.VideoStream;
+        if (stream == null)
         {
-            var running = VideoDecoder.IsRunning;
-            var stream = VideoStream;
-            VideoDecoder.Dispose();
             Flush();
-            VideoDecoder.Open(stream); // Should Re-ConfigPlanes()
-            VideoDecoder.keyPacketRequired = !VideoDecoder.isIntraOnly;
-            VideoDecoder.keyFrameRequired  = false;
-            if (running)
-                VideoDecoder.Start();
+            return;
         }
-        else
-            Flush();
+
+        var running = VideoDecoder.IsRunning;
+
+        VideoDecoder.Dispose();
+        Flush();
+        VideoDecoder.Open(stream); // Should Re-ConfigPlanes()
+        VideoDecoder.keyPacketRequired = !VideoDecoder.isIntraOnly;
+        VideoDecoder.keyFrameRequired  = false;
+        if (running)
+            VideoDecoder.Start();
     }
 
     #if DEBUG
@@ -521,7 +418,7 @@ public unsafe partial class Renderer
     {
         public Matrix4x4    mat;
         public Vector4      cropRegion;
-        
+
         public VSBufferType()
             => cropRegion = new(0, 0, 1, 1);
     }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Filters.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Filters.cs
@@ -71,7 +71,7 @@ unsafe public partial class Renderer
     {
         lock (lockDevice)
         {
-            if (Disposed || parent != null)
+            if (Disposed)
                 return;
 
             float value = Scale(cfgFilter.Value, cfgFilter.Minimum, cfgFilter.Maximum, cfgFilter.filter.MinimumPS, cfgFilter.filter.MaximumPS);
@@ -117,21 +117,21 @@ unsafe public partial class Renderer
             }
 
             if (present)
-                Present();
+                RenderRequest();
         }
     }
     internal void UpdateD3FilterValue(D3VideoFilter cfgFilter, bool present = true)
     {
         lock (lockDevice)
         {
-            if (Disposed || parent != null)
+            if (Disposed || D3D11VPFailed)
                 return;
 
             vc.VideoProcessorSetStreamFilter(vp, 0, ConvertFromVideoProcessorFilterCaps((VideoProcessorFilterCaps)cfgFilter.Filter), true,
                 (int)Scale(cfgFilter.Value, cfgFilter.Minimum, cfgFilter.Maximum, cfgFilter.filter.Minimum, cfgFilter.filter.Maximum));
 
             if (present)
-                Present();
+                RenderRequest();
         }
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -173,7 +173,17 @@ public unsafe partial class Renderer
         }
 
         var ret = swapChain.Present(Config.Video.VSync, forceWait ? PresentFlags.None : Config.Video.PresentFlags);
-        if (ret.Failure) Log.Info($"Dropped Frame - {ret.Description}");
+        if (ret.Failure) // 1 Retry (for DoNotWait) to avoid frame drop
+        {
+            if (!forceWait && Config.Video.PresentFlags.HasFlag(PresentFlags.DoNotWait))
+            {
+                Thread.Sleep(2);
+                ret = swapChain.Present(Config.Video.VSync, Config.Video.PresentFlags);
+                if (ret.Failure) Log.Info($"Dropped Frame - {ret.Description}");
+            }
+            else
+                Log.Info($"Dropped Frame - {ret.Description}");
+        }
 
         child?.PresentInternal(frame, forceWait, secondField);
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -1,5 +1,4 @@
 ﻿using SharpGen.Runtime;
-using Vortice.Direct3D11;
 using Vortice.DXGI;
 using Vortice.Mathematics;
 
@@ -10,133 +9,209 @@ namespace FlyleafLib.MediaFramework.MediaRenderer;
 
 public unsafe partial class Renderer
 {
-    bool    isPresenting;
-    long    lastPresentAt       = 0;
-    long    lastPresentRequestAt= 0;
-    object  lockPresentTask     = new();
+    long            lastPresentAt;
+    long            lastPresentRequestAt;
+    volatile bool   isPlayerPresenting;
+    volatile bool   isIdlePresenting;
+    object          lockLastFrame = new();
 
-    public bool Present(VideoFrame frame, bool forceWait = true, bool secondField = false)
+    internal void RenderRequest(VideoFrame frame = null, bool forceClear = false)
     {
-        if (Monitor.TryEnter(lockDevice, frame.timestamp == 0 ? 100 : 5)) // Allow more time for first frame
+        // NOTE: We expect frame only from player's ShowFrameX when is already Paused
+        // TODO: We use source Fps to present our updated frames which can be low (e.g. 1-10fps) | Consider passing ts to player and will act also as idle renderer? (with higher fps)
+        if (isPlayerPresenting && frame == null)
+            return;
+
+        lock (lockLastFrame)
         {
-            try
+            lastPresentRequestAt = DateTime.UtcNow.Ticks;
+
+            if ((frame != null || forceClear) && frame != LastFrame)
             {
-                var ret = PresentInternal(frame, forceWait, secondField);
-                if (frame != LastFrame) // De-interlace (Same AVFrame - Different FieldType)
+                VideoDecoder.DisposeFrame(LastFrame);
+                LastFrame = frame;
+            }
+
+            if (!canRenderPresent || isPlayerPresenting || isIdlePresenting)
+                return;
+
+            isIdlePresenting = true;
+        }
+
+        Task.Run(RenderIdleLoop);
+    }
+    void RenderIdleLoop()
+    {
+        int rechecks = 1000; // Awake for ~5sec when Idle
+        while (canRenderPresent)
+        {
+            while (lastPresentRequestAt < lastPresentAt && rechecks-- > 0)
+            {
+                if (isPlayerPresenting || !canRenderPresent)
+                    { rechecks = 0; break; }
+
+                Thread.Sleep(5); // might not TimeBeginPeriod1 (can drop fps or slow down cancelation)
+            }
+
+            if (rechecks < 1)
+                break;
+
+            RenderIdle();
+
+            rechecks = 500;
+        }
+
+        lock (lockLastFrame) // To avoid race condition*?
+        {
+            isIdlePresenting = false;
+            if (lastPresentRequestAt > lastPresentAt && !isPlayerPresenting && canRenderPresent)
+                RenderRequest();
+        }
+    }
+    void RenderIdle()
+    {
+        try
+        {
+            ResizeBuffersInternal();
+            SetViewportInternal();
+
+            lastPresentAt = DateTime.UtcNow.Ticks;
+
+            if (canRenderPresent)
+            {
+                lock (lockLastFrame)
+                    if (LastFrame != null)
+                        RenderFrame(LastFrame, false);
+                    else
+                    {
+                        ClearOverlayTexture();
+                        context.OMSetRenderTargets(backBufferRtv);
+                        context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
+                    }
+
+                swapChain.Present(1, 0);
+            }
+        }
+        catch (SharpGenException e)
+        {
+            Log.Error($"[RenderIdle] Device Lost ({e.ResultCode.NativeApiCode} ({e.ResultCode}) | {Device.DeviceRemovedReason} | {e.Message})");
+
+            if (IsDeviceError(e.ResultCode))
+            {
+                lock (lockDevice)
+                    HandleDeviceLost();
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error($"[RenderIdle] Failed ({e.Message})");
+        }
+    }
+
+    internal void RenderPlayStart()  { isPlayerPresenting = true; while(isIdlePresenting) Thread.Sleep(1); } // Stop RenderIdle
+    internal void RenderPlayStop()  => isPlayerPresenting = false; // Check if last timestamp?* to start idle (we don't update it currently)
+    internal bool RenderPlay(VideoFrame frame, bool secondField)
+    {
+        try
+        {
+            ResizeBuffersInternal();
+            SetViewportInternal();
+
+            lock (LastFrame)
+            {
+                if (canRenderPresent)
+                    RenderFrame(frame, secondField);
+                else if (frame != LastFrame)
                 {
                     VideoDecoder.DisposeFrame(LastFrame);
                     LastFrame = frame;
-                    if (child != null)
-                        child.LastFrame = frame;
                 }
 
-                return ret;
-
-            }
-            catch (SharpGenException e)
-            {
-                try { VideoDecoder.DisposeFrame(frame); vpiv?.Dispose(); } catch { };
-
-                if (e.ResultCode == Vortice.DXGI.ResultCode.DeviceRemoved || e.ResultCode == Vortice.DXGI.ResultCode.DeviceReset)
-                {
-                    Log.Error($"Device Lost ({e.ResultCode} | {Device.DeviceRemovedReason} | {e.Message})");
-                    Thread.Sleep(100);
-
-                    HandleDeviceReset();
-                }
-                else
-                {
-                    Log.Warn($"Present frame failed {e.Message} | {Device?.DeviceRemovedReason}");
-                    throw; // Force Playback Stop
-                }
-            }
-            catch (Exception e)
-            {
-                try { VideoDecoder.DisposeFrame(frame); vpiv?.Dispose(); } catch { };
-                Log.Warn($"Present frame failed {e.Message} | {Device?.DeviceRemovedReason}");
-            }
-            finally
-            {
-                Monitor.Exit(lockDevice);
+                // Don't return false when !canRenderPresent as it will cause restarts (consider as valid)
+                return true;
             }
         }
-        else
+        catch (SharpGenException e)
         {
-            try { VideoDecoder.DisposeFrame(frame); vpiv?.Dispose(); } catch { };
-            Log.Info("Dropped Frame - Lock timeout");
+            if (frame != LastFrame) VideoDecoder.DisposeFrame(frame); vpiv?.Dispose();
+            Log.Error($"[RenderPlay] Device Lost ({e.ResultCode.NativeApiCode} ({e.ResultCode}) | {Device.DeviceRemovedReason} | {e.Message})");
+
+            if (IsDeviceError(e.ResultCode))
+            {
+                lock (lockDevice)
+                    HandleDeviceLost();
+            }
+        }
+        catch (Exception e)
+        {
+            if (frame != LastFrame) VideoDecoder.DisposeFrame(frame); vpiv?.Dispose();
+            Log.Error($"[RenderPlay] Failed ({e.Message})");
         }
 
         return false;
     }
-    public void Present()
+    internal bool PresentPlay()
     {
-        if (SCDisposed)
-            return;
-
-        lock (lockPresentTask) // NOTE: We don't have TimeBeginPeriod, FpsForIdle will not be accurate
+        try
         {
-            if ((Config.Player.player == null || !Config.Player.player.requiresBuffering) && VideoDecoder.IsRunning && (VideoStream == null || VideoStream.FPS > 10)) // With slow FPS we need to refresh as fast as possible
-                return;
+            if (canRenderPresent)
+                swapChain?.Present(Config.Video.VSync, PresentFlags.None).CheckError();
 
-            if (isPresenting)
+            return true;
+        }
+        catch (SharpGenException e)
+        {
+            if (e.ResultCode == ResultCode.WasStillDrawing) // For DoNotWait (any reason to still support it with Config?)
             {
-                lastPresentRequestAt = DateTime.UtcNow.Ticks;
-                return;
+                Log.Info($"[V] Frame Dropped (GPU)");
+                return false;
             }
 
-            isPresenting = true;
+            Log.Error($"[PresentPlay] {e.ResultCode.NativeApiCode} ({e.ResultCode}) | {Device.DeviceRemovedReason} | {e.Message}");
+
+            if (IsDeviceError(e.ResultCode))
+            {
+                lock (lockDevice)
+                    HandleDeviceLost();
+            }
+            else throw; // Force Playback Stop
+        }
+        catch (Exception e)
+        {
+            Log.Error($"[PresentPlay] Failed ({e.Message})");
+            throw; // Force Playback Stop
         }
 
-        Task.Run(() =>
-        {
-            long presentingAt;
-            do
-            {
-                long sleepMs = DateTime.UtcNow.Ticks - lastPresentAt;
-                sleepMs = sleepMs < (long)(1.0 / Config.Player.IdleFps * 1000 * 10000) ? (long) (1.0 / Config.Player.IdleFps * 1000) : 0;
-                if (sleepMs > 2)
-                    Thread.Sleep((int)sleepMs);
-
-                presentingAt = DateTime.UtcNow.Ticks;
-                RefreshLayout();
-                lastPresentAt = DateTime.UtcNow.Ticks;
-
-            } while (lastPresentRequestAt > presentingAt);
-
-            isPresenting = false;
-        });
+        return false;
     }
-    internal bool PresentInternal(VideoFrame frame, bool forceWait = true, bool secondField = false)
-    {
-        if (!canRenderPresent)
-            return true; // TBR: to avoid increasing drop frames here (is just disabled)
 
+    void RenderFrame(VideoFrame frame, bool secondField) // From Play or Idle (No lock/try, ensure we don't run both)
+    {
         if (frame.srvs == null) // videoProcessor can be FlyleafVP but the player can send us a cached frame from prev videoProcessor D3D11VP (check frame.srv instead of videoProcessor)
         {
             if (frame.avFrame != null)
             {
-                vpivd.Texture2D.ArraySlice = (uint) frame.avFrame->data[1];
-                vd1.CreateVideoProcessorInputView(VideoDecoder.textureFFmpeg, vpe, vpivd, out vpiv);
+                vpivd.Texture2D.ArraySlice = (uint)frame.avFrame->data[1];
+                vd1.CreateVideoProcessorInputView(VideoDecoder.textureFFmpeg, vpe, vpivd, out vpiv).CheckError();
             }
             else
             {
                 vpivd.Texture2D.ArraySlice = 0;
-                vd1.CreateVideoProcessorInputView(frame.textures[0], vpe, vpivd, out vpiv);
+                vd1.CreateVideoProcessorInputView(frame.textures[0], vpe, vpivd, out vpiv).CheckError(); // TBR: frame.textures might be null from player (the dequeued vFrame)
             }
 
             if (vpiv == null)
-                return false;
+                throw new NullReferenceException("RenderFrame: vpiv was null");
 
             /* [Undocumented Deinterlace]
-             * Currently we don't use Past/Future frames so we consider only Bob/Weave methods (we also consider that are supported by D3D11VP)
-             * For Bob -double rate- we set the second field (InputFrameOrField/OutputIndex)
-             * Should review Present (Idle/RefreshLayout) to ignore changing those (to avoid jumping from second to first field)
-             */
+            * Currently we don't use Past/Future frames so we consider only Bob/Weave methods (we also consider that are supported by D3D11VP)
+            * For Bob -double rate- we set the second field (InputFrameOrField/OutputIndex)
+            * TODO: Bring secondField to renderer so Render refreshes can work also with it (maybe ShowFrameX too)
+            */
             vpsa[0].InputSurface= vpiv;
             vpsa[0].OutputIndex = vpsa[0].InputFrameOrField = secondField ? 1u : 0u;
             vc.VideoProcessorBlt(vp, vpov, 0, 1, vpsa);
             vpiv.Dispose();
-            forceWait |= _FieldType != VideoFrameFormat.Progressive;
         }
         else
         {
@@ -162,7 +237,7 @@ public unsafe partial class Renderer
 
             context.OMSetBlendState(blendStateAlpha);
             context.PSSetShaderResources(0, overlayTextureSRVs);
-            context.RSSetViewport((float) (view.X + (overlayTextureOriginalPosX * ratiox)), (float) (view.Y + (view.Height * ratioy)), (float) (overlayTexture.Description.Width * ratiox), (float) (overlayTexture.Description.Height * ratiox));
+            context.RSSetViewport((float)(view.X + (overlayTextureOriginalPosX * ratiox)), (float)(view.Y + (view.Height * ratioy)), (float)(overlayTexture.Description.Width * ratiox), (float)(overlayTexture.Description.Height * ratiox));
             context.PSSetShader(ShaderBGRA);
             context.Draw(6, 0);
 
@@ -172,36 +247,43 @@ public unsafe partial class Renderer
             context.RSSetViewport(GetViewport);
         }
 
-        var ret = swapChain.Present(Config.Video.VSync, forceWait ? PresentFlags.None : Config.Video.PresentFlags);
-        if (ret.Failure) // 1 Retry (for DoNotWait) to avoid frame drop
+        if (frame != LastFrame)
         {
-            if (!forceWait && Config.Video.PresentFlags.HasFlag(PresentFlags.DoNotWait))
-            {
-                Thread.Sleep(2);
-                ret = swapChain.Present(Config.Video.VSync, Config.Video.PresentFlags);
-                if (ret.Failure) Log.Info($"Dropped Frame - {ret.Description}");
-            }
-            else
-                Log.Info($"Dropped Frame - {ret.Description}");
+            VideoDecoder.DisposeFrame(LastFrame);
+            LastFrame = frame;
         }
-
-        child?.PresentInternal(frame, forceWait, secondField);
-
-        return ret.Success;
     }
 
+    public FrameStatistics GetFrameStatistics()
+    {
+        lock (lockDevice)
+        {
+            if (SCDisposed)
+                return new();
+
+            FrameStatistics stats;
+            int retries = 7;
+            while(swapChain.GetFrameStatistics(out stats).Failure && retries-- > 0);
+
+            #if DEBUG
+            if (retries == 0 && CanDebug) Log.Debug("GetFrameStatistics failed");
+            #endif
+
+            return stats;
+        }
+    }
+
+    public void ClearScreen(bool force = false) { if (Config.Video.ClearScreen || force) RenderRequest(null, true); }
     public void ClearOverlayTexture()
     {
         if (overlayTexture == null)
             return;
 
-        overlayTexture?.Dispose();
-        overlayTextureSrv?.Dispose();
+        overlayTexture?.    Dispose();
+        overlayTextureSrv?. Dispose();
         overlayTexture      = null;
         overlayTextureSrv   = null;
     }
-
-    SubresourceData subDataOverlay;
     internal void CreateOverlayTexture(SubtitlesFrame frame, int streamWidth, int streamHeight)
     {
         var rect    = frame.sub.rects[0];
@@ -221,11 +303,11 @@ public unsafe partial class Renderer
             subDataOverlay.DataPointer = (nint)ptr;
             subDataOverlay.RowPitch    = (uint)stride;
 
-            overlayTexture?.Dispose();
-            overlayTextureSrv?.Dispose();
-            overlayTexture          = Device.CreateTexture2D(overlayTextureDesc, [subDataOverlay]);
-            overlayTextureSrv       = Device.CreateShaderResourceView(overlayTexture);
-            overlayTextureSRVs[0]   = overlayTextureSrv;
+            overlayTexture?.            Dispose();
+            overlayTextureSrv?.         Dispose();
+            overlayTexture              = Device.CreateTexture2D(overlayTextureDesc, [subDataOverlay]);
+            overlayTextureSrv           = Device.CreateShaderResourceView(overlayTexture);
+            overlayTextureSRVs[0]       = overlayTextureSrv;
         }
     }
 
@@ -279,53 +361,6 @@ public unsafe partial class Renderer
             colors[n] = b | (g << 8) | (r << 16) | (a << 24);
         }
     }
-
-    public void RefreshLayout()
-    {
-        if (Monitor.TryEnter(lockDevice, 5))
-        {
-            try
-            {
-                if (SCDisposed)
-                    return;
-
-                if (LastFrame != null && (LastFrame.textures != null || LastFrame.avFrame != null))
-                    PresentInternal(LastFrame);
-                else if (Config.Video.ClearScreen)
-                {
-                    context.OMSetRenderTargets(backBufferRtv);
-                    context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
-                    swapChain.Present(Config.Video.VSync, PresentFlags.None);
-                }
-            }
-            catch (Exception e)
-            {
-                if (CanWarn) Log.Warn($"Present idle failed {e.Message} | {Device.DeviceRemovedReason}");
-            }
-            finally
-            {
-                Monitor.Exit(lockDevice);
-            }
-        }
-    }
-    public void ClearScreen()
-    {
-        ClearOverlayTexture();
-        VideoDecoder.DisposeFrame(LastFrame);
-        Present();
-    }
-    public void ClearScreenForce()
-    {
-        lock (lockDevice)
-        {
-            if (!canRenderPresent)
-                return;
-
-            ClearOverlayTexture();
-            VideoDecoder.DisposeFrame(LastFrame);
-            context.OMSetRenderTargets(backBufferRtv);
-            context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
-            swapChain.Present(Config.Video.VSync, PresentFlags.None);
-        }
-    }
+    bool IsDeviceError(Result code) => true; // code == ResultCode.DeviceRemoved || code == ResultCode.DeviceRemoved || code == ResultCode.DeviceHung || code == ResultCode.DriverInternalError;
+    // TBR: For now all.. ResultCode.InvalidCall ? (Happens also with NativeApiCode: WINCODEC_ERR_INVALIDPARAMETER, Description: The parameter is incorrect, ApiCode: InvalidParameter, Code: -2147024809
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -1,7 +1,6 @@
 ﻿using System.Windows;
 
 using Vortice;
-using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DirectComposition;
 using Vortice.DXGI;
@@ -16,7 +15,7 @@ namespace FlyleafLib.MediaFramework.MediaRenderer;
 unsafe public partial class Renderer
 {
     internal bool           forceViewToControl; // Makes sure that viewport will fill the exact same size with the control (mainly for keep ratio on resize)
-    bool                    canRenderPresent;   // Don't render / present during minimize (or invalid size)
+    volatile bool           canRenderPresent;   // Don't render / present during minimize (or invalid size)
 
     ID3D11Texture2D         backBuffer;
     ID3D11RenderTargetView  backBufferRtv;
@@ -25,48 +24,33 @@ unsafe public partial class Renderer
     IDCompositionVisual     dCompVisual;
     IDCompositionTarget     dCompTarget;
 
-    const uint              WM_NCDESTROY                = 0x0082;
+    const uint              WM_MOVE                     = 0x0003;
     const uint              WM_SIZE                     = 0x0005;
+    const uint              WM_DISPLAYCHANGE            = 0x007E;
+    const uint              WM_NCDESTROY                = 0x0082;
     const int               WS_EX_NOREDIRECTIONBITMAP   = 0x00200000;
     SubclassWndProc         wndProcDelegate;
     IntPtr                  wndProcDelegatePtr;
 
-    // Support Windows 8+
-    private SwapChainDescription1 GetSwapChainDesc(int width, int height, bool isComp = false, bool alpha = false)
-    {
-        if (Device.FeatureLevel < FeatureLevel.Level_10_0 || (!string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) && Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase)))
-        {
-            return new()
-            {
-                BufferUsage = Usage.RenderTargetOutput,
-                Format      = Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : Format.B8G8R8A8_UNorm,
-                Width       = (uint)width,
-                Height      = (uint)height,
-                AlphaMode   = AlphaMode.Ignore,
-                SwapEffect  = isComp ? SwapEffect.FlipSequential : SwapEffect.Discard, // will this work for warp?
-                Scaling     = Scaling.Stretch,
-                BufferCount = 1,
-                SampleDescription = new SampleDescription(1, 0)
-            };
-        }
-        else
-        {
-            SwapEffect swapEffect = isComp ? SwapEffect.FlipSequential : Environment.OSVersion.Version.Major >= 10 ? SwapEffect.FlipDiscard : SwapEffect.FlipSequential;
+    Format                  BGRA_OR_RGBA;
+    bool                    hasSubClass;
+    nint                    displayHwnd;
+    GPUOutput               gpuOutput;
 
-            return new()
-            {
-                BufferUsage = Usage.RenderTargetOutput,
-                Format      = Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : (Config.Video.SwapForceR8G8B8A8 ? Format.R8G8B8A8_UNorm : Format.B8G8R8A8_UNorm),
-                Width       = (uint)width,
-                Height      = (uint)height,
-                AlphaMode   = alpha  ? AlphaMode.Premultiplied : AlphaMode.Ignore,
-                SwapEffect  = swapEffect,
-                Scaling     = isComp ? Scaling.Stretch : Scaling.None,
-                BufferCount = swapEffect == SwapEffect.FlipDiscard ? Math.Min(Config.Video.SwapBuffers, 2) : Config.Video.SwapBuffers,
-                SampleDescription = new SampleDescription(1, 0),
-            };
-        }
-    }
+    private SwapChainDescription1 GetSwapChainDesc(int width, int height, bool isComp = false, bool alpha = false)
+    => new()
+    {
+        BufferUsage         = Usage.RenderTargetOutput,
+        Format              = Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA,
+        Width               = (uint)width,
+        Height              = (uint)height,
+        AlphaMode           = isComp ? AlphaMode.Premultiplied : AlphaMode.Ignore,
+        SwapEffect          = SwapEffect.FlipDiscard,
+        Scaling             = isComp ? Scaling.Stretch : Scaling.None, // DComp can't validate widhth/height?*
+        BufferCount         = Math.Max(Config.Video.SwapBuffers, 2),
+        SampleDescription   = new SampleDescription(1, 0),
+        Flags               = SwapChainFlags.None
+    };
 
     internal void InitializeSwapChain(nint handle)
     {
@@ -75,52 +59,42 @@ unsafe public partial class Renderer
             if (!SCDisposed)
                 DisposeSwapChain();
 
-            if (Disposed && parent == null)
+            if (Disposed)
                 Initialize(false);
 
+            SCDisposed      = false;
             ControlHandle   = handle;
             RECT rect       = new();
             GetWindowRect(ControlHandle, ref rect);
             ControlWidth    = rect.Right  - rect.Left;
             ControlHeight   = rect.Bottom - rect.Top;
 
+            // WS_EX_NOREDIRECTIONBITMAP: Prevent DWM from creating a redirection surface (offscreen bitmap)
+            SetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE, GetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE).ToInt32() | WS_EX_NOREDIRECTIONBITMAP);
+
             try
             {
-                if (cornerRadius == zeroCornerRadius)
-                {
-                    Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} swap chain with {Config.Video.SwapBuffers} buffers [Handle: {handle}]");
-                    swapChain = Engine.Video.Factory.CreateSwapChainForHwnd(Device, handle, GetSwapChainDesc(ControlWidth, ControlHeight));
-                }
-                else
-                {
-                    Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} composition swap chain with {Config.Video.SwapBuffers} buffers [Handle: {handle}]");
-                    swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(ControlWidth, ControlHeight, true, true));
-                    using (var dxgiDevice = Device.QueryInterface<IDXGIDevice>())
-                    dCompDevice = DComp.DCompositionCreateDevice<IDCompositionDevice>(dxgiDevice);
-                    dCompDevice.CreateTargetForHwnd(handle, false, out dCompTarget).CheckError();
-                    dCompDevice.CreateVisual(out dCompVisual).CheckError();
-                    dCompVisual.SetContent(swapChain).CheckError();
-                    dCompTarget.SetRoot(dCompVisual).CheckError();
-                    dCompDevice.Commit().CheckError();
-
-                    int styleEx = GetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE).ToInt32() | WS_EX_NOREDIRECTIONBITMAP;
-                    SetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE, new IntPtr(styleEx));
-                }
+                Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} swap chain [Handle: {handle}, Buffers: {Config.Video.SwapBuffers}, Format: {(Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA)}]");
+                swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(ControlWidth, ControlHeight, true, true));
+                DComp.DCompositionCreateDevice(dxgiDevice, out dCompDevice).CheckError();
+                dCompDevice.CreateTargetForHwnd(handle, false, out dCompTarget).CheckError();
+                dCompDevice.CreateVisual(out dCompVisual).CheckError();
+                dCompVisual.SetContent(swapChain).CheckError();
+                dCompTarget.SetRoot(dCompVisual).CheckError();
+                dCompDevice.Commit().CheckError();
             }
-            catch (Exception e)
+            catch (Exception e) // Should handle device lost etc..
             {
-                if (string.IsNullOrWhiteSpace(Config.Video.GPUAdapter) || !Config.Video.GPUAdapter.Equals("WARP", StringComparison.CurrentCultureIgnoreCase))
+                if (!gpuForceWarp)
                 {
-                    try { if (Device != null) Log.Warn($"Device Remove Reason = {Device.DeviceRemovedReason.Description}"); } catch { } // For troubleshooting
-
-                    Log.Warn($"[SwapChain] Initialization failed ({e.Message}). Failling back to WARP device.");
-                    Config.Video.GPUAdapter = "WARP";
+                    gpuForceWarp = true;
+                    Log.Error($"SwapChain Initialization failed ({e.Message}). Failling back to WARP device.");
                     Flush();
                 }
                 else
                 {
                     ControlHandle = 0;
-                    Log.Error($"[SwapChain] Initialization failed ({e.Message})");
+                    Log.Error($"SwapChain Initialization failed ({e.Message})");
                 }
 
                 return;
@@ -128,24 +102,14 @@ unsafe public partial class Renderer
 
             backBuffer      = swapChain.GetBuffer<ID3D11Texture2D>(0);
             backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
-            SCDisposed      = false;
-
-            if (!isFlushing) // avoid calling UI thread during Player.Stop
-            {
-                // SetWindowSubclass seems to require UI thread when RemoveWindowSubclass does not (docs are not mentioning this?)
-                if (Thread.CurrentThread.ManagedThreadId == Application.Current.Dispatcher.Thread.ManagedThreadId)
-                    SetWindowSubclass(ControlHandle, wndProcDelegatePtr, UIntPtr.Zero, UIntPtr.Zero);
-                else
-                    UI(() => SetWindowSubclass(ControlHandle, wndProcDelegatePtr, UIntPtr.Zero, UIntPtr.Zero));
-            }
-
             Engine.Video.Factory.MakeWindowAssociation(ControlHandle, WindowAssociationFlags.IgnoreAll);
-
-            ResizeBuffers(ControlWidth, ControlHeight); // maybe not required (only for vp)?
+            AddSubClass();
+            ResizeBuffers(ControlWidth, ControlHeight);
+            UpdateDisplay(true); // don't force if we let WndProc run without our swapchain
         }
     }
-    internal void InitializeWinUISwapChain() // TODO: width/height directly here
-    {
+    internal void InitializeWinUISwapChain()
+    {   // TODO: width/height directly here
         lock (lockDevice)
         {
             if (!SCDisposed)
@@ -174,7 +138,7 @@ unsafe public partial class Renderer
             backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
             SCDisposed      = false;
             ResizeBuffers(1, 1);
-
+            UpdateDisplay(true); // TODO: Parent Handle for WndProc and changes? (currently get's default monitor)
             SwapChainWinUIClbk?.Invoke(swapChain.QueryInterface<IDXGISwapChain2>());
         }
     }
@@ -186,29 +150,44 @@ unsafe public partial class Renderer
             if (SCDisposed)
                 return;
 
-            SCDisposed = true;
-            canRenderPresent = false;
+            SCDisposed      = true;
 
-            // Clear Screan
-            if (!Disposed && swapChain != null)
-            {
-                try
-                {
-                    context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
-                    swapChain.Present(Config.Video.VSync, PresentFlags.None);
-                }
-                catch { }
-            }
+            lock (lockLastFrame)
+                canRenderPresent = false;
+
+            while(isIdlePresenting) Thread.Sleep(1);
+            // StopPlayer (if it does not do it already before?*)
+
+            // TBR: Clear Screan (Disposing dCompTarget will do it)
+            //try
+            //{
+            //    context.OMSetRenderTargets(backBufferRtv);
+            //    context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
+            //    swapChain.Present(1, PresentFlags.None);
+            //}
+            //catch { }
 
             Log.Info($"Destroying swap chain [Handle: {ControlHandle}]");
 
-            // Unassign renderer's WndProc if still there and re-assign the old one
             if (ControlHandle != 0)
             {
-                if (!isFlushing) // SetWindowSubclass requires UI thread so avoid calling it on flush (Player.Stop)
-                    RemoveWindowSubclass(ControlHandle, wndProcDelegatePtr, UIntPtr.Zero);
-
+                if (!isFlushing) // Avoid UI Remove/Add subclass during flush
+                    RemoveSubClass();
                 ControlHandle = 0;
+            }
+
+            if (dCompVisual != null)
+            {
+                dCompVisual.SetContent(null);
+                dCompVisual.Dispose();
+                dCompVisual = null;
+            }
+
+            if (dCompTarget != null)
+            {
+                dCompTarget.SetRoot(null);
+                dCompTarget.Dispose();
+                dCompTarget = null;
             }
 
             if (SwapChainWinUIClbk != null)
@@ -218,17 +197,16 @@ unsafe public partial class Renderer
                 swapChain?.Release(); // TBR: SwapChainPanel (SCP) should be disposed and create new instance instead (currently used from Template)
             }
 
-            dCompVisual?.Dispose();
-            dCompTarget?.Dispose();
-            dCompDevice?.Dispose();
-            dCompVisual = null;
-            dCompTarget = null;
-            dCompDevice = null;
+            vpov?.          Dispose();
+            backBufferRtv?. Dispose();
+            backBuffer?.    Dispose();
+            swapChain?.     Dispose();
 
-            vpov?.Dispose();
-            backBufferRtv?.Dispose();
-            backBuffer?.Dispose();
-            swapChain?.Dispose();
+            if (dCompDevice != null)
+            {
+                dCompDevice.Dispose();
+                dCompDevice = null;
+            }
 
             if (Device != null)
                 context?.Flush();
@@ -284,11 +262,28 @@ unsafe public partial class Renderer
         SetZoomAndCenter(zoom, zoomCenter);
     }
 
+    bool needsViewport = true;
     public void SetViewport(bool refresh = true)
     {
+        lock (lockDevice)
+        {
+            needsViewport   = true;
+            canRenderPresent= true; // TBR: should be re-calculated 
+        }
+
+        if (refresh)
+            RenderRequest();
+    }
+    public void SetViewportInternal()
+    {
+        if (!needsViewport)
+            return;
+
+        needsViewport = false;
+
         int x, y, newWidth, newHeight, xZoomPixels, yZoomPixels;
 
-        var shouldFill = Config.Player.player?.Host?.Player_HandlesRatioResize(ControlWidth, ControlHeight);
+        var shouldFill = player?.Host?.Player_HandlesRatioResize(ControlWidth, ControlHeight);
 
         if (curRatio < fillRatio)
         {
@@ -329,7 +324,8 @@ unsafe public partial class Renderer
                 DisableSuperRes();
             else
             {
-                if (view.Width > VisibleWidth && view.Height > VisibleHeight)
+                if (((_RotationAngle ==  0 || _RotationAngle == 180) && view.Width > VisibleWidth  && view.Height > VisibleHeight) ||
+                    ((_RotationAngle == 90 || _RotationAngle == 270) && view.Width > VisibleHeight && view.Height > VisibleWidth))
                     EnableSuperRes();
                 else
                     DisableSuperRes();
@@ -428,13 +424,10 @@ unsafe public partial class Renderer
             context.RSSetViewport(GetViewport);
 
         canRenderPresent = true;
-
-        if (refresh)
-            Present();
-
         ViewportChanged?.Invoke(this, new());
     }
-    
+
+    bool needsResize = true;
     public void ResizeBuffers(int width, int height)
     {
         lock (lockDevice)
@@ -444,75 +437,164 @@ unsafe public partial class Renderer
                 canRenderPresent = false;
                 return;
             }
-
-            if (use2d)
+            else if (ControlWidth == width && ControlHeight == height)
             {
-                context2d.Target = null;
-                bitmap2d?.Dispose();
-                bitmap2d = null;
+                canRenderPresent = true; // TBR with minimize*
+                return;
             }
 
             ControlWidth    = width;
             ControlHeight   = height;
-            fillRatio       = ControlWidth / (double)ControlHeight;
-            if (Config.Video.AspectRatio == AspectRatio.Fill)
-                curRatio = fillRatio;
+            needsResize     = true;
 
-            backBufferRtv.Dispose();
-            vpov        ?.Dispose();
-            backBuffer   .Dispose();
+            RenderRequest();
+        }
+    }
+    void ResizeBuffersInternal()
+    {
+        if (!needsResize)
+            return;
 
-            swapChain.ResizeBuffers(0, (uint)ControlWidth, (uint)ControlHeight, Format.Unknown, SwapChainFlags.None);
+        needsResize     = false;
+        needsViewport   = true;
 
-            UpdateCornerRadius();
-            backBuffer      = swapChain.GetBuffer<ID3D11Texture2D>(0);
-            backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
-            if (videoProcessor == VideoProcessors.D3D11)
-                vd1.CreateVideoProcessorOutputView(backBuffer, vpe, vpovd, out vpov);
+        if (use2d)
+        {
+            context2d.Target = null;
+            bitmap2d?.Dispose();
+            bitmap2d = null;
+        }
 
-            if (use2d)
-            {
-                using var surface = backBuffer.QueryInterface<IDXGISurface>();
-                bitmap2d = context2d.CreateBitmapFromDxgiSurface(surface, bitmapProps2d);
-                context2d.Target = bitmap2d;
-            }
-            
-            SetViewport(); // TBR: Presents async (for performance especial in resize)
+        fillRatio = ControlWidth / (double)ControlHeight;
+        if (Config.Video.AspectRatio == AspectRatio.Fill)
+            curRatio = fillRatio;
+
+        backBufferRtv.Dispose();
+        vpov        ?.Dispose();
+        backBuffer   .Dispose();
+
+        swapChain.ResizeBuffers(0, (uint)ControlWidth, (uint)ControlHeight, Format.Unknown, SwapChainFlags.None);
+
+        if (cornerRadiusNeedsUpdate)
+            UpdateCornerRadiusInternal();
+
+        backBuffer      = swapChain.GetBuffer<ID3D11Texture2D>(0);
+        backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
+        if (videoProcessor == VideoProcessors.D3D11)
+            vd1.CreateVideoProcessorOutputView(backBuffer, vpe, vpovd, out vpov);
+
+        if (use2d)
+        {
+            using var surface = backBuffer.QueryInterface<IDXGISurface>();
+            bitmap2d = context2d.CreateBitmapFromDxgiSurface(surface, bitmapProps2d);
+            context2d.Target = bitmap2d;
         }
     }
 
-    internal void UpdateCornerRadius()
+    void UpdateCornerRadius(CornerRadius cornerRadius)
     {
-        if (dCompDevice == null)
-            return;
+        lock (lockDevice)
+        {
+            if (this.cornerRadius == cornerRadius)
+                return;
 
-        dCompDevice.CreateRectangleClip(out var clip).CheckError();
-        clip.SetLeft(0);
-        clip.SetRight(ControlWidth);
-        clip.SetTop(0);
-        clip.SetBottom(ControlHeight);
-        clip.SetTopLeftRadiusX      ((float)cornerRadius.TopLeft);
-        clip.SetTopLeftRadiusY      ((float)cornerRadius.TopLeft);
-        clip.SetTopRightRadiusX     ((float)cornerRadius.TopRight);
-        clip.SetTopRightRadiusY     ((float)cornerRadius.TopRight);
-        clip.SetBottomLeftRadiusX   ((float)cornerRadius.BottomLeft);
-        clip.SetBottomLeftRadiusY   ((float)cornerRadius.BottomLeft);
-        clip.SetBottomRightRadiusX  ((float)cornerRadius.BottomRight);
-        clip.SetBottomRightRadiusY  ((float)cornerRadius.BottomRight);
-        dCompVisual.SetClip(clip).CheckError();
-        clip.Dispose();
-        dCompDevice.Commit().CheckError();
+            this.cornerRadius = cornerRadius;
+            cornerRadiusNeedsUpdate = true;
+
+            if (!SCDisposed)
+                UpdateCornerRadiusInternal();
+        }
+    }
+    void UpdateCornerRadiusInternal()
+    {
+        try
+        {
+            dCompDevice.CreateRectangleClip(out var clip).CheckError();
+            clip.SetLeft                (0);
+            clip.SetRight               (ControlWidth);
+            clip.SetTop                 (0);
+            clip.SetBottom              (ControlHeight);
+            clip.SetTopLeftRadiusX      ((float)cornerRadius.TopLeft);
+            clip.SetTopLeftRadiusY      ((float)cornerRadius.TopLeft);
+            clip.SetTopRightRadiusX     ((float)cornerRadius.TopRight);
+            clip.SetTopRightRadiusY     ((float)cornerRadius.TopRight);
+            clip.SetBottomLeftRadiusX   ((float)cornerRadius.BottomLeft);
+            clip.SetBottomLeftRadiusY   ((float)cornerRadius.BottomLeft);
+            clip.SetBottomRightRadiusX  ((float)cornerRadius.BottomRight);
+            clip.SetBottomRightRadiusY  ((float)cornerRadius.BottomRight);
+            dCompVisual.SetClip(clip).CheckError();
+            clip.Dispose();
+            dCompDevice.Commit().CheckError();
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Failed to set CornerRadius = {cornerRadius} ({e.Message})");
+        }
     }
 
-    private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass, IntPtr dwRefData)
+    void UpdateDisplay(bool force = false)
+    {
+        nint newDisplayHwnd = MonitorFromWindow(ControlHandle, MonitorOptions.MONITOR_DEFAULTTONEAREST);
+        if (displayHwnd == newDisplayHwnd && !force)
+            return;
+
+        displayHwnd = newDisplayHwnd;
+
+        var displays = Engine.Video.GetGPUOutputs(dxgiAdapter);
+        foreach(var display in displays)
+            if (displayHwnd == display.Hwnd)
+            {
+                gpuOutput = display;
+                Config.Video.MaxVerticalResolutionAuto  = display.Height;
+                Config.Video.SDRDisplayNitsAuto         = display.MaxLuminance;
+
+                // currently not used (int accurate instead of double)
+                //refreshRateTicks = (int)((1.0 / display.RefreshRate) * 1000 * 10000);
+                if (CanDebug) Log.Debug($"{display}");
+                return;
+            }
+    }
+
+    void AddSubClass()
+    {
+        if (!hasSubClass)
+        {
+            hasSubClass = true;
+            if (Environment.CurrentManagedThreadId == Application.Current.Dispatcher.Thread.ManagedThreadId)
+                SetWindowSubclass(ControlHandle, wndProcDelegatePtr, 0, 0);
+            else
+                UI(() => SetWindowSubclass(ControlHandle, wndProcDelegatePtr, 0, 0));
+        }
+    }
+    void RemoveSubClass()
+    {
+        if (hasSubClass)
+        {
+            hasSubClass = false;
+            if (Environment.CurrentManagedThreadId == Application.Current.Dispatcher.Thread.ManagedThreadId)
+                RemoveWindowSubclass(ControlHandle, wndProcDelegatePtr, 0);
+            else
+                UI(() => RemoveWindowSubclass(ControlHandle, wndProcDelegatePtr, 0));
+        }
+    }
+    IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, IntPtr uIdSubclass, IntPtr dwRefData)
     {
         switch (msg)
         {
             case WM_NCDESTROY:
                 if (SCDisposed)
-                    RemoveWindowSubclass(ControlHandle, wndProcDelegatePtr, UIntPtr.Zero);
+                    RemoveSubClass();
                 else
                     DisposeSwapChain();
+                break;
+
+            // TODO: currently disabled for performance (we only change recommeded resolution/sdrnits) | when more added (Dpi/HDR native etc.)
+            //case WM_MOVE:
+            //    UpdateDisplay();
+            //    break;
+
+            case WM_DISPLAYCHANGE: // top-level window only (any display) - should refresh all and check if current changed
+                UpdateDisplay(true);
                 break;
 
             case WM_SIZE:

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -15,7 +15,7 @@ unsafe public partial class Renderer
      * 2) Filter default values will change when the device/adapter is changed
      */
 
-    static Dictionary<string, VideoProcessorCapsCache> VideoProcessorsCapsCache = [];
+    static Dictionary<long, VideoProcessorCapsCache> VideoProcessorsCapsCache = [];
     VideoProcessorCapsCache curVPCC;
 
     internal static VideoProcessorFilter ConvertFromVideoProcessorFilterCaps(VideoProcessorFilterCaps filter)
@@ -106,7 +106,7 @@ unsafe public partial class Renderer
 
             lock (VideoProcessorsCapsCache)
             {
-                if (VideoProcessorsCapsCache.TryGetValue(Device.Tag.ToString(), out curVPCC))
+                if (VideoProcessorsCapsCache.TryGetValue(gpuAdapter.Luid, out curVPCC))
                 {
                     while (curVPCC.Wait)
                         Thread.Sleep(10);
@@ -114,7 +114,7 @@ unsafe public partial class Renderer
                     if (curVPCC.Failed)
                         return false;
 
-                    vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
+                    vd1 = Device. QueryInterface<ID3D11VideoDevice1>();
                     vc  = context.QueryInterface<ID3D11VideoContext1>();
 
                     vd1.CreateVideoProcessorEnumerator(ref vpcd, out vpe);
@@ -128,10 +128,10 @@ unsafe public partial class Renderer
                 }
 
                 curVPCC = new();
-                VideoProcessorsCapsCache.Add(Device.Tag.ToString(), curVPCC);
+                VideoProcessorsCapsCache.Add(gpuAdapter.Luid, curVPCC);
             }
 
-            vd1 = Device.QueryInterface<ID3D11VideoDevice1>();
+            vd1 = Device. QueryInterface<ID3D11VideoDevice1>();
             vc  = context.QueryInterface<ID3D11VideoContext>();
 
             vd1.CreateVideoProcessorEnumerator(ref vpcd, out vpe);
@@ -145,8 +145,8 @@ unsafe public partial class Renderer
 
             if (CanDebug)
             {
-                var hlg     = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020,  Format.B8G8R8A8_UNorm, ColorSpaceType.RgbFullG22NoneP709);
-                var hdr10   = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, Format.B8G8R8A8_UNorm, ColorSpaceType.RgbStudioG2084NoneP2020);
+                var hlg     = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioGhlgTopLeftP2020,  BGRA_OR_RGBA, ColorSpaceType.RgbFullG22NoneP709);
+                var hdr10   = vpe1.CheckVideoProcessorFormatConversion(Format.P010, ColorSpaceType.YcbcrStudioG2084TopLeftP2020, BGRA_OR_RGBA, ColorSpaceType.RgbStudioG2084NoneP2020);
 
                 dump += $"=====================================================\r\n";
                 dump += $"MaxInputStreams           {vpCaps.MaxInputStreams}\r\n";
@@ -301,45 +301,62 @@ unsafe public partial class Renderer
 
         vc?.VideoProcessorSetOutputBackgroundColor(vp, false, D3D11VPBackgroundColor);
 
-        Present();
+        RenderRequest();
     }
 
     internal void UpdateDeinterlace()
     {
         lock (lockDevice)
         {
-            if (Disposed || VideoStream == null || parent != null)
+            if (Disposed || VideoStream == null)
                 return;
 
             if (GetVP() != VideoProcessor)
                 ConfigPlanes();
             else
-                Present();
+                RenderRequest();
         }
     }
 
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {
-        if(parent != null)
-            return;
-
+        lock (lockDevice)
+            if (!Disposed)
+                UpdateHDRtoSDRUnSafe(updateResource);
+    }
+    internal void UpdateHDRtoSDRUnSafe(bool updateResource = true)
+    {
         psBufferData.tonemap = Config.Video.HDRtoSDRMethod;
 
-        if (psBufferData.tonemap == HDRtoSDRMethod.Hable)
-            psBufferData.hdrtone = 10_000f / Config.Video.SDRDisplayNits;
-        else if (psBufferData.tonemap == HDRtoSDRMethod.Reinhard)
-            psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 2f;
-        else if (psBufferData.tonemap == HDRtoSDRMethod.Aces)
-            psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 7f;
+        switch (psBufferData.tonemap)
+        {
+            case HDRtoSDRMethod.Hable:
+                psBufferData.hdrtone = 10_000f / Config.Video.SDRDisplayNits;
+                break;
+
+            case HDRtoSDRMethod.Reinhard:
+                psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 2f;
+                break;
+
+            case HDRtoSDRMethod.Aces:
+                psBufferData.hdrtone = (10_000f / Config.Video.SDRDisplayNits) / 7f;
+                break;
+        }
 
         if (updateResource)
         {
             context.UpdateSubresource(psBufferData, psBuffer);
-            Present();
+            RenderRequest();
         }
     }
 
     void UpdateRotation(uint angle, bool refresh = true)
+    {
+        lock (lockDevice)
+            if (!Disposed)
+                UpdateRotationUnSafe(angle, refresh);
+    }
+    void UpdateRotationUnSafe(uint angle, bool refresh = true)
     {
         _RotationAngle      = angle;
         uint newRotation    = _RotationAngle;
@@ -387,17 +404,7 @@ unsafe public partial class Renderer
             context.RSSetState(rasterizerState);
         }
 
-        if (parent == null)
-            context.UpdateSubresource(vsBufferData, vsBuffer);
-
-        if (child != null)
-        {
-            child.actualRotation    = actualRotation;
-            child._d3d11vpRotation  = _d3d11vpRotation;
-            child._RotationAngle    = _RotationAngle;
-            child.hasLinesizeVFlip  = hasLinesizeVFlip;
-        }
-
+        context.UpdateSubresource(vsBufferData, vsBuffer);
         vc?.VideoProcessorSetStreamRotation(vp, 0, true, _d3d11vpRotation);
 
         UpdateAspectRatio(refresh);
@@ -405,39 +412,42 @@ unsafe public partial class Renderer
 
     internal void UpdateAspectRatio(bool refresh = true)
     {
-        lock (lockDevice) // TBR: Fix AspectRatio generally* Separate Enum + CustomValue (respect SAR, clarify Fit/Fill/Keep/Stretch/Original/Custom ...)
+        lock (lockDevice)
+            if (!Disposed)
+                UpdateAspectRatioUnSafe(refresh);
+    }
+    internal void UpdateAspectRatioUnSafe(bool refresh = true)
+    {   // TBR: Fix AspectRatio generally* Separate Enum + CustomValue (respect SAR, clarify Fit/Fill/Keep/Stretch/Original/Custom ...)
+        if (Config.Video.AspectRatio == AspectRatio.Keep)
         {
-            if (Config.Video.AspectRatio == AspectRatio.Keep)
-            {
-                curRatio = keepRatio;
-                if (actualRotation == 90 || actualRotation == 270)
-                    curRatio = 1 / curRatio;
+            curRatio = keepRatio;
+            if (actualRotation == 90 || actualRotation == 270)
+                curRatio = 1 / curRatio;
 
-                Config.Player.player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
-            }
-            else if (Config.Video.AspectRatio == AspectRatio.Fill)
-            {
-                curRatio = fillRatio;
-                if (actualRotation == 90 || actualRotation == 270)
-                    curRatio = 1 / curRatio;
-            }
-
-            // No SAR / Rotation respect for customs?
-            else if (Config.Video.AspectRatio == AspectRatio.Custom)
-                curRatio = Config.Video.CustomAspectRatio.Value;
-            else
-                curRatio = Config.Video.AspectRatio.Value;
-
-            Config.Player.player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
-
-            if (refresh)
-                SetViewport();
-
-            child?.UpdateAspectRatio(refresh); // TBR: should just pass the curRatio to child?
+            player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
         }
+        else if (Config.Video.AspectRatio == AspectRatio.Fill)
+        {
+            curRatio = fillRatio;
+            if (actualRotation == 90 || actualRotation == 270)
+                curRatio = 1 / curRatio;
+        }
+        else // No SAR / Rotation respect for customs?
+            curRatio = Config.Video.AspectRatio == AspectRatio.Custom ? Config.Video.CustomAspectRatio.Value : Config.Video.AspectRatio.Value;
+
+        player?.Host?.Player_RatioChanged(curRatio); // return handled and avoid SetViewport?*
+
+        if (refresh)
+            SetViewport();
     }
 
     internal void UpdateCropping(bool refresh = true)
+    {
+        lock (lockDevice)
+            if (!Disposed && VideoStream != null)
+                UpdateCroppingUnSafe(refresh);
+    }
+    internal void UpdateCroppingUnSafe(bool refresh = true)
     {
         /* TODO (SW)
          *
@@ -452,61 +462,52 @@ unsafe public partial class Renderer
          *  e.g. UV Chroma (Semi-Planar) Crop +- (0.5f / (W|H / 2f))?
          */
 
-        lock (lockDevice)
+        cropRect = VideoStream.cropRect;
+
+        if (Config.Video.HasUserCrop)
         {
-            cropRect = VideoStream.cropRect;
-
-            if (Config.Video.HasUserCrop)
-            {
-                cropRect.Top    += Config.Video._Crop.Top;
-                cropRect.Left   += Config.Video._Crop.Left;
-                cropRect.Right  += Config.Video._Crop.Right;
-                cropRect.Bottom += Config.Video._Crop.Bottom;
-            }
-
-            vsBufferData.cropRegion = new()
-            {
-                X = cropRect.Left / (float)textWidth,
-                Y = cropRect.Top  / (float)textHeight,
-                Z = (textWidth  - cropRect.Right)  / (float)textWidth, //1.0f - (right  / (float)textWidth),
-                W = (textHeight - cropRect.Bottom) / (float)textHeight //1.0f - (bottom / (float)textHeight)
-            };
-
-            if (parent == null)
-                context.UpdateSubresource(vsBufferData, vsBuffer);
-
-            VisibleWidth    = textWidth  - (cropRect.Left + cropRect.Right);
-            VisibleHeight   = textHeight - (cropRect.Top  + cropRect.Bottom);
-
-            int x, y;
-            _ = av_reduce(&x, &y, VisibleWidth * VideoStream.SAR.Num, VisibleHeight * VideoStream.SAR.Den, 1024 * 1024);
-            DAR = new(x, y);
-            keepRatio = DAR.Value;
-
-            Config.Player.player?.Video.SetUISize((int)VisibleWidth, (int)VisibleHeight, DAR);
-
-            if (Config.Video.AspectRatio == AspectRatio.Keep)
-            {
-                curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;
-                Config.Player.player?.Host?.Player_RatioChanged(curRatio);
-            }
-            else if (refresh)
-                SetViewport();
-
-            // TBR: child?
+            cropRect.Top    += Config.Video._Crop.Top;
+            cropRect.Left   += Config.Video._Crop.Left;
+            cropRect.Right  += Config.Video._Crop.Right;
+            cropRect.Bottom += Config.Video._Crop.Bottom;
         }
+
+        vsBufferData.cropRegion = new()
+        {
+            X = cropRect.Left / (float)textWidth,
+            Y = cropRect.Top  / (float)textHeight,
+            Z = (textWidth  - cropRect.Right)  / (float)textWidth, //1.0f - (right  / (float)textWidth),
+            W = (textHeight - cropRect.Bottom) / (float)textHeight //1.0f - (bottom / (float)textHeight)
+        };
+
+        context.UpdateSubresource(vsBufferData, vsBuffer);
+
+        VisibleWidth    = textWidth  - (cropRect.Left + cropRect.Right);
+        VisibleHeight   = textHeight - (cropRect.Top  + cropRect.Bottom);
+
+        int x, y;
+        _ = av_reduce(&x, &y, VisibleWidth * VideoStream.SAR.Num, VisibleHeight * VideoStream.SAR.Den, 1024 * 1024);
+        DAR = new(x, y);
+        keepRatio = DAR.Value;
+
+        player?.Video.SetUISize((int)VisibleWidth, (int)VisibleHeight, DAR);
+
+        if (Config.Video.AspectRatio == AspectRatio.Keep)
+        {
+            curRatio = actualRotation == 90 || actualRotation == 270 ? 1 / keepRatio : keepRatio;
+            player?.Host?.Player_RatioChanged(curRatio);
+        }
+        else if (refresh)
+            SetViewport();
     }
 
     internal void UpdateVideoProcessor()
     {
-        if(parent != null)
-            return;
-
         if (Config.Video.VideoProcessor == videoProcessor || (Config.Video.VideoProcessor == VideoProcessors.D3D11 && D3D11VPFailed))
             return;
 
         ConfigPlanes();
-        Present();
+        RenderRequest();
     }
 
     #region Super Resolution
@@ -519,9 +520,9 @@ unsafe public partial class Renderer
         uint method  = 0x2;
         uint enabled = enable ? 1u : 0u;
     }
-    static SuperResNvidia   SuperResEnabledNvidia   = new(true);
-    static SuperResNvidia   SuperResDisabledNvidia  = new(false);
-    static Guid             GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
+    static readonly SuperResNvidia  SuperResEnabledNvidia   = new(true);
+    static readonly SuperResNvidia  SuperResDisabledNvidia  = new(false);
+    static readonly Guid            GUID_SUPERRES_NVIDIA    = Guid.Parse("d43ce1b3-1f4b-48ac-baee-c3c25375e6f7");
 
     [StructLayout(LayoutKind.Sequential)]
     struct SuperResIntel
@@ -535,7 +536,7 @@ unsafe public partial class Renderer
         kIntelVpeFnMode     = 0x20,
 		kIntelVpeFnScaling  = 0x37
     }
-    static Guid             GUID_SUPERRES_INTEL     = Guid.Parse("edd1d4b9-8659-4cbc-a4d6-9831a2163ac3");
+    static readonly Guid            GUID_SUPERRES_INTEL     = Guid.Parse("edd1d4b9-8659-4cbc-a4d6-9831a2163ac3");
 
     internal void UpdateSuperRes()
     {
@@ -548,8 +549,9 @@ unsafe public partial class Renderer
                 DisableSuperRes();
             else
             {
-                var viewport = GetViewport;
-                if (viewport.Width > VisibleWidth && viewport.Height > VisibleHeight)
+                var view = GetViewport;
+                if (((_RotationAngle ==  0 || _RotationAngle == 180) && view.Width > VisibleWidth  && view.Height > VisibleHeight) ||
+                    ((_RotationAngle == 90 || _RotationAngle == 270) && view.Width > VisibleHeight && view.Height > VisibleWidth))
                     EnableSuperRes();
                 else
                     DisableSuperRes();
@@ -565,10 +567,10 @@ unsafe public partial class Renderer
         SuperResolution = true;
         RaiseUI(nameof(SuperResolution));
 
-        if (GPUAdapter.Vendor == GPUVendor.Nvidia)
+        if (gpuAdapter.Vendor == GPUVendor.Nvidia)
             fixed (SuperResNvidia* ptr = &SuperResEnabledNvidia)
                 vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
-        else if (GPUAdapter.Vendor == GPUVendor.Intel)
+        else if (gpuAdapter.Vendor == GPUVendor.Intel)
             UpdateSuperResIntel(true);
     }
 
@@ -580,10 +582,10 @@ unsafe public partial class Renderer
         SuperResolution = false;
         RaiseUI(nameof(SuperResolution));
 
-        if (GPUAdapter.Vendor == GPUVendor.Nvidia)
+        if (gpuAdapter.Vendor == GPUVendor.Nvidia)
             fixed (SuperResNvidia* ptr = &SuperResDisabledNvidia)
                 vc.VideoProcessorSetStreamExtension(vp, 0, GUID_SUPERRES_NVIDIA, (uint)sizeof(SuperResNvidia), (nint)ptr);
-        else if (GPUAdapter.Vendor == GPUVendor.Intel)
+        else if (gpuAdapter.Vendor == GPUVendor.Intel)
             UpdateSuperResIntel(false);
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -316,12 +316,7 @@ unsafe public partial class Renderer
     }
 
     internal void SetFieldType(VideoFrameFormat fieldType)
-    {
-        lock (lockDevice)
-            if (!Disposed)
-                vc.VideoProcessorSetStreamFrameFormat(vp, 0, fieldType);
-                //TBR: vpsa[0].InputFrameOrField = fieldType == DeInterlace.BottomField ? 1u : 0u; // TBR
-    }
+        => vpsa[0].InputFrameOrField = fieldType == VideoFrameFormat.InterlacedBottomFieldFirst ? 1u : 0u;
 
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -283,6 +283,7 @@ unsafe public partial class Renderer
                 Config.Video.SuperResolution ||
                 (fieldType != VideoFrameFormat.Progressive && Config.Video.VideoProcessor == VideoProcessors.Auto)))
         {
+            vpsa[0].OutputIndex = vpsa[0].InputFrameOrField = 0;
             FieldType = fieldType;
             vc.VideoProcessorSetStreamFrameFormat(vp, 0, FieldType);
             return VideoProcessors.D3D11;
@@ -312,11 +313,10 @@ unsafe public partial class Renderer
 
             if (GetVP() != VideoProcessor)
                 ConfigPlanes();
+            else
+                Present();
         }
     }
-
-    internal void SetFieldType(VideoFrameFormat fieldType)
-        => vpsa[0].InputFrameOrField = fieldType == VideoFrameFormat.InterlacedBottomFieldFirst ? 1u : 0u;
 
     internal void UpdateHDRtoSDR(bool updateResource = true)
     {

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
@@ -93,13 +93,13 @@ static const float3x3 coefs[3] =
         1.16438356, -0.18732601, -0.65042418,
         1.16438356,  2.14177196,  0.00000000
     },
-    // 1: BT.709 (Limited)
+    // 1: BT.709  (Limited)
     {
         1.16438356,  0.00000000,  1.79274107,
         1.16438356, -0.21324861, -0.53290933,
         1.16438356,  2.11240179,  0.00000000
     },
-    // 2: BT.601 (Limited)
+    // 2: BT.601  (Limited)
     {
         1.16438356,  0.00000000,  1.59602678,
         1.16438356, -0.39176160, -0.81296823,
@@ -122,13 +122,13 @@ static const float3x3 coefs[3] =
         1.00000000, -0.16455313, -0.57135313,
         1.00000000,  1.88140000,  0.00000000
     },
-    // 1: BT.709 (Full)
+    // 1: BT.709  (Full)
     {
         1.00000000,  0.00000000,  1.57480000,
         1.00000000, -0.18732600, -0.46812400,
         1.00000000,  1.85560000,  0.00000000
     },
-    // 2: BT.601 (Full)
+    // 2: BT.601  (Full)
     {
         1.00000000,  0.00000000,  1.40200000,
         1.00000000, -0.34413600, -0.71413600,
@@ -176,18 +176,14 @@ inline float3 LinearToPQ(float3 rgb, float divider)
 #if defined(dHLGToLinear)
 inline float3 HLGInverse(float3 rgb)
 {
-    const float a = 0.17883277;
-    const float b = 0.28466892;
-    const float c = 0.55991073;
+    const float A = 0.17883277;
+    const float B = 0.28466892;
+    const float C = 0.55991073;
 
     rgb = (rgb <= 0.5)
         ? rgb * rgb * 4.0
-        : (exp((rgb - c) / a) + b);
+        : (exp((rgb - C) / A) + B);
 
-    // This will require different factor-nits for HLG (*19.5)
-    //rgb = (rgb <= 0.5)
-    //    ? (rgb * rgb) / 3.0
-    //    : (exp((rgb - c) / a) + b) / 12.0;
     return rgb;
 }
 
@@ -205,12 +201,13 @@ inline float3 HLGToLinear(float3 rgb)
 #if defined(dTone)
 inline float3 ToneAces(float3 x)
 {
-    const float a = 2.51;
-    const float b = 0.03;
-    const float c = 2.43;
-    const float d = 0.59;
-    const float e = 0.14;
-    return (x * (a * x + b)) / (x * (c * x + d) + e);
+    const float A = 2.51;
+    const float B = 0.03;
+    const float C = 2.43;
+    const float D = 0.59;
+    const float E = 0.14;
+
+    return (x * (A * x + B)) / (x * (C * x + D) + E);
 }
 
 inline float3 ToneHable(float3 x)
@@ -221,14 +218,6 @@ inline float3 ToneHable(float3 x)
     const float D = 0.2f;
     const float E = 0.02f;
     const float F = 0.3f;
-
-    // some use those
-    //const float A = 0.22f;
-    //const float B = 0.3f;
-    //const float C = 0.1f;
-    //const float D = 0.2f;
-    //const float E = 0.01f;
-    //const float F = 0.3f;
 
     return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
 }
@@ -243,10 +232,8 @@ inline float3 ToneReinhard(float3 x)
 #pragma warning( disable: 4000 )
 inline float3 Hue(float3 rgb, float angle)
 {
-    // Compiler optimization will ignore it
-    //[branch]
-    //if (angle == 0)
-    //    return rgb;
+    if (angle == 0)
+        return rgb;
 
     static const float3x3 hueBase = float3x3(
         0.299,  0.587,  0.114,
@@ -274,10 +261,8 @@ inline float3 Hue(float3 rgb, float angle)
 
 inline float3 Saturation(float3 rgb, float saturation)
 {
-    // Compiler optimization will ignore it
-    //[branch]
-    //if (saturation == 1.0)
-    //    return rgb;
+    if (saturation == 1.0)
+        return rgb;
 
     static const float3 kBT709 = float3(0.2126, 0.7152, 0.0722);
 
@@ -285,11 +270,6 @@ inline float3 Saturation(float3 rgb, float saturation)
     return lerp(luminance.rrr, rgb, saturation);
 }
 #pragma warning( enable: 4000 )
-
-// hdrmethod enum
-static const int Aces       = 1;
-static const int Hable      = 2;
-static const int Reinhard   = 3;
 
 struct PSInput
 {
@@ -303,7 +283,6 @@ float4 main(PSInput input) : SV_TARGET
 "u8;
 
     static ReadOnlySpan<byte> PS_FOOTER => @"
-
     float3 c = color.rgb;
 
 #if defined(dYUVLimited)
@@ -313,23 +292,23 @@ float4 main(PSInput input) : SV_TARGET
 #endif
 
 #if defined(dBT2020)
-    c = SRGBToLinear(c);    // TODO: transferfunc gamma*
+    c = SRGBToLinear(c); // TODO: transferfunc
 	c = Gamut2020To709(c);
 	c = saturate(c);
 	c = LinearToSRGB(c);
 #else
 
-#if defined(dPQToLinear)
+    #if defined(dPQToLinear)
 	c = PQToLinear(c, Config.hdrtone);
-#elif defined(dHLGToLinear)
+    #elif defined(dHLGToLinear)
 	c = HLGToLinear(c);
 	c = LinearToPQ(c, 1000.0);
 	c = PQToLinear(c, Config.hdrtone);
-#endif
+    #endif
 
-#if defined(dTone)
+    #if defined(dTone)
     [branch]
-	if (Config.tonemap == Hable)
+	if (Config.tonemap == 2)
 	{
 		c = ToneHable(c) / HABLE_DEFAULT;
         c = saturate(c);
@@ -337,7 +316,7 @@ float4 main(PSInput input) : SV_TARGET
         c = saturate(c);
 		c = LinearToSRGB(c);
 	}
-	else if (Config.tonemap == Reinhard)
+	else if (Config.tonemap == 3)
 	{
 		c = ToneReinhard(c);
         c = saturate(c);
@@ -345,7 +324,7 @@ float4 main(PSInput input) : SV_TARGET
         c = saturate(c);
 		c = LinearToSRGB(c);
 	}
-	else if (Config.tonemap == Aces)
+	else if (Config.tonemap == 1)
 	{
 		c = ToneAces(c);
         c = saturate(c);
@@ -357,12 +336,11 @@ float4 main(PSInput input) : SV_TARGET
     {
         c = LinearToSRGB(c);
     }
-#endif
+    #endif
 
 #endif
 
 #if defined(dFilters)
-    // Contrast / Brightness / Hue / Saturation
     c *= Config.contrast;
     c += Config.brightness;
     c  = Hue(c, Config.hue);

--- a/FlyleafLib/MediaFramework/MediaStream/StreamBase.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/StreamBase.cs
@@ -74,7 +74,6 @@ public abstract unsafe class StreamBase : NotifyPropertyChanged
             StartTimePts= av_rescale_q(StartTime/10, Engine.FFmpeg.AV_TIMEBASE_Q, AVStream->time_base);
         }
 
-        UpdateHLS();
         UpdateMetadata();
         Initialize();
     }
@@ -98,7 +97,10 @@ public abstract unsafe class StreamBase : NotifyPropertyChanged
 
     // Demuxer Callback
     internal virtual void UpdateDuration()
-        => Duration = AVStream->duration != NoTs ? (long)(AVStream->duration * Timebase) : Demuxer.Duration;
+    {
+        Duration = AVStream->duration != NoTs ? (long)(AVStream->duration * Timebase) : Demuxer.Duration;
+        UpdateHLS();
+    }
 
     protected void UpdateHLS()
     {
@@ -153,9 +155,9 @@ public abstract unsafe class StreamBase : NotifyPropertyChanged
         if (StartTime != NoTs || Duration != NoTs)
         {
             dump += "\r\n\t[Time	 ] ";
-            dump += StartTimePts != NoTs ? $"{TicksToTime2(StartTime)} ({StartTimePts})" : "-";
+            dump += StartTimePts != NoTs ? $"{TicksToTime(StartTime)} ({StartTimePts})" : "-";
             dump += " / ";
-            dump += AVStream->duration != NoTs ? $"{TicksToTime2(Duration)} ({AVStream->duration})": "-";
+            dump += AVStream->duration != NoTs ? $"{TicksToTime(Duration)} ({AVStream->duration})": "-";
             dump += $" | tb: {AVStream->time_base}";
         }
 

--- a/FlyleafLib/MediaPlayer/Audio.cs
+++ b/FlyleafLib/MediaPlayer/Audio.cs
@@ -172,22 +172,22 @@ public class Audio : NotifyPropertyChanged
         uiAction = () =>
         {
             StreamIndex     = streamIndex;
-            IsOpened        = IsOpened;
-            Codec           = Codec;
-            BitRate         = BitRate;
-            Bits            = Bits;
-            Channels        = Channels;
-            ChannelLayout   = ChannelLayout;
-            SampleFormat    = SampleFormat;
-            SampleRate      = SampleRate;
+            IsOpened        = isOpened;
+            Codec           = codec;
+            BitRate         = bitRate;
+            Bits            = bits;
+            Channels        = channels;
+            ChannelLayout   = channelLayout;
+            SampleFormat    = sampleFormat;
+            SampleRate      = sampleRate;
 
-            FramesDisplayed = FramesDisplayed;
-            FramesDropped   = FramesDropped;
+            FramesDisplayed = framesDisplayed;
+            FramesDropped   = framesDropped;
         };
 
         // Set default volume
         Volume = Math.Min(Config.Player.VolumeDefault, Config.Player.VolumeMax);
-        Initialize();
+        //Initialize(); TBR: required?
     }
 
     internal void Initialize()
@@ -200,8 +200,8 @@ public class Audio : NotifyPropertyChanged
                 return;
             }
 
-            sampleRate = decoder != null && decoder.AudioStream != null && decoder.AudioStream.SampleRate > 0 ? decoder.AudioStream.SampleRate : 48000;
-            player.Log.Info($"Initialiazing audio ({Device.Name} - {Device.Id} @ {SampleRate}Hz)");
+            sampleRate = decoder.AudioStream != null && decoder.AudioStream.SampleRate > 0 ? decoder.AudioStream.SampleRate : 48000;
+            player.Log.Info($"Initialiazing audio at {SampleRate}Hz ({Device.Id}:{Device.Name})");
 
             Dispose();
 
@@ -276,17 +276,17 @@ public class Audio : NotifyPropertyChanged
                 if (CanDebug)
                     player.Log.Debug($"[Audio] Submitting samples failed ({e.Message})");
 
-                ClearBuffer(); // TBR: Inform player to resync audio?
+                ClearBuffer();
             }
         }
     }
     internal long GetBufferedDuration() { lock (locker) { return (long) ((submittedSamples - sourceVoice.State.SamplesPlayed) * Timebase); } }
-    internal long GetDeviceDelay()      { lock (locker) { return (long) ((xaudio2.PerformanceData.CurrentLatencyInSamples * Timebase) - 80000); } } // TODO: VBlack delay (8ms correction for now)
+    internal long GetDeviceDelay()      { lock (locker) { return (long) ((xaudio2.PerformanceData.CurrentLatencyInSamples * Timebase) - 8_0000); } } // TODO: VBlack delay (8ms correction for now)
     internal void ClearBuffer()
     {
         lock (locker)
         {
-            if (sourceVoice == null)
+            if (submittedSamples == 0 || sourceVoice == null)
                 return;
 
             sourceVoice.Stop();
@@ -325,7 +325,7 @@ public class Audio : NotifyPropertyChanged
         framesDisplayed = 0;
         framesDropped   = 0;
 
-        if (SampleRate!= decoder.AudioStream.SampleRate)
+        if (sampleRate != decoder.AudioStream.SampleRate)
             Initialize();
 
         player.UIAdd(uiAction);
@@ -336,7 +336,7 @@ public class Audio : NotifyPropertyChanged
 
         decoder.OpenSuggestedAudio();
 
-        player.ReSync(decoder.AudioStream, (int) (player.CurTime / 10000), true);
+        player.ReSync(decoder.AudioStream, (int) (player.curTime / 10000), true);
 
         Refresh();
         player.UIAll();
@@ -350,9 +350,7 @@ public class Audio : NotifyPropertyChanged
             return;
 
         decoder.CloseAudio();
-
-        player.aFrame = null;
-
+        player.UpdateMainDemuxer(); // possible in Reset (consider close event)?
         if (!player.Video.IsOpened)
         {
             player.canPlay = false;

--- a/FlyleafLib/MediaPlayer/Data.cs
+++ b/FlyleafLib/MediaPlayer/Data.cs
@@ -51,7 +51,7 @@ public class Data : NotifyPropertyChanged
             return;
 
         decoder.OpenSuggestedData();
-        player.ReSync(decoder.DataStream, (int)(player.CurTime / 10000), true);
+        player.ReSync(decoder.DataStream, (int)(player.curTime / 10000), true);
 
         Refresh();
         player.UIAll();

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -100,9 +100,6 @@ partial class Player
                     sFrames[i] = null;
                 }
 
-                if (renderer.FieldType != Vortice.Direct3D11.VideoFrameFormat.Progressive)
-                    renderer.SetFieldType(renderer.FieldType);
-
                 if (Status == Status.Stopped)
                     decoder?.Initialize();
                 else if (decoder != null)

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -18,10 +18,10 @@ partial class Player
     public event EventHandler<PlaybackStoppedArgs> PlaybackStopped;
     protected virtual void OnPlaybackStopped(string error = null)
     {
-        if (error != null && LastError == null)
+        if (error != null && lastError == null)
         {
             lastError = error;
-            UI(() => LastError = LastError);
+            UI(() => LastError = lastError);
         }
 
         PlaybackStopped?.Invoke(this, new PlaybackStoppedArgs(error));
@@ -39,124 +39,131 @@ partial class Player
     {
         lock (lockActions)
         {
-            if (!CanPlay || Status == Status.Playing || Status == Status.Ended)
+            if (!canPlay || status == Status.Playing || status == Status.Ended)
                 return;
 
             status = Status.Playing;
-            UI(() => Status = Status);
+            UI(() => Status = status);
         }
 
         while (taskPlayRuns || taskSeekRuns) Thread.Sleep(5);
         taskPlayRuns = true;
 
-        Thread t = new(() =>
+        Thread t = new(PlayThread)
         {
-            try
+            #if DEBUG
+            Name            = $"[#{PlayerId}] Playback",
+            #endif
+            Priority        = Config.Player.ThreadPriority,
+            IsBackground    = true
+        };
+
+        t.Start();
+    }
+
+    void PlayThread()
+    {
+        try
+        {
+            Engine.TimeBeginPeriod1();
+            Engine.ThreadExecutionStateBegin();
+
+            onBufferingStarted   = 0;
+            onBufferingCompleted = 0;
+            requiresBuffering    = true;
+
+            if (lastError != null)
             {
-                Engine.TimeBeginPeriod1();
-                NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS | NativeMethods.EXECUTION_STATE.ES_SYSTEM_REQUIRED | NativeMethods.EXECUTION_STATE.ES_DISPLAY_REQUIRED);
+                lastError = null;
+                UI(() => LastError = lastError);
+            }
 
-                onBufferingStarted   = 0;
-                onBufferingCompleted = 0;
-                requiresBuffering    = true;
-
-                if (LastError != null)
+            if (Config.Player.Usage == Usage.Audio || !Video.IsOpened)
+                ScreamerAudioOnly();
+            else
+            {
+                if (Config.Player.ZeroLatency)
+                    ScreamerZeroLatency();
+                else if (ReversePlayback)
                 {
-                    lastError = null;
-                    UI(() => LastError = LastError);
+                    shouldFlushNext = true;
+                    ScreamerReverse();
                 }
-
-                if (Config.Player.Usage == Usage.Audio || !Video.IsOpened)
-                    ScreamerAudioOnly();
                 else
                 {
-                    if (Config.Player.ZeroLatency)
-                        ScreamerZeroLatency();
-                    else if (ReversePlayback)
+                    shouldFlushPrev = true;
+                    ScreamerVASD();
+                }
+            }
+
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Playback failed ({e.Message})");
+            RaiseUnknownErrorOccurred($"Playback failed: {e.Message}", UnknownErrorType.Playback, e);
+        }
+        finally
+        {
+            if (vFrame != renderer.LastFrame)
+                VideoDecoder.DisposeFrame(vFrame);
+            vFrame = null;
+            for (int i = 0; i < subNum; i++)
+            {
+                sFrames[i] = null;
+            }
+
+            if (status == Status.Stopped)
+                decoder?.Initialize();
+            else if (decoder != null)
+            {
+                decoder.PauseOnQueueFull();
+                decoder.PauseDecoders();
+            }
+
+            Audio.ClearBuffer();
+            Engine.TimeEndPeriod1();
+            Engine.ThreadExecutionStateEnd();
+            stoppedWithError = null;
+
+            if (status == Status.Playing)
+            {
+                if (decoderHasEnded)
+                    status = Status.Ended;
+                else
+                {
+                    if (Video.IsOpened && VideoDemuxer.Interrupter.Timedout)
+                        stoppedWithError = "Timeout";
+                    else if (onBufferingStarted - 1 == onBufferingCompleted)
                     {
-                        shouldFlushNext = true;
-                        ScreamerReverse();
+                        stoppedWithError = "Playback stopped unexpectedly";
+                        OnBufferingCompleted("Buffering failed");
                     }
                     else
                     {
-                        shouldFlushPrev = true;
-                        Screamer();
-                    }
-                }
-
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"Playback failed ({ex.Message})");
-                RaiseUnknownErrorOccurred($"Playback failed: {ex.Message}", UnknownErrorType.Playback, ex);
-            }
-            finally
-            {
-                if (vFrame != renderer.LastFrame)
-                    VideoDecoder.DisposeFrame(vFrame);
-                vFrame = null;
-                for (int i = 0; i < subNum; i++)
-                {
-                    sFrames[i] = null;
-                }
-
-                if (Status == Status.Stopped)
-                    decoder?.Initialize();
-                else if (decoder != null)
-                {
-                    decoder.PauseOnQueueFull();
-                    decoder.PauseDecoders();
-                }
-
-                Audio.ClearBuffer();
-                Engine.TimeEndPeriod1();
-                NativeMethods.SetThreadExecutionState(NativeMethods.EXECUTION_STATE.ES_CONTINUOUS);
-                stoppedWithError = null;
-
-                if (IsPlaying)
-                {
-                    if (decoderHasEnded)
-                        status = Status.Ended;
-                    else
-                    {
-                        if (Video.IsOpened && VideoDemuxer.Interrupter.Timedout)
-                            stoppedWithError = "Timeout";
-                        else if (onBufferingStarted - 1 == onBufferingCompleted)
+                        if (!ReversePlayback)
                         {
-                            stoppedWithError = "Playback stopped unexpectedly";
-                            OnBufferingCompleted("Buffering failed");
-                        }
-                        else
-                        {
-                            if (!ReversePlayback)
-                            {
-                                if (isLive || Math.Abs(Duration - CurTime) > 3 * 1000 * 10000)
-                                    stoppedWithError = "Playback stopped unexpectedly";
-                            }
-                            else if (CurTime > 3 * 1000 * 10000)
+                            if (isLive || Math.Abs(duration - curTime) > 3 * 1000 * 10000)
                                 stoppedWithError = "Playback stopped unexpectedly";
                         }
-
-                        status = Status.Paused;
+                        else if (curTime > 3 * 1000 * 10000)
+                            stoppedWithError = "Playback stopped unexpectedly";
                     }
+
+                    status = Status.Paused;
                 }
-
-                OnPlaybackStopped(stoppedWithError);
-                if (CanDebug) Log.Debug($"[SCREAMER] Finished (Status: {Status}, Error: {stoppedWithError})");
-
-                UI(() =>
-                {
-                    Status = Status;
-                    UpdateCurTime();
-                });
-
-                taskPlayRuns = false;
             }
-        });
-        t.Priority = Config.Player.ThreadPriority;
-        t.Name = $"[#{PlayerId}] Playback";
-        t.IsBackground = true;
-        t.Start();
+
+            OnPlaybackStopped(stoppedWithError);
+            if (CanDebug) Log.Debug($"[SCREAMER] Finished (Status: {status}, Error: {stoppedWithError})");
+
+            UI(() =>
+            {
+                Status = status;
+                SetCurTime();
+            });
+
+            taskPlayRuns = false;
+        }
     }
 
     /// <summary>
@@ -166,11 +173,11 @@ partial class Player
     {
         lock (lockActions)
         {
-            if (!CanPlay || Status == Status.Ended)
+            if (!canPlay || status == Status.Ended)
                 return;
 
             status = Status.Paused;
-            UI(() => Status = Status);
+            UI(() => Status = status);
 
             while (taskPlayRuns) Thread.Sleep(5);
         }
@@ -178,7 +185,7 @@ partial class Player
 
     public void TogglePlayPause()
     {
-        if (IsPlaying)
+        if (status == Status.Playing)
             Pause();
         else
             Play();
@@ -235,7 +242,7 @@ partial class Player
 
     private void Seek(int ms, bool forward, bool accurate)
     {
-        if (!CanPlay)
+        if (!canPlay)
             return;
 
         lock (seeks)
@@ -248,10 +255,12 @@ partial class Player
         // (Without this, seek is called with the same timestamp on successive calls, so it will seek to the same subtitle.)
         SubtitlesManager.SetCurrentTime(new TimeSpan(curTime));
 
+        // TBR: We consider UI here? (_CurTime loses sync)
+        // BufferedDuration = 0; Can't se this as it reads the demuxer's (which we didn't seek yet..)
         Raise(nameof(CurTime));
         Raise(nameof(RemainingDuration));
 
-        if (Status == Status.Playing)
+        if (status == Status.Playing)
             return;
 
         lock (seeks)
@@ -276,7 +285,7 @@ partial class Player
                 {
                     lock (seeks)
                     {
-                        if (!(seeks.TryPop(out seekData) && CanPlay && !IsPlaying))
+                        if (!(seeks.TryPop(out seekData) && canPlay && status != Status.Playing))
                         {
                             taskSeekRuns = false;
                             break;
@@ -285,39 +294,43 @@ partial class Player
                         seeks.Clear();
                     }
 
-                    if (Status == Status.Ended)
+                    if (status == Status.Ended)
                     {
                         wasEnded = true;
                         status = Status.Paused;
-                        UI(() => Status = Status);
+                        UI(() => Status = status);
                     }
 
                     for (int i = 0; i < subNum; i++)
                     {
-                        // Display subtitles from cache when seeking while paused
                         bool display = false;
-                        var cur = SubtitlesManager[i].GetCurrent();
-                        if (cur != null)
-                        {
-                            if (!string.IsNullOrEmpty(cur.DisplayText))
-                            {
-                                SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
-                                display = true;
-                            }
-                            else if (cur.IsBitmap && cur.Bitmap != null)
-                            {
-                                SubtitleDisplay(cur.Bitmap, i);
-                                display = true;
-                            }
 
-                            if (display)
+                        if (Subtitles[i].Enabled)
+                        {
+                            // Display subtitles from cache when seeking while paused
+                            var cur = SubtitlesManager[i].GetCurrent();
+                            if (cur != null)
                             {
-                                sFramesPrev[i] = new SubtitlesFrame
+                                if (!string.IsNullOrEmpty(cur.DisplayText))
                                 {
-                                    timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
-                                    duration = (uint)cur.Duration.TotalMilliseconds,
-                                    isTranslated = cur.UseTranslated
-                                };
+                                    SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
+                                    display = true;
+                                }
+                                else if (cur.IsBitmap && cur.Bitmap != null)
+                                {
+                                    SubtitleDisplay(cur.Bitmap, i);
+                                    display = true;
+                                }
+
+                                if (display)
+                                {
+                                    sFramesPrev[i] = new SubtitlesFrame
+                                    {
+                                        timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
+                                        duration = (uint)cur.Duration.TotalMilliseconds,
+                                        isTranslated = cur.UseTranslated
+                                    };
+                                }
                             }
                         }
 
@@ -366,6 +379,7 @@ partial class Player
                         else if (!ReversePlayback && CanPlay)
                         {
                             decoder.GetVideoFrame(seekData.accurate ? seekData.ms * (long)10000 : -1);
+                            ResetFrameStats();
                             ShowOneFrame();
                             VideoDemuxer.Start();
                             AudioDemuxer.Start();

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -1,0 +1,920 @@
+﻿using Vortice.Direct3D11;
+
+using FlyleafLib.MediaFramework.MediaDecoder;
+using FlyleafLib.MediaFramework.MediaFrame;
+using FlyleafLib.MediaFramework.MediaStream;
+
+namespace FlyleafLib.MediaPlayer;
+
+unsafe partial class Player
+{
+    volatile bool isScreamerVASDAudio;
+    volatile bool stopScreamerVASDAudio;
+
+    bool BufferVASD()
+    {
+        if (CanTrace) Log.Trace("Buffering");
+
+        while (isVideoSwitch && IsPlaying) Thread.Sleep(10);
+
+        VideoDemuxer.Start();
+        VideoDecoder.Start();
+
+        if (Audio.isOpened && Config.Audio.Enabled)
+        {
+            curAudioDeviceDelay = Audio.GetDeviceDelay();
+
+            if (AudioDecoder.OnVideoDemuxer)
+                AudioDecoder.Start();
+            else if (!decoder.RequiresResync)
+            {
+                AudioDemuxer.Start();
+                AudioDecoder.Start();
+            }
+        }
+
+        if (Config.Subtitles.Enabled)
+        {
+            for (int i = 0; i < subNum; i++)
+            {
+                if (!Subtitles[i].IsOpened)
+                {
+                    continue;
+                }
+
+                lock (lockSubtitles)
+                {
+                    if (SubtitlesDecoders[i].OnVideoDemuxer)
+                    {
+                        SubtitlesDecoders[i].Start();
+                    }
+                    //else if (!decoder.RequiresResync)
+                    //{
+                    //    SubtitlesDemuxers[i].Start();
+                    //    SubtitlesDecoders[i].Start();
+                    //}
+                }
+            }
+        }
+
+        if (Data.isOpened && Config.Data.Enabled)
+        {
+            if (DataDecoder.OnVideoDemuxer)
+                DataDecoder.Start();
+            else if (!decoder.RequiresResync)
+            {
+                DataDemuxer.Start();
+                DataDecoder.Start();
+            }
+        }
+
+        VideoDecoder.DisposeFrame(vFrame);
+        vFrame = null;
+        aFrame = null;
+        for (int i = 0; i < subNum; i++)
+        {
+            sFrames[i] = null;
+        }
+        dFrame = null;
+
+        bool gotAudio       = !Audio.IsOpened || Config.Player.MaxLatency != 0;
+        bool gotVideo       = false;
+        bool shouldStop     = false;
+        bool showOneFrame   = true;
+        int  audioRetries   = 4;
+        int  loops          = 0;
+
+        if (Config.Player.MaxLatency != 0)
+        {
+            lastSpeedChangeTicks = DateTime.UtcNow.Ticks;
+            showOneFrame = false;
+            Speed = 1;
+        }
+
+        do
+        {
+            loops++;
+
+            if (showOneFrame && !VideoDecoder.Frames.IsEmpty)
+            {
+                ShowOneFrame();
+                showOneFrameTicks = DateTime.UtcNow.Ticks;
+                showOneFrame = false;
+            }
+
+            // We allo few ms to show a frame before cancelling
+            if ((!showOneFrame || loops > 8) && !seeks.IsEmpty)
+                return false;
+
+            if (!gotVideo && !showOneFrame && !VideoDecoder.Frames.IsEmpty)
+            {
+                VideoDecoder.Frames.TryDequeue(out vFrame);
+                if (vFrame != null) gotVideo = true;
+            }
+
+            if (!gotAudio && aFrame == null && !AudioDecoder.Frames.IsEmpty)
+                AudioDecoder.Frames.TryDequeue(out aFrame);
+
+            if (gotVideo)
+            {
+                if (decoder.RequiresResync)
+                    decoder.Resync(vFrame.timestamp);
+
+                if (!gotAudio && aFrame != null)
+                {
+                    for (int i = 0; i < Math.Min(20, AudioDecoder.Frames.Count); i++)
+                    {
+                        if (aFrame == null
+                            || aFrame.timestamp - curAudioDeviceDelay > vFrame.timestamp
+                            || vFrame.timestamp > duration)
+                        {
+                            gotAudio = true;
+                            break;
+                        }
+
+                        if (CanTrace) Log.Trace($"Drop aFrame {TicksToTimeMini(aFrame.timestamp)}");
+                        AudioDecoder.Frames.TryDequeue(out aFrame);
+                    }
+
+                    // Avoid infinite loop in case of all audio timestamps wrong
+                    if (!gotAudio)
+                    {
+                        audioRetries--;
+
+                        if (audioRetries < 1)
+                        {
+                            gotAudio = true;
+                            aFrame = null;
+                            Log.Warn($"Audio Exhausted 1");
+                        }
+                    }
+                }
+            }
+
+            if (!IsPlaying || decoderHasEnded)
+                shouldStop = true;
+            else
+            {
+                if (!VideoDecoder.IsRunning && !isVideoSwitch)
+                {
+                    Log.Warn("Video Exhausted");
+                    shouldStop= true;
+                }
+
+                if (gotVideo && !gotAudio && audioRetries > 0 && (!AudioDecoder.IsRunning || AudioDecoder.Demuxer.Status == MediaFramework.Status.QueueFull))
+                {
+                    if (CanWarn) Log.Warn($"Audio Exhausted 2 | {audioRetries}");
+
+                    audioRetries--;
+
+                    if (audioRetries < 1)
+                        gotAudio  = true;
+                }
+            }
+
+            Thread.Sleep(10);
+
+        } while (!shouldStop && (!gotVideo || !gotAudio));
+
+        if (shouldStop && !(decoderHasEnded && IsPlaying && vFrame != null))
+        {
+            Log.Info("Stopped");
+            return false;
+        }
+
+        if (vFrame == null)
+        {
+            Log.Error("No Frames!");
+            return false;
+        }
+
+        // Negative Buffer Duration during codec change (we don't dipose the cached frames or we receive them later) *skip waiting for now
+        var bufDuration = GetBufferedDuration();
+        if (bufDuration >= 0)
+            while(seeks.IsEmpty && bufDuration < Config.Player.MinBufferDuration && status == Status.Playing && VideoDemuxer.IsRunning && VideoDemuxer.Status != MediaFramework.Status.QueueFull)
+            {
+                Thread.Sleep(20);
+                bufDuration = GetBufferedDuration();
+                if (bufDuration < 0)
+                    break;
+            }
+
+        if (!seeks.IsEmpty)
+            return false;
+
+        decoder.OpenedPlugin.OnBufferingCompleted();
+
+        return true;
+    }
+    void ScreamerVASD()
+    {
+        /* [TODO]
+         * SecondField goes to Renderer
+         * isVideoSwitch should be removed as we use requiresBuffering all time for that?*
+         * Warm up to avoid initial drop frames and get accurate FrameStatistics / refresh rate sync with monitor (cpu-gpu sync, possible with Dwm?)
+         */
+
+        bool secondField    = false;
+
+        while (status == Status.Playing)
+        {
+            // Seeks and then requiresBuffering | TBR: missing SeekCompleted callback?
+            if (seeks.TryPop(out var seekData))
+            {
+                renderer.RenderPlayStop();
+                seeks.Clear();
+                requiresBuffering = true;
+                ResetFrameStats();
+
+                for (int i = 0; i < subNum; i++)
+                {
+                    bool display = false;
+
+                    if (Subtitles[i].Enabled)
+                    {
+                        // Display subtitles from cache when seeking while playing
+                        var cur = SubtitlesManager[i].GetCurrent();
+                        if (cur != null)
+                        {
+                            if (!string.IsNullOrEmpty(cur.DisplayText))
+                            {
+                                SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
+                                display = true;
+                            }
+                            else if (cur.IsBitmap && cur.Bitmap != null)
+                            {
+                                SubtitleDisplay(cur.Bitmap, i);
+                                display = true;
+                            }
+
+                            if (display)
+                            {
+                                sFramesPrev[i] = new SubtitlesFrame
+                                {
+                                    timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
+                                    duration = (uint)cur.Duration.TotalMilliseconds,
+                                    isTranslated = cur.UseTranslated
+                                };
+                            }
+                        }
+                    }
+
+                    // clear subtitles
+                    // but do not clear when cache hit
+                    if (!display && sFramesPrev[i] != null)
+                    {
+                        sFramesPrev[i] = null;
+                        SubtitleClear(i);
+                    }
+                }
+
+                decoder.PauseDecoders(); // TBR: Required to avoid gettings packets between Seek and ShowFrame which causes resync issues
+                StopScreamerVASDAudio();
+                if (decoder.Seek(seekData.accurate ? Math.Max(0, seekData.ms - 3000) : seekData.ms, seekData.forward, !seekData.accurate) < 0) // Consider using GetVideoFrame with no timestamp (any) to ensure keyframe packet for faster seek in HEVC
+                    Log.Warn("[V] Seek Failed");
+                else if (seekData.accurate)
+                    decoder.GetVideoFrame(seekData.ms * (long)10000);
+            }
+
+            // Ensures we have rendered vFrame ready for present (startTicks/sw)
+            if (requiresBuffering)
+            {
+                renderer.RenderPlayStop();
+                if (Config.Player.Stats && framesDisplayedDwmEnd > 0)
+                {
+                    framesDisplayedDwmEnd   = renderer.GetFrameStatistics().PresentCount - framesDisplayedDwmStart;
+                    framesDisplayedDwm     += framesDisplayedDwmEnd;
+                }
+
+                if (VideoDemuxer.Interrupter.Timedout)
+                    break;
+
+                secondField = false;
+
+                OnBufferingStarted();
+                StopScreamerVASDAudio();
+                BufferVASD();
+                requiresBuffering = false;
+                renderer.RenderPlayStart();
+                if (!seeks.IsEmpty)
+                    continue;
+
+                if (vFrame == null)
+                {
+                    if (decoderHasEnded)
+                        OnBufferingCompleted();
+                    else
+                        Log.Warn("[V] Buffer Empty");
+
+                    break;
+                }
+
+                // Prepare 2nd Frame (after ShowOneFrame)
+                if (!renderer.RenderPlay(vFrame, false)) // interlace 2nd frame probably here
+                {
+                    framesFailed++;
+                    vFrame = null;
+                    requiresBuffering = true;
+                    continue;
+                }
+
+                if (Config.Player.Stats)
+                    framesDisplayedDwmStart = renderer.GetFrameStatistics().PresentCount;
+
+                startTicks = vFrame.timestamp;
+                OnBufferingCompleted();
+                if (CanInfo) Log.Info($"[V] Started at {TicksToTimeMini(vFrame.timestamp)}]" + (aFrame == null ? "" : $" [A: {TicksToTimeMini(aFrame.timestamp)}]"));
+                sw.Restart();
+                StartScreamerVASDAudio();
+            }
+
+            if (status != Status.Playing)
+                break;
+
+            // By the end of the loop we must have vFrame ready for present
+            if (vFrame == null)
+            {
+                if (VideoDecoder.Status == MediaFramework.Status.Ended) // TBR: Transfer to Playback finally for all screamers*?
+                {
+                    UpdateCurTime(
+                        Math.Abs(VideoDemuxer.Duration - curTime) < 2 * VideoDemuxer.VideoStream.FrameDuration ?
+                        VideoDemuxer.Duration :
+                        curTime + VideoDemuxer.VideoStream.FrameDuration);
+
+                    break;
+                }
+
+                Log.Warn("[V] Buffer Empty");
+                requiresBuffering = true;
+                continue;
+            }
+
+            // Valid for Present | -3 to 2 (5ms breath)
+            elapsedTicks = (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS);
+            vDistanceMs  = (int) ((((vFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000);
+
+            // CPU Drops to avoid dropping in GPU and also losing sync
+            if (vDistanceMs < -3)
+            {
+                framesFailed++; // don't dispose vFrame is on renderer
+                if (CanDebug) Log.Debug($"[V] Frame Dropped ({vDistanceMs})");
+
+                if (vDistanceMs < -50)// || GetBufferedDuration() < Config.Player.MinBufferDuration / 2)
+                {
+                    vFrame = null;
+                    requiresBuffering = true;
+                    continue;
+                }
+
+                while (!isVideoSwitch && VideoDecoder.Frames.TryDequeue(out vFrame) && vFrame != null && (int) ((((vFrame.timestamp - startTicks) / speed) - (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS)) / 10_000) < 0)
+                {
+                    framesFailed++;
+                    if (CanDebug) Log.Debug($"[V] Frame Dropped ({(int) ((((vFrame.timestamp - startTicks) / speed) - (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS)) / 10_000)}:M)");
+                    VideoDecoder.DisposeFrame(vFrame); vFrame = null;
+                }
+
+                if (vFrame == null)
+                    continue;
+
+                secondField = false;
+                if (!renderer.RenderPlay(vFrame, secondField))
+                {
+                    framesFailed++;
+                    vFrame = null;
+                    requiresBuffering = true;
+                    continue;
+                }
+
+                continue;
+            }
+
+            // Thread Sleep in Parts | Restarts on Late Frame (2sec?)
+            if (vDistanceMs > 2)
+            {
+                if (vDistanceMs > 11)
+                {
+                    if (vDistanceMs > 2_000) // we might need to avoid disposing vFrame here (e.g. HLS wrapped and that's a keyframe?*)
+                    {
+                        requiresBuffering = true;
+                        Log.Warn($"[V] Late Frame ({vDistanceMs})");
+                    }
+                    else
+                        Thread.Sleep(10);
+
+                    continue;
+                }
+
+                Thread.Sleep(vDistanceMs);
+            }
+
+            // Present Current | Render Next
+            if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}{(secondField ? " | SF" : "")}");
+            if (decoder.VideoDecoder.Renderer.PresentPlay())
+            {
+                framesDisplayed++;
+                UpdateCurTime(vFrame.timestamp, false);
+            }
+            else
+                framesFailed++;
+
+            if (renderer.FieldType != VideoFrameFormat.Progressive && Config.Video.DoubleRate && !secondField)
+            {
+                secondField = true;
+                vFrame.timestamp += renderer.VideoStream.FrameDuration2;
+                if (!renderer.RenderPlay(vFrame, secondField))
+                {
+                    framesFailed++;
+                    vFrame = null;
+                }
+            }
+            else
+            {
+                secondField = false;
+
+                if (!isVideoSwitch) VideoDecoder.Frames.TryDequeue(out vFrame); else vFrame = null;
+                if (vFrame == null)
+                {   // Tries to avoid re-buffering by waiting the decoder to catch up
+                    int retries = 20;
+                    while (!isVideoSwitch && !VideoDecoder.Frames.TryDequeue(out vFrame) && retries-- > 0)
+                        Thread.Sleep(1);
+                }
+
+                if (vFrame != null && !renderer.RenderPlay(vFrame, secondField))
+                {
+                    framesFailed++;
+                    vFrame = null;
+                }
+            }
+
+            if (vFrame != null && Config.Player.MaxLatency != 0)
+                CheckLatency();
+
+            // Subs | Data (just transfered for now TBR - might lose sync with video above)
+            bool subOpened = false;
+            for (int i = 0; i < subNum; i++)
+            {
+                if (Subtitles[i].Enabled)
+                    subOpened = true;
+            }
+
+            if (subOpened)
+            {
+                elapsedTicks = (long)(sw.ElapsedTicks * SWFREQ_TO_TICKS);
+
+                for (int i = 0; i < subNum; i++)
+                {
+                    if (!Subtitles[i].IsOpened)
+                        continue;
+
+                    if (sFrames[i] == null && !isSubsSwitches[i])
+                        SubtitlesDecoders[i].Frames.TryPeek(out sFrames[i]);
+
+                    sDistanceMss[i] = sFrames[i] != null
+                        ? (int)((((sFrames[i].timestamp - startTicks) / speed) - elapsedTicks) / 10000)
+                        : int.MaxValue;
+                }
+
+                // Set the current time to SubtitleManager in a loop
+                long curTimeC = curTime;
+                for (int i = 0; i < subNum; i++)
+                {
+                    if (!Subtitles[i].Enabled)
+                        continue;
+
+                    SubtitlesManager[i].SetCurrentTime(new TimeSpan(curTimeC));
+                }
+
+                // Internal subtitles (Text or Bitmap or OCR)
+                for (int i = 0; i < subNum; i++)
+                {
+                    if (!Subtitles[i].Enabled)
+                        continue;
+
+                    if (sFramesPrev[i] != null && ((sFramesPrev[i].timestamp - startTicks + (sFramesPrev[i].duration * (long)10000)) / speed) - elapsedTicks < 0)
+                    {
+                        SubtitleClear(i);
+
+                        sFramesPrev[i] = null;
+                    }
+
+                    if (sFrames[i] != null)
+                    {
+                        if (Math.Abs(sDistanceMss[i]) < 30 || (sDistanceMss[i] < -30 && sFrames[i].duration + sDistanceMss[i] > 0))
+                        {
+                            if (sFrames[i].isBitmap && sFrames[i].sub.num_rects > 0)
+                            {
+                                if (SubtitlesSelectedHelper.GetMethod(i) == SelectSubMethod.OCR)
+                                {
+                                    // Prevent the problem of OCR subtitles not being used in priority by setting
+                                    // the timestamp of the subtitles as they are displayed a little earlier
+                                    SubtitlesManager[i].SetCurrentTime(new TimeSpan(sFrames[i].timestamp));
+                                }
+
+                                var cur = SubtitlesManager[i].GetCurrent();
+
+                                if (cur != null && !string.IsNullOrEmpty(cur.Text))
+                                {
+                                    // Use OCR text subtitles if available
+                                    SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
+                                }
+                                else
+                                {
+                                    // renderer.CreateOverlayTexture(sFrame, SubtitlesDecoder.CodecCtx->width, SubtitlesDecoder.CodecCtx->height);
+                                    SubtitleDisplay(sFrames[i].bitmap, i);
+                                }
+
+                                SubtitlesDecoder.DisposeFrame(sFrames[i]);  // only rects
+                            }
+                            else if (sFrames[i].isBitmap && sFrames[i].sub.num_rects == 0)
+                            {
+                                // For Blu-ray subtitles (PGS), clear the previous subtitle
+                                SubtitleClear(i);
+                                sFramesPrev[i] = sFrames[i] = null;
+                            }
+                            else
+                            {
+                                // internal text sub (does not support translate)
+                                SubtitleDisplay(sFrames[i].text, i, false);
+                            }
+                            sFramesPrev[i] = sFrames[i];
+                            sFrames[i] = null;
+                            SubtitlesDecoders[i].Frames.TryDequeue(out _);
+                        }
+                        else if (sDistanceMss[i] < -30)
+                        {
+                            if (CanDebug)
+                                Log.Debug($"sDistanceMss[i] = {sDistanceMss[i]}");
+
+                            //SubtitleClear(i);
+
+                            // TODO: L: Here sFrames can be null, occurs when switching subtitles?
+                            SubtitlesDecoder.DisposeFrame(sFrames[i]);
+                            sFrames[i] = null;
+                            SubtitlesDecoders[i].Frames.TryDequeue(out _);
+                        }
+                    }
+                }
+
+                // External or ASR subtitles
+                for (int i = 0; i < subNum; i++)
+                {
+                    if (!Subtitles[i].Enabled)
+                        continue;
+
+                    SubtitleData cur = SubtitlesManager[i].GetCurrent();
+
+                    if (cur == null)
+                    {
+                        continue;
+                    }
+
+                    if (sFramesPrev[i] == null ||
+                        sFramesPrev[i].timestamp != cur.StartTime.Ticks + Config.Subtitles[i].Delay)
+                    {
+                        bool display = false;
+                        if (!string.IsNullOrEmpty(cur.DisplayText))
+                        {
+                            SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
+                            display = true;
+                        }
+                        else if (cur.IsBitmap && cur.Bitmap != null)
+                        {
+                            SubtitleDisplay(cur.Bitmap, i);
+                            display = true;
+                        }
+
+                        if (display)
+                        {
+                            sFramesPrev[i] = new SubtitlesFrame
+                            {
+                                timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
+                                duration = (uint)cur.Duration.TotalMilliseconds,
+                                isTranslated = cur.UseTranslated
+                            };
+                        }
+                    }
+                    else
+                    {
+                        // Apply translation to current sub
+                        if (Config.Subtitles[i].EnabledTranslated)
+                        {
+
+                            // If the subtitle currently playing is not translated, change to the translated for display
+                            if (sFramesPrev[i] != null &&
+                                sFramesPrev[i].timestamp == cur.StartTime.Ticks + Config.Subtitles[i].Delay &&
+                                sFramesPrev[i].isTranslated != cur.UseTranslated)
+                            {
+                                SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
+                                sFramesPrev[i].isTranslated = cur.UseTranslated;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (Data.isOpened)
+            {
+                elapsedTicks = (long)(sw.ElapsedTicks * SWFREQ_TO_TICKS);
+
+                if (dFrame == null && !isDataSwitch)
+                    DataDecoder.Frames.TryPeek(out dFrame);
+
+                dDistanceMs = dFrame != null
+                    ? (int)((((dFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000)
+                    : int.MaxValue;
+
+                if (dFrame != null)
+                {
+                    if (Math.Abs(dDistanceMs) < 30 || (dDistanceMs < -30))
+                    {
+                        OnDataFrame?.Invoke(this, dFrame);
+
+                        dFrame = null;
+                        DataDecoder.Frames.TryDequeue(out var devnull);
+                    }
+                    else if (dDistanceMs < -30)
+                    {
+                        if (CanDebug)
+                            Log.Debug($"dDistanceMs = {dDistanceMs}");
+
+                        dFrame = null;
+                        DataDecoder.Frames.TryDequeue(out var devnull);
+                    }
+                }
+            }
+
+        } // while Playing
+
+        renderer.RenderPlayStop();
+        StopScreamerVASDAudio();
+
+        if (Config.Player.Stats)
+        {
+            Thread.Sleep(15); // wait for last present
+            framesDisplayedDwmEnd   = SafeSubstract(renderer.GetFrameStatistics().PresentCount, framesDisplayedDwmStart);
+            framesDisplayedDwm     += framesDisplayedDwmEnd;
+            //Video.fpsCurrent        = 0;
+            UI(() =>
+            {
+                Video.FramesDisplayed   = framesDisplayedDwm + showFrameCount;
+                Video.FramesDropped     = SafeSubstract(framesFailed + framesDisplayed, framesDisplayedDwm);
+                //Video.FPSCurrent        = Video.fpsCurrent;
+            });
+
+            if (CanInfo) Log.Info($"[V] Finished at {TicksToTimeMini(curTime)} | [Presented: {framesDisplayedDwm + showFrameCount}] [Dropped (CPU): {framesFailed}] [Dropped (GPU): {SafeSubstract(framesDisplayed, framesDisplayedDwm)}]]");
+        }
+        else if (CanInfo) Log.Info($"[V] Finished at {TicksToTimeMini(curTime)}");
+
+    }
+    private void CheckLatency()
+    {
+        curLatency = GetBufferedDuration();
+
+        if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Frames: {VideoDecoder.Frames.Count} Packets: {VideoDemuxer.VideoPackets.Count} Speed: {speed}");
+
+        if (curLatency <= Config.Player.MinLatency) // We've reached the down limit (back to speed x1)
+        {
+            ChangeSpeedWithoutBuffering(1);
+            return;
+        }
+        else if (curLatency < Config.Player.MaxLatency)
+            return;
+
+        var newSpeed = Math.Max(Math.Round((double)curLatency / Config.Player.MaxLatency, 1, MidpointRounding.ToPositiveInfinity), 1.1);
+
+        if (newSpeed > 4) // TBR: dispose only as much as required to avoid rebuffering
+        {
+            decoder.Flush();
+            requiresBuffering = true;
+            if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Clearing queue");
+            return;
+        }
+
+        ChangeSpeedWithoutBuffering(newSpeed);
+    }
+    void ChangeSpeedWithoutBuffering(double newSpeed)
+    {
+        if (speed == newSpeed)
+            return;
+
+        long curTicks = DateTime.UtcNow.Ticks;
+
+        if (newSpeed != 1 && curTicks - lastSpeedChangeTicks < Config.Player.LatencySpeedChangeInterval)
+            return;
+
+        lastSpeedChangeTicks = curTicks;
+
+        if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Speed changed x{speed} -> x{newSpeed}");
+
+        if (aFrame != null)
+            AudioDecoder.FixSample(aFrame, speed, newSpeed);
+
+        Speed       = newSpeed;
+        requiresBuffering
+                    = false;
+        startTicks  = curTime;
+        sw.Restart();
+    }
+    long GetBufferedDuration()
+    {
+        var decoder = VideoDecoder.Frames.IsEmpty ? 0 : VideoDecoder.Frames.ToArray()[^1].timestamp - vFrame.timestamp;
+        var demuxer = VideoDemuxer.VideoPackets.IsEmpty || VideoDemuxer.VideoPackets.LastTimestamp == NoTs
+            ? 0 :
+            (VideoDemuxer.VideoPackets.LastTimestamp - VideoDemuxer.StartTime) - vFrame.timestamp;
+
+        return Math.Max(decoder, demuxer);
+    }
+
+    void ScreamerVASDAudio()
+    {
+        long bufferTicks    = 0;
+        long delayTicks     = 0;
+        long elapsedTicks   = 0;
+        long waitTicks      = 0;
+        long desyncMs       = 0;    // use Ms to avoid rescale inaccuracy
+        long expectingPts   = NoTs; // Will be set on resync
+        bool shouldResync   = true;
+
+        const long MIN_PLAY_BUFFER  = 40_0000;  // Start fill (TBR: allow some space from MAX to avoid filling all time?*)
+        const long MAX_PLAY_BUFFER  = 80_0000;  // Stop  fill (try to keep it low so we can easier switch speed?*)
+        const long MIN_DEC_BUFFER   = 19_0000;  // Resync when enough decoded buffer (related to MaxAudioFrame, keep it low for now)
+        const long MAX_DESYNC_MS    = 50;       // A small gap between frames can create audio desync (use Ms instead to allow small diff for rescale Tb inaccuracy)
+
+        while (!stopScreamerVASDAudio)
+        {
+            if (aFrame == null)
+                AudioDecoder.Frames.TryDequeue(out aFrame);
+
+            if (aFrame == null)
+            {
+                if (decoderHasEnded)
+                    break;
+
+                Thread.Sleep(10);
+                continue;
+            }
+
+            bufferTicks = Audio.GetBufferedDuration();
+
+            if (!shouldResync)
+            {
+                if (bufferTicks > MIN_PLAY_BUFFER)      // Play Buffer has enough samples
+                    Thread.Sleep(10);
+                else if (bufferTicks < 3_0000)          // Low Play Buffer (risk of using latency on next buffer submit)
+                    shouldResync = true;
+                else if (bufferTicks <= MIN_PLAY_BUFFER)// Re-filling an already filled buffer | We consider continues (no waitTicks check) however desyncMs will catch it
+                {
+                    desyncMs += (aFrame.timestamp - expectingPts) / 10000;
+                    FillBuffer();
+                }
+            }
+            else
+            {
+                if (bufferTicks > 3_0000)
+                {
+                    Thread.Sleep(Math.Min((int)(bufferTicks / 10000), 10));
+                    continue;
+                }
+
+                delayTicks  = Audio.GetDeviceDelay();
+                elapsedTicks= (long)(sw.ElapsedTicks * SWFREQ_TO_TICKS);
+                waitTicks   = (long)((aFrame.timestamp - startTicks) / speed) - (elapsedTicks + delayTicks); // TODO: crash on AllocateCircularBuffer
+
+                if (Math.Abs(waitTicks) > 5_000_0000) // Far away
+                {
+                    Log.Warn($"[A] Late Frame ({TicksToTimeMini(waitTicks)})");
+                    requiresBuffering = true;
+                    continue;
+                }
+                else if (waitTicks > 10_0000) // Not yet
+                    continue;
+                else if (waitTicks < -10_0000) // Drop frames to get closer
+                {
+                    var dropsBefore = Audio.framesDropped;
+                    Audio.framesDropped++;
+                    while (AudioDecoder.Frames.TryDequeue(out aFrame) && aFrame != null)
+                    {
+                        Audio.framesDropped++;
+                        waitTicks = (long)((aFrame.timestamp - startTicks) / speed) - (elapsedTicks + delayTicks);
+                        if (waitTicks >= -10_0000)
+                            break;
+                    }
+
+                    if (CanDebug) Log.Debug($"[A] Frames Dropped (Drops: {Audio.framesDropped - dropsBefore}, Total: {Audio.framesDropped})");
+
+                    if (aFrame == null || Math.Abs(waitTicks) > 10_0000)
+                        continue;
+                }
+
+                // Calc decoded duration (must be enough to avoid crackling) | TBR: lock with speed?
+                var frames = AudioDecoder.Frames.ToArray();
+                long decodedDuration = 0;
+                for (int i = 0; i < frames.Length; i++)
+                {
+                    decodedDuration += (long)((frames[i].dataLen / 4) * Audio.Timebase);
+                    if (decodedDuration > MIN_DEC_BUFFER)
+                        break;
+                }
+
+                if (decodedDuration < MIN_DEC_BUFFER)
+                {
+                    if (CanDebug) Log.Debug($"[A] Resync requires more buffer ({TicksToTimeMini(decodedDuration)})");
+                    continue;
+                }
+
+                shouldResync = false;
+
+                // Small Adjustement (for early frames)
+                if (waitTicks > 1_0000)
+                    Thread.Sleep((int)(waitTicks / 10000));
+
+                // TBR: We miss samples we add so GetBufferedDuration is not accurate (mainly with filters/speed etc... might happen?)
+                // Ensure XAudio has empty buffer (we restart with device latency/delay)
+                //if (bufferTicks > 0)
+                //    while (Audio.GetBufferedDuration() > 0)
+                //        Thread.Sleep(1);
+                Audio.ClearBuffer();
+
+                if (CanDebug) Log.Debug($"[A] Resynced at {TicksToTimeMini(aFrame.timestamp)} [Diff: {TicksToTimeMini((long)((aFrame.timestamp - startTicks) / speed) - delayTicks)} | {TicksToTimeMini((long)(sw.ElapsedTicks * SWFREQ_TO_TICKS))}]");
+
+                // Fill Enough Samples
+                desyncMs = 0;
+                FillBuffer();
+            }
+
+            void FillBuffer()
+            {
+                Audio.AddSamples(aFrame);
+                expectingPts = aFrame.timestamp + (long)(speed * aFrame.dataLen / 4 * Audio.Timebase);
+                while (AudioDecoder.Frames.TryDequeue(out aFrame) && aFrame != null && Audio.GetBufferedDuration() < MAX_PLAY_BUFFER)
+                {
+                    desyncMs += (aFrame.timestamp - expectingPts) / 10000;
+                    Audio.AddSamples(aFrame);
+                    expectingPts = aFrame.timestamp + (long)(speed * aFrame.dataLen / 4 * Audio.Timebase);
+
+                    if (desyncMs > MAX_DESYNC_MS)
+                        break;
+                }
+
+                if (desyncMs > MAX_DESYNC_MS)
+                {
+                    Log.Warn($"[A] Desynced ({TicksToTimeMini(desyncMs * 10000)})");
+                    shouldResync = true;
+                }
+            }
+        }
+
+        isScreamerVASDAudio = false;
+        Audio.ClearBuffer();
+
+        if (CanInfo) Log.Info($"[A] Finished at {TicksToTimeMini(curTime)}");
+    }
+    void StartScreamerVASDAudio()
+    {
+        if (!Audio.isOpened)
+            return;
+
+        StopScreamerVASDAudio();
+        isScreamerVASDAudio = true;
+        Thread t = new(ScreamerVASDAudio) // try-catch
+        {
+            #if DEBUG
+            Name            = $"[#{PlayerId}] [A] Playback",
+            #endif
+            IsBackground    = true
+        };
+        t.Start();
+    }
+    void StopScreamerVASDAudio()
+    {
+        stopScreamerVASDAudio = true;
+        while(isScreamerVASDAudio)
+            Thread.Sleep(2);
+
+        stopScreamerVASDAudio = false;
+    }
+
+    #region Frame Statistics
+    uint showFrameCount, framesFailed, framesDisplayed, framesDisplayedDwm, framesDisplayedDwmStart, framesDisplayedDwmEnd;
+    internal void ResetFrameStats()
+    {
+        if (Config.Player.Stats && showFrameCount != 0)
+        {
+            /*Video.fpsCurrent = */showFrameCount = framesFailed = framesDisplayed = framesDisplayedDwm = framesDisplayedDwmEnd = 0;
+            UI(() => /*Video.FPSCurrent = */Video.FramesDropped = Video.FramesDisplayed = 0);
+        }
+    }
+    internal (uint, uint) FramesDisplayedDropped()
+    {
+        var presentCount = renderer.GetFrameStatistics().PresentCount;
+        var framesDisplayedDwmCur = framesDisplayedDwm + SafeSubstract(presentCount, framesDisplayedDwmStart);
+        return (framesDisplayedDwmCur + showFrameCount, SafeSubstract(framesFailed + framesDisplayed + 1, framesDisplayedDwmCur));
+    }
+    static uint SafeSubstract(uint a, uint b) => a >= b ? a - b : 0;
+
+    // we consider those during status == Status.Playing (for Engine) | We could expose public those?
+    //internal uint FramesDisplayedTotal  => renderer.GetStats().PresentCount;
+    //internal uint FramesDisplayed       => framesDisplayedDwm + SafeSubstract(renderer.GetStats().PresentCount, framesDisplayedDwmStart) + showFrameCount;
+    //internal uint FramesDropped         => SafeSubstract(framesFailed + framesDisplayed + 1, FramesDisplayed - showFrameCount); // +1 for Current
+    #endregion
+}

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -61,11 +61,9 @@ unsafe partial class Player
     int     sleepMs;
 
     long    elapsedTicks;
-    long    elapsedSec;
     long    startTicks;
     long    showOneFrameTicks;
 
-    int     allowedLateAudioDrops;
     long    lastSpeedChangeTicks;
     long    curLatency;
     internal long curAudioDeviceDelay;
@@ -83,16 +81,9 @@ unsafe partial class Player
         if (VideoDecoder.Frames.IsEmpty || !VideoDecoder.Frames.TryDequeue(out vFrame))
             return;
 
-        renderer.Present(vFrame);
-        Video.framesDisplayed++;
-
-        if (!seeks.IsEmpty)
-            return;
-
-        if (!VideoDemuxer.IsHLSLive)
-            curTime = vFrame.timestamp;
-
-        UI(() => UpdateCurTime());
+        renderer.RenderRequest(vFrame);
+        UpdateCurTime(vFrame.timestamp);
+        showFrameCount++;
 
         for (int i = 0; i < subNum; i++)
         {
@@ -124,754 +115,6 @@ unsafe partial class Player
         vFrame = null;
     }
 
-    // !!! NEEDS RECODING (We show one frame, we dispose it, we get another one and we show it also after buffering which can be in 'no time' which can leave us without any more decoded frames so we rebuffer)
-    private bool MediaBuffer()
-    {
-        if (CanTrace) Log.Trace("Buffering");
-
-        while (isVideoSwitch && IsPlaying) Thread.Sleep(10);
-
-        Audio.ClearBuffer();
-
-        VideoDemuxer.Start();
-        VideoDecoder.Start();
-
-        if (Audio.isOpened && Config.Audio.Enabled)
-        {
-            curAudioDeviceDelay = Audio.GetDeviceDelay();
-
-            if (AudioDecoder.OnVideoDemuxer)
-                AudioDecoder.Start();
-            else if (!decoder.RequiresResync)
-            {
-                AudioDemuxer.Start();
-                AudioDecoder.Start();
-            }
-        }
-
-        if (Config.Subtitles.Enabled)
-        {
-            for (int i = 0; i < subNum; i++)
-            {
-                if (!Subtitles[i].IsOpened)
-                {
-                    continue;
-                }
-
-                lock (lockSubtitles)
-                {
-                    if (SubtitlesDecoders[i].OnVideoDemuxer)
-                    {
-                        SubtitlesDecoders[i].Start();
-                    }
-                    //else if (!decoder.RequiresResync)
-                    //{
-                    //    SubtitlesDemuxers[i].Start();
-                    //    SubtitlesDecoders[i].Start();
-                    //}
-                }
-            }
-        }
-
-        if (Data.isOpened && Config.Data.Enabled)
-        {
-            if (DataDecoder.OnVideoDemuxer)
-                DataDecoder.Start();
-            else if (!decoder.RequiresResync)
-            {
-                DataDemuxer.Start();
-                DataDecoder.Start();
-            }
-        }
-
-        VideoDecoder.DisposeFrame(vFrame);
-        vFrame = null;
-        aFrame = null;
-        for (int i = 0; i < subNum; i++)
-        {
-            sFrames[i] = null;
-        }
-        dFrame = null;
-
-        bool gotAudio       = !Audio.IsOpened || Config.Player.MaxLatency != 0;
-        bool gotVideo       = false;
-        bool shouldStop     = false;
-        bool showOneFrame   = true;
-        int  audioRetries   = 4;
-        int  loops          = 0;
-
-        if (Config.Player.MaxLatency != 0)
-        {
-            lastSpeedChangeTicks = DateTime.UtcNow.Ticks;
-            showOneFrame = false;
-            Speed = 1;
-        }
-
-        do
-        {
-            loops++;
-
-            if (showOneFrame && !VideoDecoder.Frames.IsEmpty)
-            {
-                ShowOneFrame();
-                showOneFrameTicks = DateTime.UtcNow.Ticks;
-                showOneFrame = false;
-            }
-
-            // We allo few ms to show a frame before cancelling
-            if ((!showOneFrame || loops > 8) && !seeks.IsEmpty)
-                return false;
-
-            if (!gotVideo && !showOneFrame && !VideoDecoder.Frames.IsEmpty)
-            {
-                VideoDecoder.Frames.TryDequeue(out vFrame);
-                if (vFrame != null) gotVideo = true;
-            }
-
-            if (!gotAudio && aFrame == null && !AudioDecoder.Frames.IsEmpty)
-                AudioDecoder.Frames.TryDequeue(out aFrame);
-
-            if (gotVideo)
-            {
-                if (decoder.RequiresResync)
-                    decoder.Resync(vFrame.timestamp);
-
-                if (!gotAudio && aFrame != null)
-                {
-                    for (int i=0; i<Math.Min(20, AudioDecoder.Frames.Count); i++)
-                    {
-                        if (aFrame == null
-                            || aFrame.timestamp - curAudioDeviceDelay > vFrame.timestamp
-                            || vFrame.timestamp > Duration)
-                        {
-                            gotAudio = true;
-                            break;
-                        }
-
-                        if (CanTrace) Log.Trace($"Drop aFrame {TicksToTime(aFrame.timestamp)}");
-                        AudioDecoder.Frames.TryDequeue(out aFrame);
-                    }
-
-                    // Avoid infinite loop in case of all audio timestamps wrong
-                    if (!gotAudio)
-                    {
-                        audioRetries--;
-
-                        if (audioRetries < 1)
-                        {
-                            gotAudio = true;
-                            aFrame = null;
-                            Log.Warn($"Audio Exhausted 1");
-                        }
-                    }
-                }
-            }
-
-            if (!IsPlaying || decoderHasEnded)
-                shouldStop = true;
-            else
-            {
-                if (!VideoDecoder.IsRunning && !isVideoSwitch)
-                {
-                    Log.Warn("Video Exhausted");
-                    shouldStop= true;
-                }
-
-                if (gotVideo && !gotAudio && audioRetries > 0 && (!AudioDecoder.IsRunning || AudioDecoder.Demuxer.Status == MediaFramework.Status.QueueFull))
-                {
-                    if (CanWarn) Log.Warn($"Audio Exhausted 2 | {audioRetries}");
-
-                    audioRetries--;
-
-                    if (audioRetries < 1)
-                        gotAudio  = true;
-                }
-            }
-
-            Thread.Sleep(10);
-
-        } while (!shouldStop && (!gotVideo || !gotAudio));
-
-        if (shouldStop && !(decoderHasEnded && IsPlaying && vFrame != null))
-        {
-            Log.Info("Stopped");
-            return false;
-        }
-
-        if (vFrame == null)
-        {
-            Log.Error("No Frames!");
-            return false;
-        }
-
-        // Negative Buffer Duration during codec change (we don't dipose the cached frames or we receive them later) *skip waiting for now
-        var bufDuration = GetBufferedDuration();
-        if (bufDuration >= 0)
-            while(seeks.IsEmpty && bufDuration < Config.Player.MinBufferDuration && IsPlaying && VideoDemuxer.IsRunning && VideoDemuxer.Status != MediaFramework.Status.QueueFull)
-            {
-                Thread.Sleep(20);
-                bufDuration = GetBufferedDuration();
-                if (bufDuration < 0)
-                    break;
-            }
-
-        if (!seeks.IsEmpty)
-            return false;
-
-        if (CanInfo) Log.Info($"Started [V: {TicksToTime(vFrame.timestamp)}]" + (aFrame == null ? "" : $" [A: {TicksToTime(aFrame.timestamp)}]"));
-
-        decoder.OpenedPlugin.OnBufferingCompleted();
-
-        return true;
-    }
-    private void Screamer()
-    {
-        long audioBufferedDuration = 0; // We force audio resync with = 0
-        bool secondField = false;
-
-        while (Status == Status.Playing)
-        {
-            if (seeks.TryPop(out var seekData))
-            {
-                seeks.Clear();
-                requiresBuffering = true;
-
-                for (int i = 0; i < subNum; i++)
-                {
-                    // Display subtitles from cache when seeking while playing
-                    bool display = false;
-                    var cur = SubtitlesManager[i].GetCurrent();
-                    if (cur != null)
-                    {
-                        if (!string.IsNullOrEmpty(cur.DisplayText))
-                        {
-                            SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
-                            display = true;
-                        }
-                        else if (cur.IsBitmap && cur.Bitmap != null)
-                        {
-                            SubtitleDisplay(cur.Bitmap, i);
-                            display = true;
-                        }
-
-                        if (display)
-                        {
-                            sFramesPrev[i] = new SubtitlesFrame
-                            {
-                                timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
-                                duration = (uint)cur.Duration.TotalMilliseconds,
-                                isTranslated = cur.UseTranslated
-                            };
-                        }
-                    }
-
-                    // clear subtitles
-                    // but do not clear when cache hit
-                    if (!display && sFramesPrev[i] != null)
-                    {
-                        sFramesPrev[i] = null;
-                        SubtitleClear(i);
-                    }
-                }
-
-                decoder.PauseDecoders(); // TBR: Required to avoid gettings packets between Seek and ShowFrame which causes resync issues
-
-                if (decoder.Seek(seekData.accurate ? Math.Max(0, seekData.ms - (int)new TimeSpan(Config.Player.SeekAccurateFixMargin).TotalMilliseconds) : seekData.ms, seekData.forward, !seekData.accurate) < 0) // Consider using GetVideoFrame with no timestamp (any) to ensure keyframe packet for faster seek in HEVC
-                    Log.Warn("Seek failed");
-                else if (seekData.accurate)
-                    decoder.GetVideoFrame(seekData.ms * (long)10000);
-            }
-
-            if (requiresBuffering)
-            {
-                if (VideoDemuxer.Interrupter.Timedout)
-                    break;
-
-                secondField = false;
-
-                OnBufferingStarted();
-                MediaBuffer();
-                requiresBuffering = false;
-                if (!seeks.IsEmpty)
-                    continue;
-
-                if (vFrame == null)
-                {
-                    if (decoderHasEnded)
-                        OnBufferingCompleted();
-
-                    Log.Warn("[MediaBuffer] No video frame");
-                    break;
-                }
-
-                // Temp fix to ensure we had enough time to decode one more frame
-                int retries = 5;
-                while (IsPlaying && VideoDecoder.Frames.Count == 0 && retries-- > 0)
-                    Thread.Sleep(10);
-
-                // Give enough time for the 1st frame to be presented
-                while (IsPlaying && DateTime.UtcNow.Ticks - showOneFrameTicks < VideoDecoder.VideoStream.FrameDuration)
-                    Thread.Sleep(4);
-
-                OnBufferingCompleted();
-
-                audioBufferedDuration = 0;
-                allowedLateAudioDrops = 7;
-                elapsedSec = 0;
-                startTicks = vFrame.timestamp;
-                sw.Restart();
-            }
-
-            if (Status != Status.Playing)
-                break;
-
-            if (vFrame == null)
-            {
-                if (VideoDecoder.Status == MediaFramework.Status.Ended)
-                {
-                    if (!MainDemuxer.IsHLSLive)
-                    {
-                        if (Math.Abs(MainDemuxer.Duration - curTime) < 2 * VideoDemuxer.VideoStream.FrameDuration)
-                            curTime = MainDemuxer.Duration;
-                        else
-                            curTime += VideoDemuxer.VideoStream.FrameDuration;
-
-                        UI(() => Set(ref _CurTime, curTime, true, nameof(CurTime)));
-                    }
-
-                    break;
-                }
-
-                Log.Warn("No video frames");
-                requiresBuffering = true;
-                continue;
-            }
-
-            if (aFrame == null && !isAudioSwitch)
-                AudioDecoder.Frames.TryDequeue(out aFrame);
-
-            for (int i = 0; i < subNum; i++)
-            {
-                if (sFrames[i] == null && !isSubsSwitches[i])
-                    SubtitlesDecoders[i].Frames.TryPeek(out sFrames[i]);
-            }
-
-            if (dFrame == null && !isDataSwitch)
-                DataDecoder.Frames.TryPeek(out dFrame);
-
-            elapsedTicks = (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS); // Do we really need ticks precision?
-
-            vDistanceMs =
-                  (int) ((((vFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000);
-
-            if (aFrame != null)
-            {
-                curAudioDeviceDelay     = Audio.GetDeviceDelay();
-                audioBufferedDuration   = Audio.GetBufferedDuration();
-                aDistanceMs = (int) ((((aFrame.timestamp - startTicks) / speed) - (elapsedTicks - curAudioDeviceDelay)) / 10000);
-
-                // Try to keep the audio buffer full enough to avoid audio crackling (up to 50ms)
-                while (audioBufferedDuration > 0 && audioBufferedDuration < 50 * 10000 && aDistanceMs > -5 && aDistanceMs < 50)
-                {
-                    Audio.AddSamples(aFrame);
-
-                    if (isAudioSwitch)
-                    {
-                        audioBufferedDuration = 0;
-                        aDistanceMs = int.MaxValue;
-                        aFrame = null;
-                    }
-                    else
-                    {
-                        audioBufferedDuration = Audio.GetBufferedDuration();
-                        AudioDecoder.Frames.TryDequeue(out aFrame);
-                        if (aFrame != null)
-                            aDistanceMs = (int) ((((aFrame.timestamp - startTicks) / speed) - (elapsedTicks - curAudioDeviceDelay)) / 10000);
-                        else
-                            aDistanceMs = int.MaxValue;
-                    }
-                }
-            }
-            else
-                aDistanceMs = int.MaxValue;
-
-            for (int i = 0; i < subNum; i++)
-            {
-                sDistanceMss[i] = sFrames[i] != null
-                    ? (int)((((sFrames[i].timestamp - startTicks) / speed) - elapsedTicks) / 10000)
-                    : int.MaxValue;
-            }
-
-            dDistanceMs = dFrame != null
-                ? (int)((((dFrame.timestamp - startTicks) / speed) - elapsedTicks) / 10000)
-                : int.MaxValue;
-
-            sleepMs = Math.Min(dDistanceMs, Math.Min(vDistanceMs, aDistanceMs)) - 1;
-            if (sleepMs < 0 || sleepMs == int.MaxValue)
-                sleepMs = 0;
-
-            if (sleepMs > 2)
-            {
-                if (vDistanceMs > 2000)
-                {
-                    Log.Warn($"vDistanceMs = {vDistanceMs} (restarting)");
-                    requiresBuffering = true;
-                    continue;
-                }
-
-                if (Engine.Config.UICurTimePerSecond &&  (
-                    (!MainDemuxer.IsHLSLive && curTime / 10000000 != _CurTime / 10000000) ||
-                    (MainDemuxer.IsHLSLive && Math.Abs(elapsedTicks - elapsedSec) > 10000000)))
-                {
-                    elapsedSec  = elapsedTicks;
-                    UI(UpdateCurTime);
-                }
-
-                Thread.Sleep(sleepMs);
-            }
-
-            if (aFrame != null) // Should use different thread for better accurancy (renderer might delay it on high fps) | also on high offset we will have silence between samples
-            {
-                if (Math.Abs(aDistanceMs - sleepMs) <= 5)
-                {
-                    Audio.AddSamples(aFrame);
-
-                    // Audio Desync - Large Buffer | ASampleBytes (S16 * 2 Channels = 4) * TimeBase * 2 -frames duration- (TBR: Related to min/max samples on AudioDecoder filters - 2frames * 70ms max)
-                    if (Audio.GetBufferedDuration() > Math.Max(140 * 10000, (aFrame.dataLen / 4) * Audio.Timebase * 2)) // NOTE: Simple Swr does not have limits 20/70
-                    {
-                        if (CanDebug)
-                            Log.Debug($"Audio desynced by {(int)(audioBufferedDuration / 10000)}ms, clearing buffers");
-
-                        Audio.ClearBuffer();
-                        audioBufferedDuration = 0;
-                    }
-
-                    aFrame = null;
-                }
-                else if (aDistanceMs > 4000) // Drops few audio frames in case of wrong timestamps (Note this should be lower, until swr has min/max samples for about 20-70ms)
-                {
-                    if (allowedLateAudioDrops > 0)
-                    {
-                        Audio.framesDropped++;
-                        allowedLateAudioDrops--;
-                        if (CanDebug) Log.Debug($"aDistanceMs 3 = {aDistanceMs}");
-                        aFrame = null;
-                        audioBufferedDuration = 0;
-                    }
-                }
-                else if (aDistanceMs < -5) // Will be transfered back to decoder to drop invalid timestamps
-                {
-                    if (CanTrace) Log.Trace($"aDistanceMs = {aDistanceMs} | AudioFrames: {AudioDecoder.Frames.Count} AudioPackets: {AudioDecoder.Demuxer.AudioPackets.Count}");
-
-                    if (GetBufferedDuration() < Config.Player.MinBufferDuration / 2)
-                    {
-                        if (CanInfo)
-                            Log.Warn($"Not enough buffer (restarting)");
-
-                        requiresBuffering = true;
-                        continue;
-                    }
-
-                    audioBufferedDuration = 0;
-
-                    if (aDistanceMs < -600)
-                    {
-                        if (CanTrace) Log.Trace($"All audio frames disposed");
-                        Audio.framesDropped += AudioDecoder.Frames.Count;
-                        AudioDecoder.DisposeFrames();
-                        aFrame = null;
-                    }
-                    else
-                    {
-                        int maxdrop = Math.Max(Math.Min(vDistanceMs - sleepMs - 1, 20), 3);
-                        for (int i=0; i<maxdrop; i++)
-                        {
-                            if (CanTrace) Log.Trace($"aDistanceMs 2 = {aDistanceMs}");
-                            Audio.framesDropped++;
-                            AudioDecoder.Frames.TryDequeue(out aFrame);
-
-                            if (aFrame == null || ((aFrame.timestamp - startTicks) / speed) - ((long) (sw.ElapsedTicks * SWFREQ_TO_TICKS) - Audio.GetDeviceDelay() + 8 * 1000) > 0)
-                                break;
-
-                            aFrame = null;
-                        }
-                    }
-                }
-            }
-
-            if (Math.Abs(vDistanceMs - sleepMs) <= 2)
-            {
-                if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}");
-
-                if (decoder.VideoDecoder.Renderer.Present(vFrame, false, secondField))
-                    Video.framesDisplayed++;
-                else
-                    Video.framesDropped++;
-
-                lock (seeks)
-                    if (seeks.IsEmpty)
-                    {
-                        curTime = !MainDemuxer.IsHLSLive ? vFrame.timestamp : VideoDemuxer.CurTime;
-
-                        if (Config.Player.UICurTimePerFrame)
-                            UI(UpdateCurTime);
-                    }
-
-                if (renderer.FieldType != VideoFrameFormat.Progressive && Config.Video.DoubleRate && !secondField)
-                {
-                    secondField = true;
-                    vFrame.timestamp += renderer.VideoStream.FrameDuration2;
-                }
-                else
-                {
-                    VideoDecoder.Frames.TryDequeue(out vFrame);
-                    secondField = false;
-                }
-
-                if (vFrame != null && Config.Player.MaxLatency != 0)
-                    CheckLatency();
-            }
-            else if (vDistanceMs < -2)
-            {
-                if (vDistanceMs < -10 || GetBufferedDuration() < Config.Player.MinBufferDuration / 2)
-                {
-                    if (CanDebug)
-                        Log.Debug($"vDistanceMs = {vDistanceMs} (restarting)");
-
-                    requiresBuffering = true;
-                    continue;
-                }
-
-                if (CanDebug)
-                    Log.Debug($"vDistanceMs = {vDistanceMs}");
-
-                Video.framesDropped++;
-                VideoDecoder.DisposeFrame(vFrame);
-                VideoDecoder.Frames.TryDequeue(out vFrame);
-                secondField = false;
-            }
-
-            // Set the current time to SubtitleManager in a loop
-            if (Config.Subtitles.Enabled)
-            {
-                for (int i = 0; i < subNum; i++)
-                {
-                    if (Subtitles[i].Enabled)
-                    {
-                        SubtitlesManager[i].SetCurrentTime(new TimeSpan(curTime));
-                    }
-                }
-            }
-            // Internal subtitles (Text or Bitmap or OCR)
-            for (int i = 0; i < subNum; i++)
-            {
-                if (sFramesPrev[i] != null && ((sFramesPrev[i].timestamp - startTicks + (sFramesPrev[i].duration * (long)10000)) / speed) - (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS) < 0)
-                {
-                    SubtitleClear(i);
-
-                    sFramesPrev[i] = null;
-                }
-
-                if (sFrames[i] != null)
-                {
-                    if (Math.Abs(sDistanceMss[i] - sleepMs) < 30 || (sDistanceMss[i] < -30 && sFrames[i].duration + sDistanceMss[i] > 0))
-                    {
-                        if (sFrames[i].isBitmap && sFrames[i].sub.num_rects > 0)
-                        {
-                            if (SubtitlesSelectedHelper.GetMethod(i) == SelectSubMethod.OCR)
-                            {
-                                // Prevent the problem of OCR subtitles not being used in priority by setting
-                                // the timestamp of the subtitles as they are displayed a little earlier
-                                SubtitlesManager[i].SetCurrentTime(new TimeSpan(sFrames[i].timestamp));
-                            }
-
-                            var cur = SubtitlesManager[i].GetCurrent();
-
-                            if (cur != null && !string.IsNullOrEmpty(cur.Text))
-                            {
-                                // Use OCR text subtitles if available
-                                SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
-                            }
-                            else
-                            {
-                                // renderer.CreateOverlayTexture(sFrame, SubtitlesDecoder.CodecCtx->width, SubtitlesDecoder.CodecCtx->height);
-                                SubtitleDisplay(sFrames[i].bitmap, i);
-                            }
-
-                            SubtitlesDecoder.DisposeFrame(sFrames[i]);  // only rects
-                        }
-                        else if (sFrames[i].isBitmap && sFrames[i].sub.num_rects == 0)
-                        {
-                            // For Blu-ray subtitles (PGS), clear the previous subtitle
-                            SubtitleClear(i);
-                            sFramesPrev[i] = sFrames[i] = null;
-                        }
-                        else
-                        {
-                            // internal text sub (does not support translate)
-                            SubtitleDisplay(sFrames[i].text, i, false);
-                        }
-                        sFramesPrev[i] = sFrames[i];
-                        sFrames[i] = null;
-                        SubtitlesDecoders[i].Frames.TryDequeue(out _);
-                    }
-                    else if (sDistanceMss[i] < -30)
-                    {
-                        if (CanDebug)
-                            Log.Debug($"sDistanceMss[i] = {sDistanceMss[i]}");
-
-                        //SubtitleClear(i);
-
-                        // TODO: L: Here sFrames can be null, occurs when switching subtitles?
-                        SubtitlesDecoder.DisposeFrame(sFrames[i]);
-                        sFrames[i] = null;
-                        SubtitlesDecoders[i].Frames.TryDequeue(out _);
-                    }
-                }
-            }
-
-            // External or ASR subtitles
-            for (int i = 0; i < subNum; i++)
-            {
-                if (!Config.Subtitles.Enabled || !Subtitles[i].Enabled)
-                {
-                    continue;
-                }
-
-                SubtitleData cur = SubtitlesManager[i].GetCurrent();
-
-                if (cur == null)
-                {
-                    continue;
-                }
-
-                if (sFramesPrev[i] == null ||
-                    sFramesPrev[i].timestamp != cur.StartTime.Ticks + Config.Subtitles[i].Delay)
-                {
-                    bool display = false;
-                    if (!string.IsNullOrEmpty(cur.DisplayText))
-                    {
-                        SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
-                        display = true;
-                    }
-                    else if (cur.IsBitmap && cur.Bitmap != null)
-                    {
-                        SubtitleDisplay(cur.Bitmap, i);
-                        display = true;
-                    }
-
-                    if (display)
-                    {
-                        sFramesPrev[i] = new SubtitlesFrame
-                        {
-                            timestamp = cur.StartTime.Ticks + Config.Subtitles[i].Delay,
-                            duration = (uint)cur.Duration.TotalMilliseconds,
-                            isTranslated = cur.UseTranslated
-                        };
-                    }
-                }
-                else
-                {
-                    // Apply translation to current sub
-                    if (Config.Subtitles[i].EnabledTranslated) {
-
-                        // If the subtitle currently playing is not translated, change to the translated for display
-                        if (sFramesPrev[i] != null &&
-                            sFramesPrev[i].timestamp == cur.StartTime.Ticks + Config.Subtitles[i].Delay &&
-                            sFramesPrev[i].isTranslated != cur.UseTranslated)
-                        {
-                            SubtitleDisplay(cur.DisplayText, i, cur.UseTranslated);
-                            sFramesPrev[i].isTranslated = cur.UseTranslated;
-                        }
-                    }
-                }
-            }
-
-            if (dFrame != null)
-            {
-                if (Math.Abs(dDistanceMs - sleepMs) < 30 || (dDistanceMs < -30))
-                {
-                    OnDataFrame?.Invoke(this, dFrame);
-
-                    dFrame = null;
-                    DataDecoder.Frames.TryDequeue(out var devnull);
-                }
-                else if (dDistanceMs < -30)
-                {
-                    if (CanDebug)
-                        Log.Debug($"dDistanceMs = {dDistanceMs}");
-
-                    dFrame = null;
-                    DataDecoder.Frames.TryDequeue(out var devnull);
-                }
-            }
-        }
-
-        if (CanInfo) Log.Info($"Finished -> {TicksToTime(CurTime)}");
-    }
-
-    private void CheckLatency()
-    {
-        curLatency = GetBufferedDuration();
-
-        if (CanDebug)
-            Log.Debug($"[Latency {curLatency/10000}ms] Frames: {VideoDecoder.Frames.Count} Packets: {VideoDemuxer.VideoPackets.Count} Speed: {speed}");
-
-        if (curLatency <= Config.Player.MinLatency) // We've reached the down limit (back to speed x1)
-        {
-            ChangeSpeedWithoutBuffering(1);
-            return;
-        }
-        else if (curLatency < Config.Player.MaxLatency)
-            return;
-
-        var newSpeed = Math.Max(Math.Round((double)curLatency / Config.Player.MaxLatency, 1, MidpointRounding.ToPositiveInfinity), 1.1);
-
-        if (newSpeed > 4) // TBR: dispose only as much as required to avoid rebuffering
-        {
-            decoder.Flush();
-            requiresBuffering = true;
-            Log.Debug($"[Latency {curLatency/10000}ms] Clearing queue");
-            return;
-        }
-
-        ChangeSpeedWithoutBuffering(newSpeed);
-    }
-    private void ChangeSpeedWithoutBuffering(double newSpeed)
-    {
-        if (speed == newSpeed)
-            return;
-
-        long curTicks = DateTime.UtcNow.Ticks;
-
-        if (newSpeed != 1 && curTicks - lastSpeedChangeTicks < Config.Player.LatencySpeedChangeInterval)
-            return;
-
-        lastSpeedChangeTicks = curTicks;
-
-        if (CanDebug)
-            Log.Debug($"[Latency {curLatency/10000}ms] Speed changed x{speed} -> x{newSpeed}");
-
-        if (aFrame != null)
-            AudioDecoder.FixSample(aFrame, speed, newSpeed);
-
-        Speed       = newSpeed;
-        requiresBuffering
-                    = false;
-        startTicks  = curTime;
-        elapsedSec  = 0;
-        sw.Restart();
-    }
-    private long GetBufferedDuration()
-    {
-        var decoder = VideoDecoder.Frames.IsEmpty ? 0 : VideoDecoder.Frames.ToArray()[^1].timestamp - vFrame.timestamp;
-        var demuxer = VideoDemuxer.VideoPackets.IsEmpty || VideoDemuxer.VideoPackets.LastTimestamp == NoTs
-            ? 0 :
-            (VideoDemuxer.VideoPackets.LastTimestamp - VideoDemuxer.StartTime) - vFrame.timestamp;
-
-        return Math.Max(decoder, demuxer);
-    }
-
     private void AudioBuffer()
     {
         if (CanTrace) Log.Trace("Buffering");
@@ -895,16 +138,7 @@ unsafe partial class Player
         if (aFrame == null)
             return;
 
-        lock (seeks)
-            if (seeks.IsEmpty)
-            {
-                curTime = !MainDemuxer.IsHLSLive ? aFrame.timestamp : MainDemuxer.CurTime;
-                UI(() =>
-                {
-                    Set(ref _CurTime, curTime, true, nameof(CurTime));
-                    UpdateBufferedDuration();
-                });
-            }
+        UpdateCurTime(aFrame.timestamp, false);
 
         while(seeks.IsEmpty && decoder.AudioStream.Demuxer.BufferedDuration < Config.Player.MinBufferDuration && AudioDecoder.Frames.Count < Config.Decoder.MaxAudioFrames / 2 && IsPlaying && decoder.AudioStream.Demuxer.IsRunning && decoder.AudioStream.Demuxer.Status != MediaFramework.Status.QueueFull)
             Thread.Sleep(20);
@@ -994,21 +228,8 @@ unsafe partial class Player
 
                     Audio.AddSamples(aFrame);
                     bufferedDuration += (long) ((aFrame.dataLen / 4) * Audio.Timebase);
-                    curTime = !MainDemuxer.IsHLSLive ? aFrame.timestamp : MainDemuxer.CurTime;
+                    UpdateCurTime(aFrame.timestamp, false);
                 } while (bufferedDuration < 100 * 10000);
-
-                lock (seeks)
-                    if (seeks.IsEmpty)
-                    {
-                        if (!Engine.Config.UICurTimePerSecond || curTime / 10000000 != _CurTime / 10000000)
-                        {
-                            UI(() =>
-                            {
-                                Set(ref _CurTime, curTime, true, nameof(CurTime));
-                                UpdateBufferedDuration();
-                            });
-                        }
-                    }
 
                 Thread.Sleep(20);
             }
@@ -1019,7 +240,7 @@ unsafe partial class Player
 
     private void ScreamerReverse()
     {
-        while (Status == Status.Playing)
+        while (status == Status.Playing)
         {
             if (seeks.TryPop(out var seekData))
             {
@@ -1043,7 +264,7 @@ unsafe partial class Player
                 VideoDemuxer.Start();
                 VideoDecoder.Start();
 
-                while (VideoDecoder.Frames.IsEmpty && Status == Status.Playing && VideoDecoder.IsRunning) Thread.Sleep(15);
+                while (VideoDecoder.Frames.IsEmpty && status == Status.Playing && VideoDecoder.IsRunning) Thread.Sleep(15);
                 OnBufferingCompleted();
                 VideoDecoder.Frames.TryDequeue(out vFrame);
                 if (vFrame == null) { Log.Warn("No video frame"); break; }
@@ -1051,11 +272,7 @@ unsafe partial class Player
 
                 startTicks = vFrame.timestamp;
                 sw.Restart();
-                elapsedSec = 0;
-
-                if (!MainDemuxer.IsHLSLive && seeks.IsEmpty)
-                    curTime = (long) (vFrame.timestamp * Speed);
-                UI(() => UpdateCurTime());
+                UpdateCurTime(vFrame.timestamp, false);
             }
 
             elapsedTicks    = startTicks - (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS);
@@ -1084,26 +301,13 @@ unsafe partial class Player
                     continue; // rebuffer
                 }
 
-                // Every seconds informs the application with CurTime / Bitrates (invokes UI thread to ensure the updates will actually happen)
-                if (Engine.Config.UICurTimePerSecond && (
-                    (!MainDemuxer.IsHLSLive && curTime / 10000000 != _CurTime / 10000000) ||
-                    (MainDemuxer.IsHLSLive && Math.Abs(elapsedTicks - elapsedSec) > 10000000)))
-                {
-                    elapsedSec  = elapsedTicks;
-                    UI(() => UpdateCurTime());
-                }
-
                 Thread.Sleep(sleepMs);
             }
 
-            decoder.VideoDecoder.Renderer.Present(vFrame, false);
-            if (!MainDemuxer.IsHLSLive && seeks.IsEmpty)
-            {
-                curTime = (long) (vFrame.timestamp * Speed);
+            if (renderer.RenderPlay(vFrame, false))
+                renderer.PresentPlay();
 
-                if (Config.Player.UICurTimePerFrame)
-                    UI(() => UpdateCurTime());
-            }
+            UpdateCurTime(vFrame.timestamp, false);
 
             VideoDecoder.Frames.TryDequeue(out vFrame);
             if (vFrame != null)
@@ -1113,30 +317,24 @@ unsafe partial class Player
 
     private void ScreamerZeroLatency()
     {
-        // Video Only | IsLive | No Deinterlacing | No Frame Stepping / Curtime | No Bitrate Stats | No Buffered Duration | Frame rate = receiving packets rate
+        // Video Only | IsLive | No Deinterlacing | No Frame Stepping | No Bitrate Stats | No Buffered Duration | Frame rate = receiving packets rate
 
-        var vDecoder = VideoDecoder;
-        var renderer = vDecoder.Renderer;
 
         VideoDemuxer.Pause();
-        vDecoder.Pause();
+        VideoDecoder.Pause();
         VideoDemuxer.DisposePackets();
-        vDecoder.Flush();
+        VideoDecoder.Flush();
 
-        while (Status == Status.Playing)
+        while (status == Status.Playing)
         {
-            vFrame = vDecoder.GetFrameNext();
+            vFrame = VideoDecoder.GetFrameNext();
             if (vFrame == null)
                 break;
 
-            // Required?
-            //curTime = vFrame.timestamp;
-            //UI(() => Set(ref _CurTime, curTime, true, nameof(CurTime)));
+            if (renderer.RenderPlay(vFrame, false))
+                renderer.PresentPlay();
 
-            if (renderer.Present(vFrame, false))
-                Video.framesDisplayed++;
-            else
-                Video.framesDropped++;
+            UpdateCurTime(vFrame.timestamp, false);
         }
 
         if (CanInfo) Log.Info($"Finished -> {TicksToTime(CurTime)}");

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -528,7 +528,7 @@ unsafe partial class Player
                     (MainDemuxer.IsHLSLive && Math.Abs(elapsedTicks - elapsedSec) > 10000000)))
                 {
                     elapsedSec  = elapsedTicks;
-                    UI(() => UpdateCurTime());
+                    UI(UpdateCurTime);
                 }
 
                 Thread.Sleep(sleepMs);
@@ -541,7 +541,7 @@ unsafe partial class Player
                     Audio.AddSamples(aFrame);
 
                     // Audio Desync - Large Buffer | ASampleBytes (S16 * 2 Channels = 4) * TimeBase * 2 -frames duration- (TBR: Related to min/max samples on AudioDecoder filters - 2frames * 70ms max)
-                    if (Audio.GetBufferedDuration() > 140 * 10000) //Math.Max(140 * 10000, (aFrame.dataLen / 4) * Audio.Timebase * 2))
+                    if (Audio.GetBufferedDuration() > Math.Max(140 * 10000, (aFrame.dataLen / 4) * Audio.Timebase * 2)) // NOTE: Simple Swr does not have limits 20/70
                     {
                         if (CanDebug)
                             Log.Debug($"Audio desynced by {(int)(audioBufferedDuration / 10000)}ms, clearing buffers");
@@ -607,7 +607,7 @@ unsafe partial class Player
             {
                 if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}");
 
-                if (decoder.VideoDecoder.Renderer.Present(vFrame, false))
+                if (decoder.VideoDecoder.Renderer.Present(vFrame, renderer.FieldType == VideoFrameFormat.Progressive))
                     Video.framesDisplayed++;
                 else
                     Video.framesDropped++;
@@ -618,7 +618,7 @@ unsafe partial class Player
                         curTime = !MainDemuxer.IsHLSLive ? vFrame.timestamp : VideoDemuxer.CurTime;
 
                         if (Config.Player.UICurTimePerFrame)
-                            UI(() => UpdateCurTime());
+                            UI(UpdateCurTime);
                     }
 
                 if (renderer.FieldType == VideoFrameFormat.Progressive)

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -6,8 +6,6 @@ using FlyleafLib.MediaFramework.MediaRenderer;
 using FlyleafLib.MediaFramework.MediaPlaylist;
 using FlyleafLib.MediaFramework.MediaDemuxer;
 
-using static FlyleafLib.Logger;
-
 namespace FlyleafLib.MediaPlayer;
 
 public unsafe partial class Player : NotifyPropertyChanged, IDisposable
@@ -31,8 +29,6 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     /// </summary>
     public Commands             Commands            { get; private set; }
 
-    public Playlist             Playlist            => decoder.Playlist;
-
     /// <summary>
     /// Player's Audio (In/Out)
     /// </summary>
@@ -54,85 +50,108 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     public Data                 Data                { get; private set; }
 
     /// <summary>
-    /// Player's Renderer
-    /// (Normally you should not access this directly)
-    /// </summary>
-    public Renderer             renderer            => decoder.VideoDecoder.Renderer;
-
-    /// <summary>
     /// Player's Decoder Context
     /// (Normally you should not access this directly)
     /// </summary>
     public DecoderContext       decoder             { get; private set; }
 
     /// <summary>
+    /// Playlist
+    /// (Normally you should not access this directly)
+    /// </summary>
+    public Playlist             Playlist            { get; private set; }
+
+    /// <summary>
     /// Audio Decoder
     /// (Normally you should not access this directly)
     /// </summary>
-    public AudioDecoder         AudioDecoder        => decoder.AudioDecoder;
+    public AudioDecoder         AudioDecoder;
 
     /// <summary>
     /// Video Decoder
     /// (Normally you should not access this directly)
     /// </summary>
-    public VideoDecoder         VideoDecoder        => decoder.VideoDecoder;
+    public VideoDecoder         VideoDecoder;
+
+    /// <summary>
+    /// Player's Renderer
+    /// (Normally you should not access this directly)
+    /// </summary>
+    public Renderer             renderer            { get; private set; }
 
     /// <summary>
     /// Subtitles Decoder
     /// (Normally you should not access this directly)
     /// </summary>
-    public SubtitlesDecoder[]   SubtitlesDecoders   => decoder.SubtitlesDecoders;
+    public SubtitlesDecoder[]   SubtitlesDecoders;
 
     /// <summary>
     /// Data Decoder
     /// (Normally you should not access this directly)
     /// </summary>
-    public DataDecoder          DataDecoder         => decoder.DataDecoder;
+    public DataDecoder          DataDecoder;
 
     /// <summary>
     /// Main Demuxer (if video disabled or audio only can be AudioDemuxer instead of VideoDemuxer)
     /// (Normally you should not access this directly)
     /// </summary>
-    public Demuxer              MainDemuxer         => decoder.MainDemuxer;
+    public Demuxer              MainDemuxer;
+    internal void UpdateMainDemuxer()
+    {
+        var main = !VideoDemuxer.Disposed ? VideoDemuxer : AudioDemuxer;
+        if (main != MainDemuxer)
+        {
+            if (MainDemuxer != null)
+            {
+                main.HLSDurationChanged = null;
+                main.HLSCurTimeChanged  = null;
+            }
+
+            MainDemuxer = main;
+            main.HLSDurationChanged = UpdateDurationHLS;
+            main.HLSCurTimeChanged  = UpdateCurTimeHLS;
+
+        }
+    }
 
     /// <summary>
     /// Audio Demuxer
     /// (Normally you should not access this directly)
     /// </summary>
-    public Demuxer              AudioDemuxer        => decoder.AudioDemuxer;
+    public Demuxer              AudioDemuxer;
 
     /// <summary>
     /// Video Demuxer
     /// (Normally you should not access this directly)
     /// </summary>
-    public Demuxer              VideoDemuxer        => decoder.VideoDemuxer;
+    public Demuxer              VideoDemuxer;
 
     /// <summary>
     /// Subtitles Demuxer
     /// (Normally you should not access this directly)
     /// </summary>
-    public Demuxer[]            SubtitlesDemuxers  => decoder.SubtitlesDemuxers;
+    public Demuxer[]            SubtitlesDemuxers;
 
     /// <summary>
     /// Subtitles Manager
     /// </summary>
-    public SubtitlesManager     SubtitlesManager   => decoder.SubtitlesManager;
+    public SubtitlesManager     SubtitlesManager;
 
     /// <summary>
     /// Subtitles OCR
     /// </summary>
-    public SubtitlesOCR         SubtitlesOCR       => decoder.SubtitlesOCR;
+    public SubtitlesOCR         SubtitlesOCR;
 
     /// <summary>
     /// Subtitles ASR
     /// </summary>
-    public SubtitlesASR         SubtitlesASR       => decoder.SubtitlesASR;
+    public SubtitlesASR         SubtitlesASR;
 
     /// <summary>
     /// Data Demuxer
     /// (Normally you should not access this directly)
     /// </summary>
-    public Demuxer DataDemuxer => decoder.DataDemuxer;
+    public Demuxer              DataDemuxer;
 
 
     /// <summary>
@@ -175,7 +194,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         }
     }
 
-    Status _Status = Status.Stopped, status = Status.Stopped;
+    internal Status _Status = Status.Stopped, status = Status.Stopped;
     public bool         IsPlaying           => status == Status.Playing;
     public bool         IsOpening           => status == Status.Opening;
 
@@ -195,36 +214,46 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     /// Player's current time or user's current seek time (uses backward direction or accurate seek based on Config.Player.SeekAccurate)
     /// </summary>
     public long         CurTime             { get => curTime;           set { if (Config.Player.SeekAccurate) SeekAccurate((int) (value/10000)); else Seek((int) (value/10000), false); } } // Note: forward seeking casues issues to some formats and can have serious delays (eg. dash with h264, dash with vp9 works fine)
-    long _CurTime, curTime;
-    internal void UpdateCurTime()
+    internal long _CurTime, curTime;
+    internal void SetCurTime()
     {
-        lock (seeks)
-        {
-            if (MainDemuxer == null || !seeks.IsEmpty)
-                return;
-
-            if (MainDemuxer.IsHLSLive)
-            {
-                curTime  = MainDemuxer.CurTime; // *speed ?
-                duration = MainDemuxer.Duration;
-                Duration = Duration;
-            }
-        }
-
         if (Set(ref _CurTime, curTime, true, nameof(CurTime)))
         {
             Raise(nameof(RemainingDuration));
         }
-
-        UpdateBufferedDuration();
     }
-    internal void UpdateBufferedDuration()
+
+    void UpdateCurTime(long ts, bool skipRefreshType = true)
     {
-        if (_BufferedDuration != MainDemuxer.BufferedDuration)
+        if (!VideoDemuxer.IsHLSLive)
         {
-            _BufferedDuration = MainDemuxer.BufferedDuration;
-            Raise(nameof(BufferedDuration));
+            lock (seeks)
+            {
+                if (!seeks.IsEmpty)
+                    return;
+
+                curTime = ts;
+            }
+
+            if (skipRefreshType
+                || Config.Player.UICurTime == UIRefreshType.PerFrame
+                ||(Config.Player.UICurTime == UIRefreshType.PerFrameSecond && _CurTime / 1_000_0000 != ts / 1_000_0000))
+                UI(SetCurTime);
         }
+    }
+    void UpdateCurTimeHLS(long ts)
+    {
+        lock (seeks)
+        {
+            if (!seeks.IsEmpty)
+                return;
+
+            curTime = ts;
+        }
+
+        if (   Config.Player.UICurTime == UIRefreshType.PerFrame
+            ||(Config.Player.UICurTime == UIRefreshType.PerFrameSecond && _CurTime / 1_000_0000 != ts / 1_000_0000))
+            UI(SetCurTime);
     }
 
     public long         RemainingDuration => Duration - CurTime;
@@ -244,6 +273,11 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         }
     }
     long _Duration, duration;
+    void UpdateDurationHLS(long duration)
+    {
+        this.duration = duration;
+        UI(() => Duration = this.duration);
+    }
 
     /// <summary>
     /// Forces Player's and Demuxer's Duration to allow Seek
@@ -260,22 +294,21 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         isLive = MainDemuxer.IsLive;
         UI(() =>
         {
-            Duration= Duration;
-            IsLive  = IsLive;
+            Duration= this.duration;
+            IsLive  = isLive;
         });
     }
 
     /// <summary>
     /// The current buffered duration in the demuxer
     /// </summary>
-    public long         BufferedDuration    { get => MainDemuxer == null ? 0 : MainDemuxer.BufferedDuration;
-                                                                        internal set => Set(ref _BufferedDuration, value); }
+    public long         BufferedDuration    { get => MainDemuxer.BufferedDuration; internal set => Set(ref _BufferedDuration, value); }
     long _BufferedDuration;
 
     /// <summary>
     /// Whether the input is live (duration might not be 0 on live sessions to allow live seek, eg. hls)
     /// </summary>
-    public bool         IsLive              { get => isLive;            private set => Set(ref _IsLive, value); }
+    public bool         IsLive              { get => MainDemuxer.IsLive;            private set => Set(ref _IsLive, value); }
     bool _IsLive, isLive;
 
     ///// <summary>
@@ -384,12 +417,12 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
             _ReversePlayback = value;
             UI(() => Set(ref _ReversePlayback, value, false));
 
-            if (!Video.IsOpened || !CanPlay | IsLive)
+            if (!Video.IsOpened || !canPlay | isLive)
                 return;
 
             lock (lockActions)
             {
-                bool shouldPlay = IsPlaying || (Status == Status.Ended && Config.Player.AutoPlay);
+                bool shouldPlay = status == Status.Playing || (status == Status.Ended && Config.Player.AutoPlay);
                 Pause();
                 dFrame = null;
 
@@ -402,10 +435,10 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
                 decoder.StopThreads();
                 decoder.Flush();
 
-                if (Status == Status.Ended)
+                if (status == Status.Ended)
                 {
                     status = Status.Paused;
-                    UI(() => Status = Status);
+                    UI(() => Status = status);
                 }
 
                 if (value)
@@ -443,7 +476,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     public event        EventHandler<KnownErrorOccurredEventArgs> KnownErrorOccurred;
     public event        EventHandler<UnknownErrorOccurredEventArgs> UnknownErrorOccurred;
 
-    bool decoderHasEnded => decoder != null && (VideoDecoder.Status == MediaFramework.Status.Ended || (VideoDecoder.Disposed && AudioDecoder.Status == MediaFramework.Status.Ended));
+    bool decoderHasEnded => (VideoDecoder.Status == MediaFramework.Status.Ended || (VideoDecoder.Disposed && AudioDecoder.Status == MediaFramework.Status.Ended));
     #endregion
 
     #region Properties Internal
@@ -464,13 +497,13 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     internal PlayerStats    stats = new();
     internal LogHandler     Log;
 
-    internal bool requiresBuffering;
+    internal volatile bool requiresBuffering;
     bool reversePlaybackResync;
 
-    bool isVideoSwitch;
-    bool isAudioSwitch;
-    bool[] isSubsSwitches;
-    bool isDataSwitch;
+    volatile bool isVideoSwitch;
+    volatile bool isAudioSwitch;
+    volatile bool[] isSubsSwitches;
+    volatile bool isDataSwitch;
     #endregion
 
     public Player(Config config = null)
@@ -507,8 +540,23 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         decoder = new(Config, PlayerId) { Tag = this };
         Engine.AddPlayer(this);
 
-        if (decoder.VideoDecoder.Renderer != null)
-            decoder.VideoDecoder.Renderer.forceNotExtractor = true;
+        AudioDecoder     = decoder.AudioDecoder;
+        VideoDecoder     = decoder.VideoDecoder;
+        SubtitlesDecoders= decoder.SubtitlesDecoders;
+        DataDecoder      = decoder.DataDecoder;
+        AudioDemuxer     = decoder.AudioDemuxer;
+        VideoDemuxer     = decoder.VideoDemuxer;
+        SubtitlesDemuxers= decoder.SubtitlesDemuxers;
+        SubtitlesManager = decoder.SubtitlesManager;
+        SubtitlesOCR     = decoder.SubtitlesOCR;
+        SubtitlesASR     = decoder.SubtitlesASR;
+        DataDemuxer      = decoder.DataDemuxer;
+        Playlist         = decoder.Playlist;
+        renderer         = VideoDecoder.Renderer;
+
+        UpdateMainDemuxer();
+        if (renderer != null)
+            renderer.forceNotExtractor = true;
 
         //decoder.OpenPlaylistItemCompleted              += Decoder_OnOpenExternalSubtitlesStreamCompleted;
 
@@ -521,7 +569,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         decoder.OpenExternalVideoStreamCompleted       += Decoder_OpenExternalVideoStreamCompleted;
         decoder.OpenExternalSubtitlesStreamCompleted   += Decoder_OpenExternalSubtitlesStreamCompleted;
 
-        AudioDecoder.CBufAlloc      = () => { if (aFrame != null) aFrame.dataPtr = IntPtr.Zero; aFrame = null; Audio.ClearBuffer(); aFrame = null; };
+        //AudioDecoder.CBufAlloc      = () => { if (aFrame != null) aFrame.dataPtr = IntPtr.Zero; aFrame = null; Audio.ClearBuffer(); aFrame = null; };
         AudioDecoder.CodecChanged   = Decoder_AudioCodecChanged;
         VideoDecoder.CodecChanged   = Decoder_VideoCodecChanged;
         decoder.RecordingCompleted += (o, e) => { IsRecording = false; };
@@ -589,14 +637,14 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
 
         UIAdd(() =>
         {
-            BitRate     = BitRate;
-            Duration    = Duration;
-            IsLive      = IsLive;
-            Status      = Status;
-            CanPlay     = CanPlay;
-            LastError   = LastError;
+            BitRate     = bitRate;
+            Duration    = duration;
+            IsLive      = isLive;
+            Status      = status;
+            CanPlay     = canPlay;
+            LastError   = lastError;
             BufferedDuration = 0;
-            Set(ref _CurTime, curTime, true, nameof(CurTime));
+            SetCurTime();
         });
     }
     private void Reset()
@@ -665,7 +713,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     public override int GetHashCode() => PlayerId.GetHashCode();
 
     // Avoid having this code in OnPaintBackground as it can cause designer issues (renderer will try to load FFmpeg.Autogen assembly because of HDR Data)
-    internal bool WFPresent() { if (renderer == null || renderer.SCDisposed) return false; renderer?.Present(); return true; }
+    internal bool WFPresent() { if (renderer == null || renderer.SCDisposed) return false; renderer?.RenderRequest(); return true; }
 
     internal void RaiseKnownErrorOccurred(string message, KnownErrorType errorType)
     {

--- a/FlyleafLib/MediaPlayer/Subtitles.cs
+++ b/FlyleafLib/MediaPlayer/Subtitles.cs
@@ -494,11 +494,11 @@ public class Subtitle : NotifyPropertyChanged
     {
         UI(() =>
         {
-            StreamIndex = StreamIndex;
-            IsOpened = IsOpened;
-            Codec = Codec;
-            IsBitmap = IsBitmap;
-            EnabledASR = EnabledASR;
+            StreamIndex = _streamIndex;
+            IsOpened = _isOpened;
+            Codec = _codec;
+            IsBitmap = _isBitmap;
+            EnabledASR = _enabledASR;
         });
     }
 

--- a/FlyleafLib/MediaPlayer/Video.cs
+++ b/FlyleafLib/MediaPlayer/Video.cs
@@ -5,8 +5,13 @@ namespace FlyleafLib.MediaPlayer;
 
 public class Video : NotifyPropertyChanged
 {
-    // TODO: Consider replacing with VideoStream and everyone (player/renderer) will update values there* (Update UI or event by groups -fill demux, fill codec/frame-)
-    // We consider this as read only? (we have also read/write Video properties on Player that point to renderer)
+    /* [TODO]
+     *
+     * Consider replacing with VideoStream and everyone (player/renderer) will update values there* (Update UI or event by groups -fill demux, fill codec/frame-)
+     *  We consider this as read only? (we have also read/write Video properties on Player that point to renderer)
+     *
+     * We mix Source with Output values here? (Fps in -> Fps out) - Maybe move stats
+     */
 
     /// <summary>
     /// Embedded Streams
@@ -33,25 +38,34 @@ public class Video : NotifyPropertyChanged
     internal double _BitRate, bitRate;
 
     /// <summary>
-    /// Total Dropped Frames
-    /// </summary>
-    public int          FramesDropped   { get => framesDropped;     internal set => Set(ref _FramesDropped, value); }
-    internal int    _FramesDropped, framesDropped;
-
-    /// <summary>
     /// Total Frames
+    /// Notes: Either estimated from Duration and Fps or actually announced from stream parameters
     /// </summary>
     public long         FramesTotal     { get => framesTotal;       internal set => Set(ref _FramesTotal, value); }
     internal long   _FramesTotal, framesTotal;
 
-    public int          FramesDisplayed { get => framesDisplayed;   internal set => Set(ref _FramesDisplayed, value); }
-    internal int    _FramesDisplayed, framesDisplayed;
+    /// <summary>
+    /// DWM Total Frames Presented (requires Config.Player.Stats and Engine.Config.UIRefresh)
+    /// Notes: For better count accuracy should avoid Alt+Tab and Minimize (resets per input or seek)
+    /// </summary>
+    public uint         FramesDisplayed { get => _FramesDisplayed;   internal set => Set(ref _FramesDisplayed, value); }
+    internal uint   _FramesDisplayed;
 
+    /// <summary>
+    /// DWM Total Frames Dropped (requires Config.Player.Stats and Engine.Config.UIRefresh)
+    /// Notes: For better count accuracy should avoid Alt+Tab and Minimize (resets per input or seek)
+    /// </summary>
+    public uint         FramesDropped   { get => _FramesDropped;     internal set => Set(ref _FramesDropped, value); }
+    internal uint   _FramesDropped;
+
+    /// <summary>
+    /// Source Frames Per Second (Fps)
+    /// </summary>
     public double       FPS             { get => fps;               internal set => Set(ref _FPS, value); }
     internal double _FPS, fps;
 
     /// <summary>
-    /// Actual Frames rendered per second (FPS)
+    /// DWM Current Frames Per Second (Fps)
     /// </summary>
     public double       FPSCurrent      { get => fpsCurrent;        internal set => Set(ref _FPSCurrent, value); }
     internal double _FPSCurrent, fpsCurrent;
@@ -72,7 +86,7 @@ public class Video : NotifyPropertyChanged
     public int          Width           { get; internal set; }
     public int          Height          { get; internal set; }
     public AspectRatio  AspectRatio     { get; internal set; }
-    //public int          Rotation        { get; internal set; } 
+    //public int          Rotation        { get; internal set; }
 
     public Player Player => player;
 
@@ -88,17 +102,14 @@ public class Video : NotifyPropertyChanged
         uiAction = () =>
         {
             StreamIndex         = streamIndex;
-            IsOpened            = IsOpened;
-            Codec               = Codec;
-            FramesTotal         = FramesTotal;
-            FPS                 = FPS;
-            PixelFormat         = PixelFormat;
-            VideoAcceleration   = VideoAcceleration;
-            HDRFormat           = HDRFormat;
-            ColorFormat         = ColorFormat;
-
-            FramesDisplayed     = FramesDisplayed;
-            FramesDropped       = FramesDropped;
+            IsOpened            = isOpened;
+            Codec               = codec;
+            FramesTotal         = framesTotal;
+            FPS                 = fps;
+            PixelFormat         = pixelFormat;
+            VideoAcceleration   = videoAcceleration;
+            HDRFormat           = hdrFormat;
+            ColorFormat         = colorFormat;
         };
     }
 
@@ -106,7 +117,6 @@ public class Video : NotifyPropertyChanged
     {
         streamIndex         = -1;
         codec               = null;
-        bitRate             = 0;
         fps                 = 0;
         pixelFormat         = null;
         framesTotal         = 0;
@@ -114,6 +124,9 @@ public class Video : NotifyPropertyChanged
         isOpened            = false;
         hdrFormat           = HDRFormat.None;
         colorFormat         = "";
+
+        bitRate             = 0;
+        player.ResetFrameStats();
 
         player.UIAdd(uiAction);
         SetUISize(0, 0, new(0, 0));//, 0);
@@ -138,8 +151,8 @@ public class Video : NotifyPropertyChanged
         colorFormat = $"{decoder.VideoStream.ColorSpace}\r\n{decoder.VideoStream.ColorTransfer}\r\n{decoder.VideoStream.ColorRange}";
         isOpened    =!decoder.VideoDecoder.Disposed;
 
-        framesDisplayed = 0;
-        framesDropped   = 0;
+        player.ResetFrameStats();
+        bitRate         = 0;
 
         player.UIAdd(uiAction);
     }
@@ -197,6 +210,7 @@ public class Video : NotifyPropertyChanged
 
         player.Pause();
         decoder.CloseVideo();
+        player.UpdateMainDemuxer();
         player.SubtitleClear();
 
         if (!player.Audio.IsOpened)

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -7,34 +7,23 @@ public static partial class Utils
 {
     public static class NativeMethods
     {
-        static NativeMethods()
-        {
-            if (IntPtr.Size == 4)
-            {
-                GetWindowLong = GetWindowLongPtr32;
-                SetWindowLong = SetWindowLongPtr32;
-            }
-            else
-            {
-                GetWindowLong = GetWindowLongPtr64;
-                SetWindowLong = SetWindowLongPtr64;
-            }
-        }
+        public static nint GetWindowLong(nint hWnd, int nIndex)
+            => IntPtr.Size == 8 ? GetWindowLongPtr64(hWnd, nIndex) : GetWindowLongPtr32(hWnd, nIndex);
 
-        public static Func<IntPtr, int, IntPtr, IntPtr> SetWindowLong;
-        public static Func<IntPtr, int, IntPtr> GetWindowLong;
+        public static nint SetWindowLong(nint hWnd, int nIndex, nint dwNewLong)
+            => IntPtr.Size == 8 ? SetWindowLongPtr64(hWnd, nIndex, dwNewLong) : SetWindowLongPtr32(hWnd, nIndex, dwNewLong);
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
-        public static extern IntPtr GetWindowLongPtr32(IntPtr hWnd, int nIndex);
+        public static extern nint GetWindowLongPtr32(nint hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
-        public static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+        public static extern nint GetWindowLongPtr64(nint hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-        public static extern IntPtr SetWindowLongPtr32(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+        public static extern nint SetWindowLongPtr32(nint hWnd, int nIndex, nint dwNewLong);
 
-        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")] // , SetLastError = true
-        public static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+        public static extern nint SetWindowLongPtr64(nint hWnd, int nIndex, nint dwNewLong);
 
         [DllImport("user32.dll")]
         public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
@@ -68,9 +57,9 @@ public static partial class Utils
 
             public static bool operator ==(POINT left, POINT right) => left.X == right.X && left.Y == right.Y;
             public static bool operator !=(POINT left, POINT right) => !(left == right);
-            public override bool Equals(object obj)                 => obj is POINT other && this == other;
-            public bool Equals(POINT other)                         => this == other;
-            public override int GetHashCode()                       => HashCode.Combine(X, Y);
+            public override bool Equals(object obj) => obj is POINT other && this == other;
+            public bool Equals(POINT other) => this == other;
+            public override int GetHashCode() => HashCode.Combine(X, Y);
         }
 
         [DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
@@ -82,7 +71,7 @@ public static partial class Utils
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         public static extern EXECUTION_STATE SetThreadExecutionState(EXECUTION_STATE esFlags);
         [FlagsAttribute]
-        public enum EXECUTION_STATE :uint
+        public enum EXECUTION_STATE : uint
         {
             ES_AWAYMODE_REQUIRED    = 0x00000040,
             ES_CONTINUOUS           = 0x80000000,
@@ -173,16 +162,16 @@ public static partial class Utils
         [Flags]
         public enum WindowLongFlags : int
         {
-             GWL_EXSTYLE = -20,
-             GWLP_HINSTANCE = -6,
-             GWLP_HWNDPARENT = -8,
-             GWL_ID = -12,
-             GWL_STYLE = -16,
-             GWL_USERDATA = -21,
-             GWL_WNDPROC = -4,
-             DWLP_USER = 0x8,
-             DWLP_MSGRESULT = 0x0,
-             DWLP_DLGPROC = 0x4
+            GWL_EXSTYLE = -20,
+            GWLP_HINSTANCE = -6,
+            GWLP_HWNDPARENT = -8,
+            GWL_ID = -12,
+            GWL_STYLE = -16,
+            GWL_USERDATA = -21,
+            GWL_WNDPROC = -4,
+            DWLP_USER = 0x8,
+            DWLP_MSGRESULT = 0x0,
+            DWLP_DLGPROC = 0x4
         }
 
         [Flags]
@@ -277,16 +266,26 @@ public static partial class Utils
         public static double DpiXSource = 96, DpiYSource = 96;
 
         [DllImport("user32.dll")]
-        public static extern IntPtr MonitorFromPoint(Point pt, uint dwFlags);
+        public static extern IntPtr MonitorFromPoint(Point pt, MonitorOptions dwFlags);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr MonitorFromWindow(nint hwnd, MonitorOptions dwFlags);
+
+        [Flags]
+        public enum MonitorOptions : uint
+        {
+            MONITOR_DEFAULTTONULL   = 0x00000000,
+            MONITOR_DEFAULTTOPRIMARY= 0x00000001,
+            MONITOR_DEFAULTTONEAREST= 0x00000002
+        }
 
         [DllImport("shcore.dll")]
         public static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
 
-        private const int MONITOR_DEFAULTTONEAREST = 2;
         private const int MDT_EFFECTIVE_DPI = 0;
         public static (double dpiX, double dpiY) GetDpiAtPoint(Point point)
         {
-            IntPtr monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+            IntPtr monitor = MonitorFromPoint(point,  MonitorOptions.MONITOR_DEFAULTTONEAREST);
 
             if (monitor != IntPtr.Zero && GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, out uint dpiX, out uint dpiY) == 0)
                 return (dpiX / 96.0, dpiY / 96.0);
@@ -296,5 +295,109 @@ public static partial class Utils
             return (g.DpiX / 96.0, g.DpiY / 96.0);
         }
         #endregion
+
+        // Currently not used (mainly for refresh rate?*)
+        //[StructLayout(LayoutKind.Sequential)]
+        //public struct DEVMODE
+        //{
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        //    public string dmDeviceName;
+        //    public ushort dmSpecVersion;
+        //    public ushort dmDriverVersion;
+        //    public ushort dmSize;
+        //    public ushort dmDriverExtra;
+        //    public int dmFields;
+        //    public int dmPositionX;
+        //    public int dmPositionY;
+        //    public int dmDisplayOrientation;
+        //    public int dmDisplayFixedOutput;
+        //    public short dmColor;
+        //    public short dmDuplex;
+        //    public short dmYResolution;
+        //    public short dmTTOption;
+        //    public short dmCollate;
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        //    public string dmFormName;
+        //    public ushort dmLogPixels;
+        //    public int dmBitsPerPel;
+        //    public int dmPelsWidth;
+        //    public int dmPelsHeight;
+        //    public int dmDisplayFlags;
+        //    public int dmDisplayFrequency; // not accurate should be ratio / float (e.g. 59.95 will be 59)
+        //    public int dmICMMethod;
+        //    public int dmICMIntent;
+        //    public int dmMediaType;
+        //    public int dmDitherType;
+        //    public int dmReserved1;
+        //    public int dmReserved2;
+        //    public int dmPanningWidth;
+        //    public int dmPanningHeight;
+
+        //    public static DEVMODE Get(string deviceName)
+        //    {
+        //        DEVMODE dev = new();
+        //        dev.dmSize = (ushort)Marshal.SizeOf(dev);
+        //        EnumDisplaySettings(deviceName, ENUM_CURRENT_SETTINGS, ref dev);
+        //        return dev;
+        //    }
+        //}
+
+        //[DllImport("user32.dll", CharSet = CharSet.Ansi)]
+        //private static extern bool EnumDisplaySettings(string deviceName, int modeNum, ref DEVMODE devMode);
+
+        //private const int ENUM_CURRENT_SETTINGS = -1;
+
+
+        //[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        //public static extern bool GetMonitorInfoW(IntPtr hMonitor, ref MONITORINFOEXW lpmi);
+
+        //[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        //public struct MONITORINFOEXW
+        //{
+        //    public uint cbSize;
+        //    public RECT rcMonitor;
+        //    public RECT rcWork;
+        //    public MonitorInfoFlags dwFlags;
+
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        //    public string szDevice;
+
+        //    public static MONITORINFOEXW Create()
+        //        => new() { cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFOEXW)), szDevice = string.Empty };
+        //}
+
+        //[Flags]
+        //public enum MonitorInfoFlags : uint
+        //{
+        //    MONITORINFOF_PRIMARY = 0x00000001
+        //}
+
+        //[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        //public struct DISPLAY_DEVICE
+        //{
+        //    public int cb;
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        //    public string DeviceName;
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        //    public string DeviceString;
+        //    public int StateFlags;
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        //    public string DeviceID;
+        //    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        //    public string DeviceKey;
+
+        //    public static DISPLAY_DEVICE Create()
+        //    {
+        //        var display = new DISPLAY_DEVICE();
+        //        display.cb = Marshal.SizeOf(display);
+        //        return display;
+        //    }
+        //}
+
+        //[DllImport("user32.dll", CharSet = CharSet.Ansi)]
+        //public static extern bool EnumDisplayDevices(string lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, uint dwFlags);
+
+        //[DllImport("user32.dll", SetLastError = true)]
+        //public static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_DEVICE_INFO_HEADER requestPacket);
     }
 }

--- a/FlyleafLib/Utils/Utils.cs
+++ b/FlyleafLib/Utils/Utils.cs
@@ -101,7 +101,7 @@ public static partial class Utils
     /// Invokes the UI thread to execute the specified action
     /// </summary>
     /// <param name="action"></param>
-    public static void UIInvoke(Action action) => Application.Current.Dispatcher.Invoke(action);
+    public static void UIInvoke(Action action) => Application.Current.Dispatcher.Invoke(action, System.Windows.Threading.DispatcherPriority.DataBind);
 
     /// <summary>
     /// Invokes the UI thread if required to execute the specified action
@@ -112,7 +112,7 @@ public static partial class Utils
         if (Environment.CurrentManagedThreadId == Application.Current.Dispatcher.Thread.ManagedThreadId)
             action();
         else
-            Application.Current.Dispatcher.Invoke(action);
+            Application.Current.Dispatcher.Invoke(action, System.Windows.Threading.DispatcherPriority.DataBind);
     }
 
     public static Thread STA(Action action)
@@ -658,7 +658,6 @@ public static partial class Utils
         return hexBuilder.ToString();
     }
     public static int GCD(int a, int b) => b == 0 ? a : GCD(b, a % b);
-    public static string TicksToTime(long ticks) => new TimeSpan(ticks).ToString();
     public static void Log(string msg) { try { Debug.WriteLine($"{DateTime.Now:HH.mm.ss.fff} | {msg}"); } catch (Exception) { Debug.WriteLine($"[............] [MediaFramework] {msg}"); } }
 
     [GeneratedRegex("[^a-z0-9]extended", RegexOptions.IgnoreCase)]
@@ -723,7 +722,7 @@ public static partial class Utils
 
         return $"\t[Metadata] {dump}";
     }
-    public static string TicksToTime2(long ticks)
+    public static string TicksToTime(long ticks)
     {
         if (ticks == NoTs)
             return "-";
@@ -759,6 +758,39 @@ public static partial class Utils
             return ts.ToString(@"\-d\-hh\:mm\:ss\.fff");
     }
     public static string DoubleToTimeMini(double d) => d.ToString("#.000", CultureInfo.InvariantCulture);
+    public static string TicksToTimeMini(long ticks)
+    {
+        if (ticks == NoTs)
+            return "-";
+
+        if (ticks == 0)
+            return "00.000";
+
+        return TsToTimeMini(TimeSpan.FromTicks(ticks));
+    }
+    static string TsToTimeMini(TimeSpan ts)
+    {
+        if (ts.Ticks > 0)
+        {
+            if (ts.TotalMinutes < 1)
+                return ts.ToString(@"ss\.fff");
+            else if (ts.TotalHours < 1)
+                return ts.ToString(@"mm\:ss\.fff");
+            else if (ts.TotalDays < 1)
+                return ts.ToString(@"hh\:mm\:ss\.fff");
+            else
+                return ts.ToString(@"d\-hh\:mm\:ss\.fff");
+        }
+        
+        if (ts.TotalMinutes > -1)
+            return ts.ToString(@"\-ss\.fff");
+        else if (ts.TotalHours > -1)
+            return ts.ToString(@"\-mm\:ss\.fff");
+        else if (ts.TotalDays > -1)
+            return ts.ToString(@"\-hh\:mm\:ss\.fff");
+        else
+            return ts.ToString(@"\-d\-hh\:mm\:ss\.fff");
+    }
     public static List<T> GetFlagsAsList<T>(T value) where T : Enum
     {
         List<T> values = [];

--- a/LLPlayer/Controls/FlyleafBar.xaml
+++ b/LLPlayer/Controls/FlyleafBar.xaml
@@ -45,7 +45,7 @@
                     Ticks="{Binding FL.Player.Chapters, Converter={StaticResource ChaptersToTicksConv}}"
                     IsSelectionRangeEnabled="True" SelectionStart="{Binding RelativeSource={RelativeSource Self}, Path=Value, Mode=OneWay}" Style="{DynamicResource FlyleafSlider}" Focusable="False" Margin="10,0,10,0" VerticalAlignment="Center" Value="{Binding FL.Player.CurTime, Mode=TwoWay, Converter={StaticResource TicksToSecondsConv}}" Maximum="{Binding FL.Player.Duration, Converter={StaticResource TicksToSecondsConv}}">
                     <b:Interaction.Behaviors>
-                        <local:SliderToolTipBehavior Chapters="{Binding FL.Player.VideoDemuxer.Chapters}" />
+                        <local:SliderToolTipBehavior Chapters="{Binding FL.Player.Chapters}" />
                     </b:Interaction.Behaviors>
                     <Slider.SelectionEnd>
                         <MultiBinding Converter="{StaticResource SumConv}">

--- a/LLPlayer/Controls/Settings/SettingsVideo.xaml
+++ b/LLPlayer/Controls/Settings/SettingsVideo.xaml
@@ -87,6 +87,14 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBlock
                             Width="180"
+                            Text="Double Rate" />
+                        <ToggleButton
+                            IsChecked="{Binding FL.PlayerConfig.Video.DoubleRate}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock
+                            Width="180"
                             Text="Super Resolution" />
                         <ToggleButton
                             IsChecked="{Binding FL.PlayerConfig.Video.SuperResolution}" />

--- a/LLPlayer/ViewModels/MainWindowVM.cs
+++ b/LLPlayer/ViewModels/MainWindowVM.cs
@@ -142,7 +142,7 @@ public class MainWindowVM : Bindable
             if (!args.Success || args.IsSubtitles)
             {
                 if (!args.IsSubtitles)
-                    FL.Player.renderer?.ClearScreenForce();
+                    FL.Player.renderer?.ClearScreen(true);
 
                 return;
             }


### PR DESCRIPTION
Update FlyleafLib v3.9 from v3.8.14

## Changelog

# Major A/V (Playback & Rendering) Improvements

Significant performance and stability upgrades in both audio and video paths — resulting in no tearing, fewer dropped frames (even on high refresh rate displays), and no audio crackling.

## Core Changes

- Switched from DXGI swapchain to DirectComposition (DComp) with WS_EX_NOREDIRECTIONBITMAP, bypassing the WPF/WinForms/WinUI rendering pipeline and rendering directly to the DWM compositor
 ✅ Eliminates GPU→CPU copies, frame drops, and UI freezes

- Re-implemented high-performance rendering loops (for both Playback and Idle modes)
 ✅ Calls to ResizeBuffers and SetViewPort occur only when necessary
 ✅ Avoids locking and improves frame throughput

- Re-implemented A/V Playback (Screamer)
 ✅ Fully separated audio/video threads to prevent desync and delay issues
 ✅ Decoupled Render/Draw from Present, giving the GPU more time per frame for smooth playback

## Changelog

- Renderer.Device: Improves creation implementation
- Renderer.Swapchain: Switches to DirectComposition (DComp)
- Renderer.Swapchain: Gets dynamically the GPU output from the adapter during creation
- Renderer.Swapchain: Fixes support for RGBA (instead of BGRA) and might perform even better (currently not default as causes critical issues with Super Resolution - see Config.Video.SwapForceR8G8B8A8)
- Renderer.Present: Re-implementation with new rendering loops for playback and idle modes with VSync-Wait mode (deprecates DoNotWait)
- Renderer.Present: Separates rendering and presenting for playback to achieve less dropped frames
- Renderer.D3D11VP: Fixes an issue with Super Resolution during Rotation
- Player.Screamer: New AVSD implementation which separates A/V threads with less dropped frames, less audio crackling and better A/V sync
- Player.Stats: Real-time accurate frame statistics from DWM
- AudioDecoder: Workaround with Circular Buffer that could cause unexpected results during re-allocation
- VideoDecoder: Fixes issues with extra frames (+1 required for renderer and handle max allowed by the system)
- VideoStream: Better handling of Fps (could cause issues with interlace and formats that announce huge wrong numbers)
- Demuxer: Fixes an issue with IsHLSLive falsely set to true
- Demuxer: Fixes an issue with backwards seeking that it would return forward packets from cache

## Breaking Changes

- Config.Video: Defaults VSync to 1 to avoid tearing
- Config.Video: Deprecates PresentFlags (no support for DoNotWait - no reason)
- Config.Player: Deprecates IdleFps
- Config.Player: Renames UICurTimePerFrame to UICurTime
- Engine.Config: Deprecates UICurTimePerSecond (use Config.Player.UICurTime instead)
- Engine.Config: Defaults UIRefresh to true (for proper UI updates/refreshes)
- Engine.Video: Deprecates Screens and RecommendedLuminance (use GPUAdapter.GetGPUOutputs instead)
- Engine.Video: Separates GPUOutput from GPUAdapter
- Renderer/FlyleafHost.Wpf: Deprecates replica/child (might re-include it in the future)

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/57fd5f25534c28d88ca02a1dd207b9c9add9e0c5...8577292e72e2163f59683deb23bb1d4499b9905d