### PR TITLE
Update FlyleafLib v3.9.1

### DIFF
--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.9</Version>
+    <Version>3.9.1</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
@@ -387,7 +387,8 @@ public unsafe partial class AudioDecoder : DecoderBase
             AudioFrame mFrame = new()
             {
                 timestamp   = (long)(frame->pts * AudioStream.Timebase) - demuxer.StartTime + Config.Audio.Delay,
-                dataLen     = speedDataLen
+                dataLen     = speedDataLen,
+                speed       = speed
             };
             if (CanTrace) Log.Trace($"Processes {TicksToTime(mFrame.timestamp)}");
 

--- a/FlyleafLib/MediaFramework/MediaFrame/AudioFrame.cs
+++ b/FlyleafLib/MediaFramework/MediaFrame/AudioFrame.cs
@@ -4,4 +4,5 @@ public class AudioFrame : FrameBase
 {
     public IntPtr   dataPtr;
     public int      dataLen;
+    public double   speed = 1;
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -262,7 +262,7 @@ public unsafe partial class Renderer
 
             if (CanDebug) Log.Debug("Disposing");
 
-            lock (lockLastFrame)
+            lock (lockRenderLoops)
             {
                 VideoDecoder.DisposeFrame(LastFrame);
                 LastFrame = null;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -13,19 +13,17 @@ public unsafe partial class Renderer
     long            lastPresentRequestAt;
     volatile bool   isPlayerPresenting;
     volatile bool   isIdlePresenting;
-    object          lockLastFrame = new();
+    object          lockRenderLoops = new();
 
     internal void RenderRequest(VideoFrame frame = null, bool forceClear = false)
     {
         // NOTE: We expect frame only from player's ShowFrameX when is already Paused
         // TODO: We use source Fps to present our updated frames which can be low (e.g. 1-10fps) | Consider passing ts to player and will act also as idle renderer? (with higher fps)
-        if (isPlayerPresenting && frame == null)
-            return;
-
-        lock (lockLastFrame)
+        lock (lockRenderLoops)
         {
             lastPresentRequestAt = DateTime.UtcNow.Ticks;
 
+            // Swap with LastFrame must be done during request (respect of extra frames)
             if ((frame != null || forceClear) && frame != LastFrame)
             {
                 VideoDecoder.DisposeFrame(LastFrame);
@@ -45,7 +43,7 @@ public unsafe partial class Renderer
         int rechecks = 1000; // Awake for ~5sec when Idle
         while (canRenderPresent)
         {
-            while (lastPresentRequestAt < lastPresentAt && rechecks-- > 0)
+            while (lastPresentRequestAt <= lastPresentAt && rechecks-- > 0)
             {
                 if (isPlayerPresenting || !canRenderPresent)
                     { rechecks = 0; break; }
@@ -56,12 +54,12 @@ public unsafe partial class Renderer
             if (rechecks < 1)
                 break;
 
+            lastPresentAt = lastPresentRequestAt;
+            rechecks = 1000;
             RenderIdle();
-
-            rechecks = 500;
         }
 
-        lock (lockLastFrame) // To avoid race condition*?
+        lock (lockRenderLoops) // To avoid race condition*?
         {
             isIdlePresenting = false;
             if (lastPresentRequestAt > lastPresentAt && !isPlayerPresenting && canRenderPresent)
@@ -72,25 +70,25 @@ public unsafe partial class Renderer
     {
         try
         {
-            ResizeBuffersInternal();
-            SetViewportInternal();
-
-            lastPresentAt = DateTime.UtcNow.Ticks;
-
-            if (canRenderPresent)
+            lock (lockRenderLoops)
             {
-                lock (lockLastFrame)
-                    if (LastFrame != null)
-                        RenderFrame(LastFrame, false);
-                    else
-                    {
-                        ClearOverlayTexture();
-                        context.OMSetRenderTargets(backBufferRtv);
-                        context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
-                    }
+                ResizeBuffersInternal();
+                SetViewportInternal();
 
-                swapChain.Present(1, 0);
+                if (!canRenderPresent) // When control has not been created yet
+                    return;
+
+                if (LastFrame != null)
+                    RenderFrame(LastFrame, false);
+                else
+                {
+                    ClearOverlayTexture();
+                    context.OMSetRenderTargets(backBufferRtv);
+                    context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
+                }
             }
+
+            swapChain.Present(1, 0);
         }
         catch (SharpGenException e)
         {
@@ -109,19 +107,20 @@ public unsafe partial class Renderer
     }
 
     internal void RenderPlayStart()  { isPlayerPresenting = true; while(isIdlePresenting) Thread.Sleep(1); } // Stop RenderIdle
-    internal void RenderPlayStop()  => isPlayerPresenting = false; // Check if last timestamp?* to start idle (we don't update it currently)
+    internal void RenderPlayStop()   { isPlayerPresenting = false; RenderRequest(); } // Check if last timestamp?* to start idle (we don't update it currently)
     internal bool RenderPlay(VideoFrame frame, bool secondField)
     {
         try
         {
-            ResizeBuffersInternal();
-            SetViewportInternal();
-
-            lock (LastFrame)
+            lock (lockRenderLoops)
             {
+                ResizeBuffersInternal();
+                SetViewportInternal();
+
                 if (canRenderPresent)
                     RenderFrame(frame, secondField);
-                else if (frame != LastFrame)
+
+                if (frame != LastFrame)
                 {
                     VideoDecoder.DisposeFrame(LastFrame);
                     LastFrame = frame;
@@ -245,12 +244,6 @@ public unsafe partial class Renderer
             context.PSSetShader(ShaderPS);
             context.OMSetBlendState(VideoStream.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Alpha) ? blendStateAlpha : null);
             context.RSSetViewport(GetViewport);
-        }
-
-        if (frame != LastFrame)
-        {
-            VideoDecoder.DisposeFrame(LastFrame);
-            LastFrame = frame;
         }
     }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -75,7 +75,7 @@ public unsafe partial class Renderer
                 ResizeBuffersInternal();
                 SetViewportInternal();
 
-                if (!canRenderPresent) // When control has not been created yet
+                if (!canRenderPresent)
                     return;
 
                 if (LastFrame != null)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -37,20 +37,20 @@ unsafe public partial class Renderer
     nint                    displayHwnd;
     GPUOutput               gpuOutput;
 
-    private SwapChainDescription1 GetSwapChainDesc(int width, int height, bool isComp = false, bool alpha = false)
-    => new()
-    {
-        BufferUsage         = Usage.RenderTargetOutput,
-        Format              = Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA,
-        Width               = (uint)width,
-        Height              = (uint)height,
-        AlphaMode           = isComp ? AlphaMode.Premultiplied : AlphaMode.Ignore,
-        SwapEffect          = SwapEffect.FlipDiscard,
-        Scaling             = isComp ? Scaling.Stretch : Scaling.None, // DComp can't validate widhth/height?*
-        BufferCount         = Math.Max(Config.Video.SwapBuffers, 2),
-        SampleDescription   = new SampleDescription(1, 0),
-        Flags               = SwapChainFlags.None
-    };
+    private SwapChainDescription1 GetSwapChainDesc(int width, int height)
+        => new()
+        {
+            BufferUsage         = Usage.RenderTargetOutput,
+            Format              = Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA,
+            Width               = (uint)width,
+            Height              = (uint)height,
+            AlphaMode           = AlphaMode.Premultiplied,  // TBR
+            SwapEffect          = SwapEffect.FlipDiscard,   
+            Scaling             = Scaling.Stretch,          // DComp can't validate widhth/height?*
+            BufferCount         = Math.Max(Config.Video.SwapBuffers, 2),
+            SampleDescription   = new SampleDescription(1, 0),
+            Flags               = SwapChainFlags.None
+        };
 
     internal void InitializeSwapChain(nint handle)
     {
@@ -75,7 +75,7 @@ unsafe public partial class Renderer
             try
             {
                 Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} swap chain [Handle: {handle}, Buffers: {Config.Video.SwapBuffers}, Format: {(Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA)}]");
-                swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(ControlWidth, ControlHeight, true, true));
+                swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(ControlWidth, ControlHeight));
                 DComp.DCompositionCreateDevice(dxgiDevice, out dCompDevice).CheckError();
                 dCompDevice.CreateTargetForHwnd(handle, false, out dCompTarget).CheckError();
                 dCompDevice.CreateVisual(out dCompVisual).CheckError();
@@ -122,7 +122,7 @@ unsafe public partial class Renderer
 
             try
             {
-                swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(1, 1, true));
+                swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(1, 1));
             }
             catch (Exception e)
             {
@@ -150,10 +150,13 @@ unsafe public partial class Renderer
             if (SCDisposed)
                 return;
 
-            SCDisposed      = true;
+            SCDisposed = true;
 
-            lock (lockLastFrame)
-                canRenderPresent = false;
+            lock (lockRenderLoops)
+            {
+                canRenderPresent= false;
+                needsResize     = needsViewport = false;
+            }
 
             while(isIdlePresenting) Thread.Sleep(1);
             // StopPlayer (if it does not do it already before?*)
@@ -262,17 +265,17 @@ unsafe public partial class Renderer
         SetZoomAndCenter(zoom, zoomCenter);
     }
 
-    bool needsViewport = true;
+    bool needsViewport;
     public void SetViewport(bool refresh = true)
     {
-        lock (lockDevice)
+        lock (lockRenderLoops)
         {
             needsViewport   = true;
-            canRenderPresent= true; // TBR: should be re-calculated 
-        }
+            canRenderPresent= true; // TBR: should be re-calculated
 
-        if (refresh)
-            RenderRequest();
+            if (refresh)
+                RenderRequest();
+        }
     }
     public void SetViewportInternal()
     {
@@ -427,10 +430,10 @@ unsafe public partial class Renderer
         ViewportChanged?.Invoke(this, new());
     }
 
-    bool needsResize = true;
+    bool needsResize;
     public void ResizeBuffers(int width, int height)
-    {
-        lock (lockDevice)
+    {   // TBR: Fast way from resize (no locks? to avoid possible delay)
+        lock (lockRenderLoops)
         {
             if (SCDisposed || width <= 0 || height <= 0)
             {
@@ -439,7 +442,22 @@ unsafe public partial class Renderer
             }
             else if (ControlWidth == width && ControlHeight == height)
             {
-                canRenderPresent = true; // TBR with minimize*
+                // Re-calculate of canRenderPresent
+                if (videoProcessor == VideoProcessors.D3D11)
+                {
+                    Viewport view   = GetViewport;
+                    int right       = (int)(view.X + view.Width);
+                    int bottom      = (int)(view.Y + view.Height);
+
+                    if (view.Width < 1 || view.Y >= ControlHeight || view.X >= ControlWidth || bottom <= 0 || right <= 0)
+                        canRenderPresent = false;
+                    else
+                        canRenderPresent = true;
+                }
+                else
+                    canRenderPresent = true;
+
+                //RenderRequest(); // We don't refresh as we consider same view
                 return;
             }
 

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -270,6 +270,9 @@ unsafe public partial class Renderer
     {
         lock (lockRenderLoops)
         {
+            if (SCDisposed)
+                return;
+
             needsViewport   = true;
             canRenderPresent= true; // TBR: should be re-calculated
 

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -213,6 +213,9 @@ unsafe partial class Player
          * SecondField goes to Renderer
          * isVideoSwitch should be removed as we use requiresBuffering all time for that?*
          * Warm up to avoid initial drop frames and get accurate FrameStatistics / refresh rate sync with monitor (cpu-gpu sync, possible with Dwm?)
+         * We actually need +1 extra frame not for renderer but for the time that we TryDequeue 1 frame and at the same time we keep the LastFrame for the renderer
+         *  If we swap it directly we will not need this anymore (however this could cause losing the LastFrame if the new one is corrupted/failed etc.)
+         *  We could also get rid of vFrame (use only LastFrame) and no bother disposing it just keep the timestamp from renderframe until present
          */
 
         bool secondField = false; // To be transfered in renderer

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -295,7 +295,6 @@ unsafe partial class Player
                 StopScreamerVASDAudio();
                 BufferVASD();
                 requiresBuffering = false;
-                renderer.RenderPlayStart();
                 if (!seeks.IsEmpty)
                     continue;
 
@@ -308,6 +307,8 @@ unsafe partial class Player
 
                     break;
                 }
+
+                renderer.RenderPlayStart();
 
                 // Prepare 2nd Frame (after ShowOneFrame)
                 if (!renderer.RenderPlay(vFrame, false)) // interlace 2nd frame probably here

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -1,10 +1,7 @@
 ﻿﻿using System.Diagnostics;
 
-using Vortice.Direct3D11;
-
 using FlyleafLib.MediaFramework.MediaDecoder;
 using FlyleafLib.MediaFramework.MediaFrame;
-using FlyleafLib.MediaFramework.MediaStream;
 
 namespace FlyleafLib.MediaPlayer;
 
@@ -40,10 +37,10 @@ unsafe partial class Player
     {
         if (onBufferingStarted - 1 != onBufferingCompleted) return;
 
-        if (error != null && LastError == null)
+        if (error != null && lastError == null)
         {
             lastError = error;
-            UI(() => LastError = LastError);
+            UI(() => LastError = lastError);
         }
 
         BufferingCompleted?.Invoke(this, new BufferingCompletedArgs(error));
@@ -78,7 +75,7 @@ unsafe partial class Player
         {
             sFrames[i] = null;
         }
-        if (VideoDecoder.Frames.IsEmpty || !VideoDecoder.Frames.TryDequeue(out vFrame))
+        if (!VideoDecoder.Frames.TryDequeue(out vFrame))
             return;
 
         renderer.RenderRequest(vFrame);
@@ -144,7 +141,7 @@ unsafe partial class Player
             Thread.Sleep(20);
     }
     private void ScreamerAudioOnly()
-    {
+    {   // TODO: Needs Recoding (old code)
         long bufferedDuration = 0;
 
         while (IsPlaying)
@@ -239,11 +236,15 @@ unsafe partial class Player
     }
 
     private void ScreamerReverse()
-    {
+    {   // TBR: Timings / Rebuffer
         while (status == Status.Playing)
         {
             if (seeks.TryPop(out var seekData))
             {
+                if (vFrame != null)
+                    { VideoDecoder.DisposeFrame(vFrame); vFrame = null; } // should never be LastFrame
+                renderer.RenderPlayStop();
+
                 seeks.Clear();
                 if (decoder.Seek(seekData.ms, seekData.forward) < 0)
                     Log.Warn("Seek failed");
@@ -254,6 +255,7 @@ unsafe partial class Player
                 if (VideoDecoder.Status == MediaFramework.Status.Ended)
                     break;
 
+                renderer.RenderPlayStop();
                 OnBufferingStarted();
                 if (reversePlaybackResync)
                 {
@@ -264,41 +266,38 @@ unsafe partial class Player
                 VideoDemuxer.Start();
                 VideoDecoder.Start();
 
+                // Recoding*
                 while (VideoDecoder.Frames.IsEmpty && status == Status.Playing && VideoDecoder.IsRunning) Thread.Sleep(15);
                 OnBufferingCompleted();
-                VideoDecoder.Frames.TryDequeue(out vFrame);
-                if (vFrame == null) { Log.Warn("No video frame"); break; }
-                vFrame.timestamp = (long) (vFrame.timestamp / Speed);
+                if (!VideoDecoder.Frames.TryDequeue(out vFrame))
+                    { Log.Warn("No video frame"); break; }
 
                 startTicks = vFrame.timestamp;
-                sw.Restart();
                 UpdateCurTime(vFrame.timestamp, false);
+                renderer.RenderPlayStart();
+                sw.Restart();
             }
 
-            elapsedTicks    = startTicks - (long) (sw.ElapsedTicks * SWFREQ_TO_TICKS);
-            vDistanceMs     = (int) ((elapsedTicks - vFrame.timestamp) / 10000);
+            elapsedTicks    = (long)(sw.ElapsedTicks * SWFREQ_TO_TICKS);
+            vDistanceMs     = (int) ((((startTicks - vFrame.timestamp) / speed) - elapsedTicks) / 10000);
             sleepMs         = vDistanceMs - 1;
 
             if (sleepMs < 0) sleepMs = 0;
 
             if (Math.Abs(vDistanceMs - sleepMs) > 5)
             {
-                //Log($"vDistanceMs |-> {vDistanceMs}");
-                VideoDecoder.DisposeFrame(vFrame);
-                vFrame = null;
+                VideoDecoder.DisposeFrame(vFrame); vFrame = null; // should never be LastFrame
                 Thread.Sleep(5);
                 continue; // rebuffer
             }
 
             if (sleepMs > 2)
             {
-                if (sleepMs > 1000)
+                if (sleepMs > 2000)
                 {
-                    //Log($"sleepMs -> {sleepMs} , vDistanceMs |-> {vDistanceMs}");
-                    VideoDecoder.DisposeFrame(vFrame);
-                    vFrame = null;
+                    VideoDecoder.DisposeFrame(vFrame); vFrame = null; // should never be LastFrame
                     Thread.Sleep(5);
-                    continue; // rebuffer
+                    continue;
                 }
 
                 Thread.Sleep(sleepMs);
@@ -309,22 +308,24 @@ unsafe partial class Player
 
             UpdateCurTime(vFrame.timestamp, false);
 
-            VideoDecoder.Frames.TryDequeue(out vFrame);
-            if (vFrame != null)
-                vFrame.timestamp = (long) (vFrame.timestamp / Speed);
+            vFrame = null;
+            int dequeueRetries  = MAX_DEQUEUE_RETRIES;
+            while (!isVideoSwitch && !VideoDecoder.Frames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
+                Thread.Sleep(1);
         }
+        if (vFrame != null)
+            { VideoDecoder.DisposeFrame(vFrame); vFrame = null; } // should never be LastFrame
+        if (CanInfo) Log.Info($"Finished at {TicksToTimeMini(curTime)}");
     }
 
     private void ScreamerZeroLatency()
-    {
-        // Video Only | IsLive | No Deinterlacing | No Frame Stepping | No Bitrate Stats | No Buffered Duration | Frame rate = receiving packets rate
-
-
+    {   // Video Only | IsLive | No Deinterlacing | No Frame Stepping | No Bitrate Stats | No Buffered Duration | Frame rate = receiving packets rate
         VideoDemuxer.Pause();
         VideoDecoder.Pause();
         VideoDemuxer.DisposePackets();
         VideoDecoder.Flush();
 
+        renderer.RenderPlayStart();
         while (status == Status.Playing)
         {
             vFrame = VideoDecoder.GetFrameNext();
@@ -337,7 +338,10 @@ unsafe partial class Player
             UpdateCurTime(vFrame.timestamp, false);
         }
 
-        if (CanInfo) Log.Info($"Finished -> {TicksToTime(CurTime)}");
+        vFrame = null;
+        renderer.RenderPlayStop();
+
+        if (CanInfo) Log.Info($"Finished at {TicksToTimeMini(curTime)}");
     }
 }
 


### PR DESCRIPTION
Update FlyleafLib v3.9.1 from v3.9

## Changelog
- Player.ScreamerVASD: Fixes/Improves MaxLatency with the new implementation
- Player.ScreamerVASD: Simplifies/Improves GetBufferedDuration calculation
- Player.Screamers: Few Fixes/Improvements with the new implementation
- Renderer: Fixes a critical crash issue during initialization when handle/control has not been assigned yet
- Renderer.Present: Fixes possible issues with locks to ensure stability
- AudioFrame: Attaches speed on audio frame which handles better speed changes

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/8577292e72e2163f59683deb23bb1d4499b9905d...19794196d3192cd59aafc6749fdfc5c012e2a1c9