### PR TITLE
Update FlyleafLib v3.9.2

### DIFF
--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.9.1</Version>
+    <Version>3.9.2</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
@@ -27,10 +27,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.18362.0|AnyCPU'">
     <WarningLevel>6</WarningLevel>
+    <NoWarn>1701;1702;WFO1000</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.18362.0|AnyCPU'">
     <WarningLevel>6</WarningLevel>
+    <NoWarn>1701;1702;WFO1000</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -80,12 +80,14 @@ public unsafe partial class Renderer
 
                 if (LastFrame != null)
                     RenderFrame(LastFrame, false);
-                else
+                else if (Config.Video.ClearScreen)
                 {
                     ClearOverlayTexture();
                     context.OMSetRenderTargets(backBufferRtv);
                     context.ClearRenderTargetView(backBufferRtv, Config.Video._BackgroundColor);
                 }
+                else
+                    return;
             }
 
             swapChain.Present(1, 0);

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -14,7 +14,6 @@ namespace FlyleafLib.MediaFramework.MediaRenderer;
 
 unsafe public partial class Renderer
 {
-    internal bool           forceViewToControl; // Makes sure that viewport will fill the exact same size with the control (mainly for keep ratio on resize)
     volatile bool           canRenderPresent;   // Don't render / present during minimize (or invalid size)
 
     ID3D11Texture2D         backBuffer;
@@ -74,7 +73,7 @@ unsafe public partial class Renderer
 
             try
             {
-                Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} swap chain [Handle: {handle}, Buffers: {Config.Video.SwapBuffers}, Format: {(Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA)}]");
+                if (CanInfo) Log.Info($"Initializing {(Config.Video.Swap10Bit ? "10-bit" : "8-bit")} swap chain [Handle: {handle}, Buffers: {Config.Video.SwapBuffers}, Format: {(Config.Video.Swap10Bit ? Format.R10G10B10A2_UNorm : BGRA_OR_RGBA)}]");
                 swapChain = Engine.Video.Factory.CreateSwapChainForComposition(Device, GetSwapChainDesc(2, 2)); // we will resize on rendering
                 DComp.DCompositionCreateDevice(dxgiDevice, out dCompDevice).CheckError();
                 dCompDevice.CreateTargetForHwnd(handle, false, out dCompTarget).CheckError();
@@ -526,7 +525,7 @@ unsafe public partial class Renderer
                 return;
 
             this.cornerRadius = cornerRadius;
-            cornerRadiusNeedsUpdate = true;
+            cornerRadiusNeedsUpdate = true; // TBR: Probably false if we reset it back to zero corner radius
 
             if (!SCDisposed)
                 UpdateCornerRadiusInternal();

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -45,7 +45,7 @@ unsafe public partial class Renderer
             Width               = (uint)width,
             Height              = (uint)height,
             AlphaMode           = AlphaMode.Premultiplied,  // TBR
-            SwapEffect          = SwapEffect.FlipDiscard,   
+            SwapEffect          = SwapEffect.FlipDiscard,
             Scaling             = Scaling.Stretch,          // DComp can't validate widhth/height?*
             BufferCount         = Math.Max(Config.Video.SwapBuffers, 2),
             SampleDescription   = new SampleDescription(1, 0),
@@ -275,7 +275,7 @@ unsafe public partial class Renderer
                 return;
 
             needsViewport   = true;
-            canRenderPresent= true; // TBR: should be re-calculated
+            canRenderPresent= true;
 
             if (refresh)
                 RenderRequest();
@@ -322,7 +322,7 @@ unsafe public partial class Renderer
         }
 
         GetViewport = new((int)(x - xZoomPixels * (float)zoomCenter.X), (int)(y - yZoomPixels * (float)zoomCenter.Y), newWidth, newHeight);
-        
+
         if (videoProcessor == VideoProcessors.D3D11)
         {
             Viewport view = GetViewport;
@@ -440,10 +440,7 @@ unsafe public partial class Renderer
         lock (lockRenderLoops)
         {
             if (SCDisposed || width <= 0 || height <= 0)
-            {
                 canRenderPresent = false;
-                return;
-            }
             else if (ControlWidth == width && ControlHeight == height)
             {
                 // Re-calculate of canRenderPresent
@@ -460,16 +457,16 @@ unsafe public partial class Renderer
                 }
                 else
                     canRenderPresent = true;
-
-                //RenderRequest(); // We don't refresh as we consider same view
-                return;
             }
+            else
+            {
+                ControlWidth    = width;
+                ControlHeight   = height;
+                canRenderPresent= true;
+                needsResize     = true;
 
-            ControlWidth    = width;
-            ControlHeight   = height;
-            needsResize     = true;
-
-            RenderRequest();
+                RenderRequest();
+            }
         }
     }
     void ResizeBuffersInternal()

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -104,6 +104,7 @@ unsafe public partial class Renderer
             backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
             Engine.Video.Factory.MakeWindowAssociation(ControlHandle, WindowAssociationFlags.IgnoreAll);
             AddSubClass();
+            fillRatio = ControlWidth / (double)ControlHeight; // ResizeBuffers will not trigger it if same width/height as before
             ResizeBuffers(ControlWidth, ControlHeight);
             UpdateDisplay(true); // don't force if we let WndProc run without our swapchain
         }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -104,7 +104,12 @@ unsafe public partial class Renderer
             backBufferRtv   = Device.CreateRenderTargetView(backBuffer);
             Engine.Video.Factory.MakeWindowAssociation(ControlHandle, WindowAssociationFlags.IgnoreAll);
             AddSubClass();
-            fillRatio = ControlWidth / (double)ControlHeight; // ResizeBuffers will not trigger it if same width/height as before
+
+            // ResizeBuffers will not trigger it if same width/height as before
+            fillRatio = ControlWidth / (double)ControlHeight;
+            if (Config.Video.AspectRatio == AspectRatio.Fill)
+                curRatio = fillRatio;
+
             ResizeBuffers(ControlWidth, ControlHeight);
             UpdateDisplay(true); // don't force if we let WndProc run without our swapchain
         }

--- a/FlyleafLib/MediaPlayer/Player.Playback.cs
+++ b/FlyleafLib/MediaPlayer/Player.Playback.cs
@@ -94,6 +94,11 @@ partial class Player
                     shouldFlushPrev = true;
                     ScreamerVASD();
                 }
+
+                if (vFrame != renderer.LastFrame) // Audio does not have renderer
+                    VideoDecoder.DisposeFrame(vFrame);
+
+                vFrame = null;
             }
 
         }
@@ -104,9 +109,6 @@ partial class Player
         }
         finally
         {
-            if (vFrame != renderer.LastFrame)
-                VideoDecoder.DisposeFrame(vFrame);
-            vFrame = null;
             for (int i = 0; i < subNum; i++)
             {
                 sFrames[i] = null;

--- a/Plugins/YoutubeDL/YoutubeDL.csproj
+++ b/Plugins/YoutubeDL/YoutubeDL.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-		<Exec Command="if &quot;$(OutDir)&quot; == &quot;bin\Debug\net9.0-windows10.0.18362.0\&quot; (&#xD;&#xA;  set plugindir=Plugins.NET9&#xD;&#xA;) else if &quot;$(OutDir)&quot; == &quot;bin\Release\net9.0-windows10.0.18362.0\&quot; (&#xD;&#xA;  set plugindir=Plugins.NET9&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;set pluginname=YoutubeDL&#xD;&#xA;&#xD;&#xA;if not exist &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25&quot; mkdir &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25&quot;&#xD;&#xA;&#xD;&#xA;move &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\&quot;&#xD;&#xA;copy /Y &quot;$(ProjectDir)Libs\*&quot; &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\&quot;&#xD;&#xA;del /Q &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\yt-dlp.exe_here&quot;" />
+		<Exec Command="set plugindir=Plugins.NET9&#xD;&#xA;set pluginname=YoutubeDL&#xD;&#xA;if not exist &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25&quot; mkdir &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25&quot;&#xD;&#xA;move &quot;$(TargetDir)*.dll&quot; &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\&quot;&#xD;&#xA;copy /Y &quot;$(ProjectDir)Libs\*&quot; &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\&quot;&#xD;&#xA;del /Q &quot;$(SolutionDir)\Plugins\bin\%25plugindir%25\%25pluginname%25\yt-dlp.exe_here&quot;" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
Update FlyleafLib v3.9.2 from v3.9.1

## Changelog
- Renderer.SwapChain: Fixes an issue during initialization (could cause black screens and wrong aspect ratios during initialize/swap)
- Renderer.Present: Respects Config.Video.ClearScreen and avoids clearing the screen when not set
- Player: Fixes a crashing issue for Audio only

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/19794196d3192cd59aafc6749fdfc5c012e2a1c9...08ed18b52e8d3b21255a2115b8798d9848e4bb1b