### PR TITLE
Update FlyleafLib v3.9.3

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -138,11 +138,11 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
     static bool         isDesignMode;
     static int          idGenerator = 1;
-    static nint         NONE_STYLE = (nint) (WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE); // WS_MINIMIZEBOX required for swapchain
-    static Point        zeroPoint;
-    static POINT        zeroPOINT;
-    static Rect         zeroRect;
-    static CornerRadius zeroCornerRadius;
+    static nint         NONE_STYLE      = (nint) (WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE); // WS_MINIMIZEBOX required for swapchain
+    static Point        zeroPoint       = new();
+    static POINT        zeroPOINT       = new();
+    static Rect         zeroRect        = new();
+    static CornerRadius zeroCornerRadius= new();
 
     double              curResizeRatio;
     bool                surfaceClosed, surfaceClosing, overlayClosed;

--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -138,7 +138,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
     static bool         isDesignMode;
     static int          idGenerator = 1;
-    static nint         NONE_STYLE      = (nint) (WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE); // WS_MINIMIZEBOX required for swapchain
+    static WindowStyles NONE_STYLE      = WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_VISIBLE; // WS_MINIMIZEBOX required for swapchain
     static Point        zeroPoint       = new();
     static POINT        zeroPOINT       = new();
     static Rect         zeroRect        = new();
@@ -523,6 +523,14 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
     }
     public static readonly DependencyProperty CornerRadiusProperty =
         DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), _flType, new(new CornerRadius(0), new(OnCornerRadiusChanged)));
+
+    public Brush VideoBackground
+    {
+        get => (Brush)GetValue(VideoBackgroundProperty);
+        set => SetValue(VideoBackgroundProperty, value);
+    }
+    public static readonly DependencyProperty VideoBackgroundProperty =
+        DependencyProperty.Register(nameof(VideoBackground), typeof(Brush), _flType, new(Brushes.Black, new(OnVideoBackgroundChanged)));
     #endregion
 
     #region Events
@@ -580,9 +588,9 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             return;
 
         if (host.DetachedShowInTaskbar)
-            SetWindowLong(host.SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE, GetWindowLong(host.SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE) | (nint)WindowStylesEx.WS_EX_APPWINDOW);
+            SetWindowLong(host.SurfaceHandle, GetWindowLongEx(host.SurfaceHandle) |  WindowStylesEx.WS_EX_APPWINDOW);
         else
-            SetWindowLong(host.SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE, GetWindowLong(host.SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE) & ~(nint)WindowStylesEx.WS_EX_APPWINDOW);
+            SetWindowLong(host.SurfaceHandle, GetWindowLongEx(host.SurfaceHandle) & ~WindowStylesEx.WS_EX_APPWINDOW);
     }
     private static void OnNoOwnerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -725,31 +733,20 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         if (host.Surface == null)
             return;
 
-        if (host.CornerRadius == zeroCornerRadius)
-            host.Surface.Background  = Brushes.Black;
-        else
-        {
-            host.Surface.Background  = Brushes.Transparent;
-            host.SetCornerRadiusBorder();
-        }
-
         if (host?.Player == null)
             return;
 
         host.Player.renderer.CornerRadius = (CornerRadius)e.NewValue;
 
     }
-    private void SetCornerRadiusBorder()
+    private static void OnVideoBackgroundChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        // Required to handle mouse events as the window's background will be transparent
-        // This does not set the background color we do that with the renderer (which causes some issues eg. when returning from fullscreen to normalscreen)
-        Surface.Content = new Border()
-        {
-            Background          = Brushes.Black, // TBR: for alpha channel -> Background == Brushes.Transparent || Background ==null ? new SolidColorBrush(Color.FromArgb(1,0,0,0)) : Background
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment   = VerticalAlignment.Stretch,
-            CornerRadius        = CornerRadius,
-        };
+        FlyleafHost host = d as FlyleafHost;
+        if (host.Disposed)
+            return;
+
+        if (host.Surface != null)
+            host.Surface.Background = (Brush)e.NewValue;
     }
     private static object OnContentChanging(DependencyObject d, object baseValue)
     {
@@ -885,14 +882,14 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
                 {
                     // Detach Overlay
                     SetParent(OverlayHandle, IntPtr.Zero);
-                    SetWindowLong(OverlayHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE);
+                    SetWindowLong(OverlayHandle, NONE_STYLE);
                     Overlay.Owner = null;
 
                     SetWindowPos(OverlayHandle, IntPtr.Zero, 0, 0, (int)Surface.ActualWidth, (int)Surface.ActualHeight,
                         (uint)(SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE));
 
                     // Attache Overlay
-                    SetWindowLong(OverlayHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE | (nint)(WindowStyles.WS_CHILD | WindowStyles.WS_MAXIMIZE));
+                    SetWindowLong(OverlayHandle, NONE_STYLE | WindowStyles.WS_CHILD | WindowStyles.WS_MAXIMIZE);
                     Overlay.Owner = Surface;
                     SetParent(OverlayHandle, SurfaceHandle);
 
@@ -1536,14 +1533,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         }
 
         if (Surface != null)
-        {
-            if (CornerRadius == zeroCornerRadius)
-                Surface.Background = new SolidColorBrush(Player.Config.Video.BackgroundColor);
-            //else // TBR: this border probably not required? only when we don't have a renderer?
-                //((Border)Surface.Content).Background = new SolidColorBrush(Player.Config.Video.BackgroundColor);
-
             Player.VideoDecoder.CreateSwapChain(SurfaceHandle);
-        }
     }
     public virtual void SetSurface(bool fromSetOverlay = false)
     {
@@ -1551,23 +1541,23 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             return;
 
         // Required for some reason (WindowStyle.None will not be updated with our style)
-        Surface             = new();
-        Surface.Name        = $"Surface_{UniqueId}";
-        Surface.Width       = Surface.Height = 1; // Will be set on loaded
-        Surface.WindowStyle = WindowStyle.None;
-        Surface.ResizeMode  = ResizeMode.NoResize;
-        Surface.ShowInTaskbar = false;
-
-        // CornerRadius must be set initially to AllowsTransparency!
-        if (_CornerRadius == zeroCornerRadius)
-            Surface.Background = Player != null ? new SolidColorBrush(Player.Config.Video.BackgroundColor) : Brushes.Black;
-        else
+        Surface = new()
         {
-            Surface.AllowsTransparency  = true;
-            Surface.Background          = Brushes.Transparent;
-            SetCornerRadiusBorder();
-        }
+            Name            = $"Surface_{UniqueId}",
+            Width           = 1,
+            Height          = 1,
+            WindowStyle     = WindowStyle.None,
+            ResizeMode      = ResizeMode.NoResize,
+            ShowInTaskbar   = false,
+            Background      = VideoBackground
+        };
 
+        // NOTE: AllowsTransparency will cause performance issues (enable only if really required)
+        if (Surface.Background is SolidColorBrush scb)
+            Surface.AllowsTransparency = scb.Color.A < 255;
+        else
+            Surface.AllowsTransparency = true; // Non-solid consider true?
+        
         // When using ItemsControl with ObservableCollection<Player> to fill DataTemplates with FlyleafHost EnsureHandle will call Host_loaded
         if (_IsAttached) Loaded -= Host_Loaded;
         SurfaceHandle = new WindowInteropHelper(Surface).EnsureHandle();
@@ -1575,20 +1565,22 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
         if (_IsAttached)
         {
-            SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE | (nint)WindowStyles.WS_CHILD);
-            SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE, (nint)WindowStylesEx.WS_EX_LAYERED);
+            SetWindowLong(SurfaceHandle, NONE_STYLE | WindowStyles.WS_CHILD);
+            SetWindowLong(SurfaceHandle, WindowStylesEx.WS_EX_LAYERED);
         }
         else // Detached || StandAlone
         {
-            SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE);
+            SetWindowLong(SurfaceHandle, NONE_STYLE);
             if (DetachedShowInTaskbar || IsStandAlone)
-                SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE, (nint)(WindowStylesEx.WS_EX_APPWINDOW | WindowStylesEx.WS_EX_LAYERED));
+                SetWindowLong(SurfaceHandle, WindowStylesEx.WS_EX_APPWINDOW | WindowStylesEx.WS_EX_LAYERED);
             else
-                SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_EXSTYLE, (nint)WindowStylesEx.WS_EX_LAYERED);
+                SetWindowLong(SurfaceHandle, WindowStylesEx.WS_EX_LAYERED);
         }
 
-        if (Player != null)
-            Player.VideoDecoder.CreateSwapChain(SurfaceHandle);
+        // AllowsTransparency = true will ignore it (if we have it with other flags it might cause issues)
+        SetWindowLong(SurfaceHandle, GetWindowLongEx(SurfaceHandle) | WindowStylesEx.WS_EX_NOREDIRECTIONBITMAP);
+
+        Player?.VideoDecoder.CreateSwapChain(SurfaceHandle);
 
         Surface.IsVisibleChanged
                             += Surface_IsVisibleChanged;
@@ -1667,7 +1659,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         Overlay.ShowInTaskbar   = false;
         Overlay.Owner           = Surface;
         SetParent(OverlayHandle, SurfaceHandle);
-        SetWindowLong(OverlayHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE | (nint)(WindowStyles.WS_CHILD | WindowStyles.WS_MAXIMIZE)); // TBR: WS_MAXIMIZE required? (possible better for DWM on fullscreen?)
+        SetWindowLong(OverlayHandle, NONE_STYLE | WindowStyles.WS_CHILD | WindowStyles.WS_MAXIMIZE); // TBR: WS_MAXIMIZE required? (possible better for DWM on fullscreen?)
 
         Overlay.KeyUp       += Overlay_KeyUp;
         Overlay.KeyDown     += Overlay_KeyDown;
@@ -1836,7 +1828,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
         Surface.MaxWidth    = MaxWidth;
         Surface.MaxHeight   = MaxHeight;
 
-        SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE | (nint)WindowStyles.WS_CHILD);
+        SetWindowLong(SurfaceHandle, NONE_STYLE | WindowStyles.WS_CHILD);
         Surface.Owner = Owner;
         SetParent(SurfaceHandle, OwnerHandle);
 
@@ -1913,7 +1905,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
         // Detach (Parent=Null, Owner=Null ?, ShowInTaskBar?, TopMost?)
         SetParent(SurfaceHandle, IntPtr.Zero);
-        SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE); // TBR (also in Attach/FullScren): Needs to be after SetParent. when detached and trying to close the owner will take two clicks (like mouse capture without release) //SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, GetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE) & ~(nint)WindowStyles.WS_CHILD);
+        SetWindowLong(SurfaceHandle, NONE_STYLE); // TBR (also in Attach/FullScren): Needs to be after SetParent. when detached and trying to close the owner will take two clicks (like mouse capture without release) //SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, GetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE) & ~(nint)WindowStyles.WS_CHILD);
         Surface.Owner = DetachedNoOwner ? null : Owner;
         Surface.Topmost = DetachedTopMost;
 
@@ -1938,7 +1930,7 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
                 ResetVisibleRect();
                 SetParent(SurfaceHandle, IntPtr.Zero);
-                SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, NONE_STYLE); // TBR (also in Attach/FullScren): Needs to be after SetParent. when detached and trying to close the owner will take two clicks (like mouse capture without release) //SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, GetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE) & ~(nint)WindowStyles.WS_CHILD);
+                SetWindowLong(SurfaceHandle, NONE_STYLE); // TBR (also in Attach/FullScren): Needs to be after SetParent. when detached and trying to close the owner will take two clicks (like mouse capture without release) //SetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE, GetWindowLong(SurfaceHandle, (int)WindowLongFlags.GWL_STYLE) & ~(nint)WindowStyles.WS_CHILD);
                 Surface.Owner   = DetachedNoOwner ? null : Owner;
                 Surface.Topmost = DetachedTopMost;
 
@@ -1947,9 +1939,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
 
             if (Player != null)
                 Player.renderer.CornerRadius = zeroCornerRadius;
-
-            if (CornerRadius != zeroCornerRadius)
-                ((Border)Surface.Content).CornerRadius = zeroCornerRadius;
 
             if (Overlay != null)
             {
@@ -1986,9 +1975,6 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             // TBR: CornerRadius background has issue it's like a mask color?
             if (Player != null)
                 Player.renderer.CornerRadius = CornerRadius;
-
-            if (CornerRadius != zeroCornerRadius)
-                ((Border)Surface.Content).CornerRadius = CornerRadius;
 
             if (!IsStandAlone) //when play with alpha video and not standalone, we need to set window state to normal last, otherwise it will be lost the background
                 Surface.WindowState = WindowState.Normal;

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -644,7 +644,7 @@ public class Config : NotifyPropertyChanged
         bool _ShowCorrupted;
 
         /// <summary>
-        /// Ensures that after a key packet receives a also key frame (can create artifacts on some broken formats when disabled)
+        /// Ensures that after a key packet receives a also key frame (can create artifacts on some broken formats when disabled and seek issues when enabled)
         /// </summary>
         public bool             KeyFrameValidation  { get => _KeyFrameValidation;   set => SetUI(ref _KeyFrameValidation, value); }
         internal bool _KeyFrameValidation;

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -646,10 +646,15 @@ public class Config : NotifyPropertyChanged
         bool _ShowCorrupted;
 
         /// <summary>
-        /// Forces low delay (Parses AV_CODEC_FLAG_LOW_DELAY to AVCodecContext) (auto-enabled with MaxLatency)
+        /// Forces low delay (Parses AV_CODEC_FLAG2_FAST or AV_CODEC_FLAG_LOW_DELAY -based on DropFrames- to AVCodecContext) (auto-enabled with MaxLatency)
         /// </summary>
         public bool             LowDelay        { get => _LowDelay; set => SetUI(ref _LowDelay, value); }
         bool _LowDelay;
+
+        /// <summary>
+        /// Sets AVCodecContext skip_frame to None or Default (affects also LowDelay)
+        /// </summary>
+        public bool             DropFrames      { get; set; }
 
         public Dictionary<string, string>
                                 AudioCodecOpt       { get; set; } = [];

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -655,6 +655,18 @@ public class Config : NotifyPropertyChanged
         public bool             AllowDropFrames     { get => _AllowDropFrames;      set => SetUI(ref _AllowDropFrames, value); }
         bool _AllowDropFrames;
 
+        public string           AudioCodec          { get => _AudioCodec;           set => SetUI(ref _AudioCodec, value); }
+        string _AudioCodec;
+
+        public string           VideoCodec          { get => _VideoCodec;           set => SetUI(ref _VideoCodec, value); }
+        string _VideoCodec;
+
+        public string           SubtitlesCodec      { get => _SubtitlesCodec;           set => SetUI(ref _SubtitlesCodec, value); }
+        string _SubtitlesCodec;
+
+        public string GetCodecPtr(MediaType type)
+            => type == MediaType.Video ? _VideoCodec : type == MediaType.Audio ? _AudioCodec : _SubtitlesCodec;
+
         public Dictionary<string, string>
                                 AudioCodecOpt       { get; set; } = [];
         public Dictionary<string, string>

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -454,101 +454,100 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Maximuim allowed packets for buffering (as an extra check along with BufferDuration)
         /// </summary>
-        public long             BufferPackets   { get; set; }
+        public long             BufferPackets       { get; set; }
 
         /// <summary>
         /// Maximuim allowed audio packets (when reached it will drop the extra packets and will fire the AudioLimit event)
         /// </summary>
-        public long             MaxAudioPackets { get; set; }
+        public long             MaxAudioPackets     { get; set; }
 
         /// <summary>
         /// Maximum allowed errors before stopping
         /// </summary>
-        public int              MaxErrors       { get; set; } = 30;
+        public int              MaxErrors           { get; set; } = 30;
 
         /// <summary>
         /// Custom IO Stream buffer size (in bytes) for the AVIO Context
         /// </summary>
-        public int              IOStreamBufferSize
-                                                { get; set; } = 0x200000;
+        public int              IOStreamBufferSize  { get; set; } = 0x200000;
 
         /// <summary>
         /// avformat_close_input timeout (ticks) for protocols that support interrupts
         /// </summary>
-        public long             CloseTimeout    { get => closeTimeout; set { closeTimeout = value; closeTimeoutMs = value / 10000; } }
+        public long             CloseTimeout        { get => closeTimeout; set { closeTimeout = value; closeTimeoutMs = value / 10000; } }
         private long closeTimeout = 1 * 1000 * 10000;
         internal long closeTimeoutMs = 1 * 1000;
 
         /// <summary>
         /// avformat_open_input + avformat_find_stream_info timeout (ticks) for protocols that support interrupts (should be related to probesize/analyzeduration)
         /// </summary>
-        public long             OpenTimeout     { get => openTimeout; set { openTimeout = value; openTimeoutMs = value / 10000; } }
+        public long             OpenTimeout         { get => openTimeout; set { openTimeout = value; openTimeoutMs = value / 10000; } }
         private long openTimeout = 5 * 60 * (long)1000 * 10000;
         internal long openTimeoutMs = 5 * 60 * 1000;
 
         /// <summary>
         /// av_read_frame timeout (ticks) for protocols that support interrupts
         /// </summary>
-        public long             ReadTimeout     { get => readTimeout; set { readTimeout = value; readTimeoutMs = value / 10000; } }
+        public long             ReadTimeout         { get => readTimeout; set { readTimeout = value; readTimeoutMs = value / 10000; } }
         private long readTimeout = 10 * 1000 * 10000;
         internal long readTimeoutMs = 10 * 1000;
 
         /// <summary>
         /// av_read_frame timeout (ticks) for protocols that support interrupts (for Live streams)
         /// </summary>
-        public long             ReadLiveTimeout { get => readLiveTimeout; set { readLiveTimeout = value; readLiveTimeoutMs = value / 10000; } }
+        public long             ReadLiveTimeout     { get => readLiveTimeout; set { readLiveTimeout = value; readLiveTimeoutMs = value / 10000; } }
         private long readLiveTimeout = 20 * 1000 * 10000;
         internal long readLiveTimeoutMs = 20 * 1000;
 
         /// <summary>
         /// av_seek_frame timeout (ticks) for protocols that support interrupts
         /// </summary>
-        public long             SeekTimeout     { get => seekTimeout; set { seekTimeout = value; seekTimeoutMs = value / 10000; } }
+        public long             SeekTimeout         { get => seekTimeout; set { seekTimeout = value; seekTimeoutMs = value / 10000; } }
         private long seekTimeout = 8 * 1000 * 10000;
         internal long seekTimeoutMs = 8 * 1000;
 
         /// <summary>
         /// Forces Input Format
         /// </summary>
-        public string           ForceFormat     { get; set; }
+        public string           ForceFormat         { get; set; }
 
         /// <summary>
         /// Forces FPS for NoTimestamp formats (such as h264/hevc)
         /// </summary>
-        public double           ForceFPS        { get; set; }
+        public double           ForceFPS            { get; set; }
 
         /// <summary>
         /// FFmpeg's format flags for demuxer (see https://ffmpeg.org/doxygen/trunk/avformat_8h.html)
         /// eg. FormatFlags |= 0x40; // For AVFMT_FLAG_NOBUFFER
         /// </summary>
-        public DemuxerFlags     FormatFlags     { get; set; } = DemuxerFlags.DiscardCorrupt;// FFmpeg.AutoGen.ffmpeg.AVFMT_FLAG_DISCARD_CORRUPT;
+        public DemuxerFlags     FormatFlags         { get; set; } = DemuxerFlags.DiscardCorrupt;// FFmpeg.AutoGen.ffmpeg.AVFMT_FLAG_DISCARD_CORRUPT;
 
         /// <summary>
         /// Certain muxers and demuxers do nesting (they open one or more additional internal format contexts). This will pass the FormatOpt and HTTPQuery params to the underlying contexts)
         /// </summary>
         public bool             FormatOptToUnderlying
-                                                { get; set; }
+                                                    { get; set; }
 
         /// <summary>
         /// Passes original's Url HTTP Query String parameters to underlying
         /// </summary>
         public bool             DefaultHTTPQueryToUnderlying
-                                                { get; set; } = true;
+                                                    { get; set; } = true;
 
         /// <summary>
         /// HTTP Query String parameters to pass to underlying
         /// </summary>
         public Dictionary<string, string>
                                 ExtraHTTPQueryParamsToUnderlying
-                                                { get; set; } = [];
+                                                    { get; set; } = [];
 
         /// <summary>
         /// FFmpeg's format options for demuxer
         /// </summary>
         public Dictionary<string, string>
-                                FormatOpt       { get; set; } = DefaultVideoFormatOpt();
+                                FormatOpt           { get; set; } = DefaultVideoFormatOpt();
         public Dictionary<string, string>
-                                AudioFormatOpt  { get; set; } = DefaultVideoFormatOpt();
+                                AudioFormatOpt      { get; set; } = DefaultVideoFormatOpt();
 
         public Dictionary<string, string>
                                 SubtitlesFormatOpt  { get; set; } = DefaultVideoFormatOpt();
@@ -603,58 +602,58 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Threads that will be used from the decoder
         /// </summary>
-        public int              VideoThreads    { get; set; } = Environment.ProcessorCount;
+        public int              VideoThreads        { get; set; } = Environment.ProcessorCount;
 
         /// <summary>
         /// Maximum video frames to be decoded and processed for rendering
         /// </summary>
-        public int              MaxVideoFrames  { get => _MaxVideoFrames; set { if (Set(ref _MaxVideoFrames, value)) { player?.RefreshMaxVideoFrames(); } } }
+        public int              MaxVideoFrames      { get => _MaxVideoFrames;   set { if (Set(ref _MaxVideoFrames, value)) { player?.RefreshMaxVideoFrames(); } } }
         int _MaxVideoFrames = 4;
         internal void SetMaxVideoFrames(int maxVideoFrames) { _MaxVideoFrames = maxVideoFrames; RaiseUI(nameof(MaxVideoFrames)); } // can be updated by video decoder if fails to allocate them
 
         /// <summary>
         /// Maximum audio frames to be decoded and processed for playback
         /// </summary>
-        public int              MaxAudioFrames  { get; set; } = 10;
+        public int              MaxAudioFrames      { get; set; } = 10;
 
         /// <summary>
         /// Maximum subtitle frames to be decoded
         /// </summary>
-        public int              MaxSubsFrames   { get; set; } = 1;
+        public int              MaxSubsFrames       { get; set; } = 1;
 
         /// <summary>
         /// Maximum data frames to be decoded
         /// </summary>
-        public int              MaxDataFrames   { get; set; } = 100;
+        public int              MaxDataFrames       { get; set; } = 100;
 
         /// <summary>
         /// Maximum allowed errors before stopping
         /// </summary>
-        public int              MaxErrors       { get; set; } = 200;
+        public int              MaxErrors           { get; set; } = 200;
 
         /// <summary>
         /// Allows video accceleration even in codec's profile mismatch
         /// </summary>
-        public bool             AllowProfileMismatch
-                                                { get => _AllowProfileMismatch; set => SetUI(ref _AllowProfileMismatch, value); }
+        public bool             AllowProfileMismatch{ get => _AllowProfileMismatch; set => SetUI(ref _AllowProfileMismatch, value); }
         bool _AllowProfileMismatch = true;
 
         /// <summary>
         /// Allows corrupted frames (Parses AV_CODEC_FLAG_OUTPUT_CORRUPT to AVCodecContext)
         /// </summary>
-        public bool             ShowCorrupted   { get => _ShowCorrupted; set => SetUI(ref _ShowCorrupted, value); }
+        public bool             ShowCorrupted       { get => _ShowCorrupted;        set => SetUI(ref _ShowCorrupted, value); }
         bool _ShowCorrupted;
 
         /// <summary>
         /// Forces low delay (Parses AV_CODEC_FLAG2_FAST or AV_CODEC_FLAG_LOW_DELAY -based on DropFrames- to AVCodecContext) (auto-enabled with MaxLatency)
         /// </summary>
-        public bool             LowDelay        { get => _LowDelay; set => SetUI(ref _LowDelay, value); }
+        public bool             LowDelay            { get => _LowDelay;             set => SetUI(ref _LowDelay, value); }
         bool _LowDelay;
 
         /// <summary>
         /// Sets AVCodecContext skip_frame to None or Default (affects also LowDelay)
         /// </summary>
-        public bool             DropFrames      { get; set; }
+        public bool             AllowDropFrames     { get => _AllowDropFrames;      set => SetUI(ref _AllowDropFrames, value); }
+        bool _AllowDropFrames;
 
         public Dictionary<string, string>
                                 AudioCodecOpt       { get; set; } = [];
@@ -670,8 +669,8 @@ public class Config : NotifyPropertyChanged
     {
         public VideoConfig()
         {
-            BindingOperations.EnableCollectionSynchronization(Filters, lockFilters);
-            BindingOperations.EnableCollectionSynchronization(D3Filters, lockD3Filters);
+            BindingOperations.EnableCollectionSynchronization(Filters,  lockFilters);
+            BindingOperations.EnableCollectionSynchronization(D3Filters,lockD3Filters);
         }
 
         public VideoConfig Clone()
@@ -1172,7 +1171,7 @@ public class Config : NotifyPropertyChanged
         /// Allowed input types to be searched locally for subtitles (empty list allows all types)
         /// </summary>
         public List<InputType>  SearchLocalOnInputType
-                                                    { get; set; } = [ InputType.File, InputType.UNC, InputType.Torrent ];
+                                                    { get; set; } = [InputType.File, InputType.UNC, InputType.Torrent];
 
         /// <summary>
         /// Whether to use online search plugins (see also <see cref="SearchOnlineOnInputType"/>)
@@ -1184,7 +1183,7 @@ public class Config : NotifyPropertyChanged
         /// Allowed input types to be searched online for subtitles (empty list allows all types)
         /// </summary>
         public List<InputType>  SearchOnlineOnInputType
-                                                    { get; set; } = [ InputType.File, InputType.UNC, InputType.Torrent ];
+                                                    { get; set; } = [InputType.File, InputType.UNC, InputType.Torrent];
 
         /// <summary>
         /// Subtitles parser (can be used for custom parsing)

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -644,6 +644,12 @@ public class Config : NotifyPropertyChanged
         bool _ShowCorrupted;
 
         /// <summary>
+        /// Ensures that after a key packet receives a also key frame (can create artifacts on some broken formats when disabled)
+        /// </summary>
+        public bool             KeyFrameValidation  { get => _KeyFrameValidation;   set => SetUI(ref _KeyFrameValidation, value); }
+        internal bool _KeyFrameValidation;
+
+        /// <summary>
         /// Forces low delay (Parses AV_CODEC_FLAG2_FAST or AV_CODEC_FLAG_LOW_DELAY -based on DropFrames- to AVCodecContext) (auto-enabled with MaxLatency)
         /// </summary>
         public bool             LowDelay            { get => _LowDelay;             set => SetUI(ref _LowDelay, value); }

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -42,12 +42,12 @@
     <PackageReference Include="SearchPioneer.Lingua" Version="1.0.4" />
     <PackageReference Include="TesseractOCR" Version="5.5.1" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
-    <PackageReference Include="Vortice.D3DCompiler" Version="3.6.2" />
-    <PackageReference Include="Vortice.Direct3D11" Version="3.6.2" />
-    <PackageReference Include="Vortice.DirectComposition" Version="3.6.2" />
-    <PackageReference Include="Vortice.Mathematics" Version="1.9.2" />
-    <PackageReference Include="Vortice.MediaFoundation" Version="3.6.2" />
-    <PackageReference Include="Vortice.XAudio2" Version="3.6.2" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="3.7.6-beta" />
+    <PackageReference Include="Vortice.Direct3D11" Version="3.7.6-beta" />
+    <PackageReference Include="Vortice.DirectComposition" Version="3.7.6-beta" />
+    <PackageReference Include="Vortice.Mathematics" Version="1.9.3" />
+    <PackageReference Include="Vortice.MediaFoundation" Version="3.7.6-beta" />
+    <PackageReference Include="Vortice.XAudio2" Version="3.7.6-beta" />
     <PackageReference Include="Whisper.net" Version="1.8.1" />
   </ItemGroup>
 

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.9.2</Version>
+    <Version>3.9.3</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -673,7 +673,7 @@ public unsafe partial class DecoderContext : PluginHandler
                 if (packet->flags.HasFlag(PktFlags.Key) || packet->pts == VideoDecoder.startPts)
                 {
                     VideoDecoder.keyPacketRequired = false;
-                    VideoDecoder.keyFrameRequired  = true;
+                    VideoDecoder.keyFrameRequired  = Config.Decoder._KeyFrameValidation;
                 }
                 else
                 {

--- a/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/AudioDecoder.cs
@@ -39,7 +39,6 @@ public unsafe partial class AudioDecoder : DecoderBase
     public ConcurrentQueue<AudioFrame>
                             Frames              { get; protected set; } = new();
 
-    internal Action         CBufAlloc;          // Informs Audio player to clear buffer pointers to avoid access violation
     static readonly int     cBufTimesSize       = 4; // Extra for draining / filters (speed)
     int                     cBufTimesCur        = 1;
     byte[]                  cBuf;
@@ -463,7 +462,6 @@ public unsafe partial class AudioDecoder : DecoderBase
                 cBufHistory.Dequeue();
         }
         
-        CBufAlloc?.Invoke();
         cBuf        = new byte[size];
         cBufPos     = 0;
         cBufSamples = samples;

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -61,6 +61,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
     protected string Open2(StreamBase stream, StreamBase prevStream, bool openStream = true)
     {
         string error = null;
+        AVCodec* codec;
 
         try
         {
@@ -76,10 +77,17 @@ public abstract unsafe class DecoderBase : RunThreadBase
 
                 if (stream is not DataStream) // if we don't open/use a data codec context why not just push the Data Frames directly from the Demuxer? no need to have DataDecoder*
                 {
-                    // avcodec_find_decoder will use libdav1d which does not support hardware decoding (software fallback with openStream = false from av1 to default:libdav1d) [#340]
-                    var codec = stream.CodecID == AVCodecID.Av1 && openStream && Config.Video.VideoAcceleration ? avcodec_find_decoder_by_name("av1") : avcodec_find_decoder(stream.CodecID);
+                    var codecStr = Config.Decoder.GetCodecPtr(stream.Type);
+                    if (string.IsNullOrEmpty(codecStr))
+                        // avcodec_find_decoder will use libdav1d which does not support hardware decoding (software fallback with openStream = false from av1 to default:libdav1d) [#340]
+                        codec = stream.CodecID == AVCodecID.Av1 && openStream && Config.Video.VideoAcceleration ? avcodec_find_decoder_by_name("av1") : avcodec_find_decoder(stream.CodecID);
+                    else
+                        codec = avcodec_find_decoder_by_name(codecStr);
+
                     if (codec == null)
-                        return error = $"[{Type} avcodec_find_decoder] No suitable codec found";
+                        return error = $"[{Type} avcodec_find_decoder] No suitable codec found ";
+
+                    if (CanDebug) Log.Debug($"[{Type}] Using {avcodec_get_name(codec->id)} codec");
 
                     codecCtx = avcodec_alloc_context3(codec); // Pass codec to use default settings
                     if (codecCtx == null)

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -96,7 +96,17 @@ public abstract unsafe class DecoderBase : RunThreadBase
                         codecCtx->flags |= CodecFlags.OutputCorrupt;
 
                     if (Config.Decoder.LowDelay)
-                        codecCtx->flags |= CodecFlags.LowDelay;
+                    {
+                        if (Config.Decoder.DropFrames)
+                            codecCtx->flags |= CodecFlags.LowDelay;
+                        else
+                        {
+                            codecCtx->skip_frame = AVDiscard.None;
+                            codecCtx->flags2 |= CodecFlags2.Fast;
+                        }
+                    }
+                    else if (!Config.Decoder.DropFrames)
+                        codecCtx->skip_frame = AVDiscard.None;
 
                     try { ret = Setup(codec); } catch(Exception e) { return error = $"[{Type} Setup] {e.Message}"; }
                     if (ret < 0)

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -105,7 +105,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
                     var codecOpts = Config.Decoder.GetCodecOptPtr(stream.Type);
                     AVDictionary* avopt = null;
                     foreach(var optKV in codecOpts)
-                        av_dict_set(&avopt, optKV.Key, optKV.Value, 0);
+                        _ = av_dict_set(&avopt, optKV.Key, optKV.Value, 0);
 
                     ret = avcodec_open2(codecCtx, null, avopt == null ? null : &avopt);
 

--- a/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/DecoderBase.cs
@@ -97,7 +97,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
 
                     if (Config.Decoder.LowDelay)
                     {
-                        if (Config.Decoder.DropFrames)
+                        if (Config.Decoder.AllowDropFrames)
                             codecCtx->flags |= CodecFlags.LowDelay;
                         else
                         {
@@ -105,7 +105,7 @@ public abstract unsafe class DecoderBase : RunThreadBase
                             codecCtx->flags2 |= CodecFlags2.Fast;
                         }
                     }
-                    else if (!Config.Decoder.DropFrames)
+                    else if (!Config.Decoder.AllowDropFrames)
                         codecCtx->skip_frame = AVDiscard.None;
 
                     try { ret = Setup(codec); } catch(Exception e) { return error = $"[{Type} Setup] {e.Message}"; }

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -493,7 +493,7 @@ public unsafe class VideoDecoder : DecoderBase
                 {
                     if (packet->flags.HasFlag(PktFlags.Key) || packet->pts == startPts)
                     {
-                        keyFrameRequired  = true;
+                        keyFrameRequired  = Config.Decoder._KeyFrameValidation;
                         keyPacketRequired = false;
                     }
                     else
@@ -1086,7 +1086,7 @@ public unsafe class VideoDecoder : DecoderBase
                 if (demuxer.packet->flags.HasFlag(PktFlags.Key) || demuxer.packet->pts == startPts)
                 {
                     keyPacketRequired = false;
-                    keyFrameRequired  = true;
+                    keyFrameRequired  = Config.Decoder._KeyFrameValidation;
                 }
                 else
                 {

--- a/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
+++ b/FlyleafLib/MediaFramework/MediaDemuxer/Demuxer.cs
@@ -1033,7 +1033,7 @@ public unsafe class Demuxer : RunThreadBase
             if (ticks + (VideoStream != null && forward ? (10000 * 10000) : 0) > CurTime + startTime && ticks < CurTime + startTime + BufferedDuration)
             {
                 bool found = false;
-                while (VideoPackets.Count > 0)
+                while (!VideoPackets.IsEmpty)
                 {
                     var packet = VideoPackets.Peek();
                     if (packet->pts != AV_NOPTS_VALUE && ticks < packet->pts * VideoStream.Timebase && (packet->flags & PktFlags.Key) != 0)
@@ -1051,7 +1051,7 @@ public unsafe class Demuxer : RunThreadBase
                     av_packet_free(&packet);
                 }
 
-                while (AudioPackets.Count > 0)
+                while (!AudioPackets.IsEmpty)
                 {
                     var packet = AudioPackets.Peek();
                     if (packet->pts != AV_NOPTS_VALUE && (packet->pts + packet->duration) * AudioStream.Timebase >= ticks)
@@ -1068,7 +1068,7 @@ public unsafe class Demuxer : RunThreadBase
 
                 for (int i = 0; i < subNum; i++)
                 {
-                    while (SubtitlesPackets[i].Count > 0)
+                    while (!SubtitlesPackets[i].IsEmpty)
                     {
                         var packet = SubtitlesPackets[i].Peek();
                         if (packet->pts != AV_NOPTS_VALUE && ticks < (packet->pts + packet->duration) * SubtitlesStreams[i].Timebase)
@@ -1086,7 +1086,7 @@ public unsafe class Demuxer : RunThreadBase
                     }
                 }
 
-                while (DataPackets.Count > 0)
+                while (!DataPackets.IsEmpty)
                 {
                     var packet = DataPackets.Peek();
                     if (packet->pts != AV_NOPTS_VALUE && ticks < (packet->pts + packet->duration) * DataStream.Timebase)
@@ -1890,7 +1890,7 @@ public unsafe class Demuxer : RunThreadBase
     /// <returns>0 on success</returns>
     public int GetNextVideoPacket()
     {
-        if (VideoPackets.Count > 0)
+        if (!VideoPackets.IsEmpty)
         {
             packet = VideoPackets.Dequeue();
             return 0;
@@ -1944,50 +1944,54 @@ public unsafe class Demuxer : RunThreadBase
     #endregion
 }
 
-public unsafe class PacketQueue
+public unsafe class PacketQueue : Queue<nint>
 {
     // TODO: DTS might not be available without avformat_find_stream_info (should changed based on packet->duration and fallback should be removed)
     readonly Demuxer demuxer;
-    readonly ConcurrentQueue<nint> packets = [];
     public long frameDuration = 30 * 1000 * 10000; // in case of negative buffer duration calculate it based on packets count / FPS
 
     public long Bytes               { get; private set; }
     public long BufferedDuration    { get; private set; }
     public long CurTime             { get; private set; }
-    public int  Count               => packets.Count;
-    public bool IsEmpty             => packets.IsEmpty;
 
     public long FirstTimestamp      { get; private set; } = AV_NOPTS_VALUE;
     public long LastTimestamp       { get; private set; } = AV_NOPTS_VALUE;
+    public bool IsEmpty             => Count == 0;
 
-    public PacketQueue(Demuxer demuxer)
+    public PacketQueue(Demuxer demuxer) : base()
         => this.demuxer = demuxer;
 
-    public void Clear()
+    #if DEBUG
+    // Ensures we don't access base queue directly
+    public new void Enqueue     (nint _)    => throw new NotImplementedException("Use AVPacket*");
+    public new bool TryDequeue  (out nint _)=> throw new NotImplementedException("Use AVPacket*");
+    public new bool TryPeek     (out nint _)=> throw new NotImplementedException("Use AVPacket*");
+    #endif
+
+    public new void Clear()
     {
-        lock(packets)
+        lock(this)
         {
-            while (!packets.IsEmpty)
+            while (base.TryDequeue(out nint packetPtr))
             {
-                packets.TryDequeue(out nint packetPtr);
-                if (packetPtr == 0) continue;
+                if (packetPtr == 0) continue; // TBR: can be disposed?
                 AVPacket* packet = (AVPacket*)packetPtr;
                 av_packet_free(&packet);
             }
 
-            FirstTimestamp = AV_NOPTS_VALUE;
-            LastTimestamp = AV_NOPTS_VALUE;
-            Bytes = 0;
-            BufferedDuration = 0;
-            CurTime = 0;
+            FirstTimestamp  = AV_NOPTS_VALUE;
+            LastTimestamp   = AV_NOPTS_VALUE;
+            Bytes           = 0;
+            BufferedDuration= 0;
+            CurTime         = 0;
         }
     }
 
     public void Enqueue(AVPacket* packet)
     {
-        lock (packets)
+        lock (this)
         {
-            packets.Enqueue((nint)packet);
+            base.Enqueue((nint)packet);
 
             if (packet->dts != AV_NOPTS_VALUE || packet->pts != AV_NOPTS_VALUE)
             {
@@ -2004,20 +2008,20 @@ public unsafe class PacketQueue
                 {
                     BufferedDuration = LastTimestamp - FirstTimestamp;
                     if (BufferedDuration < 0)
-                        BufferedDuration = packets.Count * frameDuration;
+                        BufferedDuration = Count * frameDuration;
                 }
             }
             else
-                BufferedDuration = packets.Count * frameDuration;
+                BufferedDuration = Count * frameDuration;
 
             Bytes += packet->size;
         }
     }
 
-    public AVPacket* Dequeue()
+    public new AVPacket* Dequeue()
     {
-        lock(packets)
-            if (packets.TryDequeue(out nint packetPtr))
+        lock(this)
+            if (base.TryDequeue(out nint packetPtr))
             {
                 AVPacket* packet = (AVPacket*)packetPtr;
 
@@ -2030,7 +2034,7 @@ public unsafe class PacketQueue
                     UpdateCurTime();
                 }
                 else
-                    BufferedDuration = packets.Count * frameDuration;
+                    BufferedDuration = Count * frameDuration;
 
                 return (AVPacket*)packetPtr;
             }
@@ -2038,8 +2042,8 @@ public unsafe class PacketQueue
         return null;
     }
 
-    public AVPacket* Peek()
-        => packets.TryPeek(out nint packetPtr)
+    public new AVPacket* Peek() // Should use lock but we use it only during SeekInQueue (decoders paused)
+        => base.TryPeek(out nint packetPtr)
         ? (AVPacket*)packetPtr
         : (AVPacket*)null;
 
@@ -2068,6 +2072,6 @@ public unsafe class PacketQueue
         BufferedDuration = LastTimestamp - FirstTimestamp;
 
         if (BufferedDuration < 0)
-            BufferedDuration = packets.Count * frameDuration;
+            BufferedDuration = Count * frameDuration;
     }
 }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Device.cs
@@ -212,7 +212,7 @@ public unsafe partial class Renderer
                 // subs
                 ShaderBGRA = ShaderCompiler.CompilePS(Device, "bgra", @"color = float4(Texture1.Sample(Sampler, input.Texture).rgba);", null);
 
-                // Blend State (currently used -mainly- for RGBA images and OverlayTexture)
+                // Blend State (currently used for OverlayTexture)
                 blendStateAlpha = Device.CreateBlendState(blendDesc);
 
                 // Rasterizer (Will change CullMode to None for H-V Flip)

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.PixelShader.cs
@@ -656,7 +656,6 @@ unsafe public partial class Renderer
 ");
             }
 
-            context.OMSetBlendState(VideoStream.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Alpha) ? blendStateAlpha : null);
             Log.Debug($"Prepared planes for {VideoStream.PixelFormatStr} with {videoProcessor} [{curPSCase}]");
 
             return true;

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.Present.cs
@@ -243,7 +243,7 @@ public unsafe partial class Renderer
 
             // restore context
             context.PSSetShader(ShaderPS);
-            context.OMSetBlendState(VideoStream.PixelFormatDesc->flags.HasFlag(PixFmtFlags.Alpha) ? blendStateAlpha : null);
+            context.OMSetBlendState(null);
             context.RSSetViewport(GetViewport);
         }
     }

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.SwapChain.cs
@@ -27,7 +27,7 @@ unsafe public partial class Renderer
     const uint              WM_SIZE                     = 0x0005;
     const uint              WM_DISPLAYCHANGE            = 0x007E;
     const uint              WM_NCDESTROY                = 0x0082;
-    const int               WS_EX_NOREDIRECTIONBITMAP   = 0x00200000;
+
     SubclassWndProc         wndProcDelegate;
     IntPtr                  wndProcDelegatePtr;
 
@@ -67,9 +67,6 @@ unsafe public partial class Renderer
             GetWindowRect(ControlHandle, ref rect);
             ControlWidth    = rect.Right  - rect.Left;
             ControlHeight   = rect.Bottom - rect.Top;
-
-            // WS_EX_NOREDIRECTIONBITMAP: Prevent DWM from creating a redirection surface (offscreen bitmap)
-            SetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE, GetWindowLong(handle, (int)WindowLongFlags.GWL_EXSTYLE).ToInt32() | WS_EX_NOREDIRECTIONBITMAP);
 
             try
             {

--- a/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/Renderer.VideoProcessor.cs
@@ -407,7 +407,7 @@ unsafe public partial class Renderer
         context.UpdateSubresource(vsBufferData, vsBuffer);
         vc?.VideoProcessorSetStreamRotation(vp, 0, true, _d3d11vpRotation);
 
-        UpdateAspectRatio(refresh);
+        UpdateAspectRatioUnSafe(refresh);
     }
 
     internal void UpdateAspectRatio(bool refresh = true)

--- a/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
+++ b/FlyleafLib/MediaFramework/MediaRenderer/ShaderCompiler.PixelShader.cs
@@ -347,7 +347,7 @@ float4 main(PSInput input) : SV_TARGET
     c  = Saturation(c, Config.saturation);
 #endif
     
-    return saturate(float4(c, color.a));
+    return saturate(float4(c * color.a, color.a));
 }
 "u8;
 }

--- a/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/VideoStream.cs
@@ -221,8 +221,11 @@ public unsafe class VideoStream : StreamBase
             }
         }
 
-        Width   = (uint)(frame->width  - (cropRect.Left + cropRect.Right));
-        Height  = (uint)(frame->height - (cropRect.Top  + cropRect.Bottom));
+        if (Width == 0)
+        {   // Those are for info only (mainly before opening the stream, otherwise we get them from renderer at player's Video.X)
+            Width   = (uint)codecCtx->width;
+            Height  = (uint)codecCtx->height;
+        }
 
         if (frame->flags.HasFlag(FrameFlags.Interlaced))
             FieldOrder = frame->flags.HasFlag(FrameFlags.TopFieldFirst) ? VideoFrameFormat.InterlacedTopFieldFirst : VideoFrameFormat.InterlacedBottomFieldFirst;

--- a/FlyleafLib/MediaPlayer/Audio.cs
+++ b/FlyleafLib/MediaPlayer/Audio.cs
@@ -281,7 +281,27 @@ public class Audio : NotifyPropertyChanged
         }
     }
     internal long GetBufferedDuration() { lock (locker) { return (long) ((submittedSamples - sourceVoice.State.SamplesPlayed) * Timebase); } }
-    internal long GetDeviceDelay()      { lock (locker) { return (long) ((xaudio2.PerformanceData.CurrentLatencyInSamples * Timebase) - 8_0000); } } // TODO: VBlack delay (8ms correction for now)
+    internal long GetDeviceDelay()
+    {
+        /* TODO
+         * Get rid of lockers during playback
+         * VBlack delay (8ms correction for now)
+         * TBR: (Very rare) Possible invalid response after quick Clear Buffers?* can return huge number ~60sec and can't even restore on next clear buffer
+         */
+        lock (locker)
+        {
+            var latency = (long) ((xaudio2.PerformanceData.CurrentLatencyInSamples * Timebase) - 8_0000);
+            if (latency > TimeSpan.FromMilliseconds(500).Ticks)
+            {
+                #if DEBUG
+                player.Log.Error($"!!! Device Latency nosense -> {TicksToTimeMini(latency)}");
+                #endif
+                return TimeSpan.FromMilliseconds(40).Ticks;
+            }
+            
+            return latency;
+        }
+    }
     internal void ClearBuffer()
     {
         lock (locker)

--- a/FlyleafLib/MediaPlayer/Player.Extra.cs
+++ b/FlyleafLib/MediaPlayer/Player.Extra.cs
@@ -190,10 +190,10 @@ unsafe partial class Player
                 SubtitleClear(i);
             }
 
-            if (VideoDecoder.Frames.IsEmpty)
+            if (vFrames.IsEmpty)
                 vFrame = VideoDecoder.GetFrameNext();
             else
-                VideoDecoder.Frames.TryDequeue(out vFrame);
+                vFrames.TryDequeue(out vFrame);
 
             if (vFrame == null)
                 return;
@@ -237,13 +237,13 @@ unsafe partial class Player
                 SubtitleClear(i);
             }
 
-            if (VideoDecoder.Frames.IsEmpty)
+            if (vFrames.IsEmpty)
             {
                 reversePlaybackResync = true; // Temp fix for previous timestamps until we seperate GetFrame for Extractor and the Player
                 vFrame = VideoDecoder.GetFrame(VideoDecoder.GetFrameNumber(CurTime) - 1, true);
             }
             else
-                VideoDecoder.Frames.TryDequeue(out vFrame);
+                vFrames.TryDequeue(out vFrame);
 
             if (vFrame == null)
                 return;

--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -637,13 +637,13 @@ unsafe partial class Player
 
             if (resync && (Duration > 0 || stream.Demuxer.IsHLSLive))
             {
-                // Wait for at least on package before seek to update the HLS context first_time
+                // Wait for at least X packets before seek to update the HLS context first_time
                 if (stream.Demuxer.IsHLSLive)
                 {
                     var curDemuxer = stream.Demuxer;
 
                     int retries = 1000; // 20sec ? | For audio check also VideoPackets
-                    while (stream.Demuxer.IsRunning && stream.Demuxer.GetPacketsPtr(stream).Count < 3 && stream.Demuxer.VideoPackets.Count < 3 && retries-- > 0)
+                    while (stream.Demuxer.IsRunning && stream.Demuxer.GetPacketsPtr(stream).Count < 3 && retries-- > 0)
                         Thread.Sleep(20);
 
                     ReSync(stream, (int)((duration - fromEnd - (DateTime.UtcNow.Ticks - delay)) / 10000));
@@ -730,7 +730,7 @@ unsafe partial class Player
     internal void ReSync(StreamBase stream, int syncMs = -1, bool accurate = false)
     {
         /* TODO
-         *
+         * TBR: Audio only might have issues
          * HLS live resync on stream switch should be from the end not from the start (could have different cache/duration)
          */
 

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -78,7 +78,8 @@ unsafe partial class Player
             }
         }
 
-        VideoDecoder.DisposeFrame(vFrame); // TBR: Should never be not null (check with LastFrame?)
+        if (vFrame != null && vFrame != renderer.LastFrame) // TBR: lock?
+            VideoDecoder.DisposeFrame(vFrame);
         vFrame = null; aFrame = null; dFrame = null;
         for (int i = 0; i < subNum; i++)
         {

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -11,9 +11,18 @@ unsafe partial class Player
     const int MAX_DEQUEUE_RETRIES = 20; // (Ms) Tries to avoid re-buffering by waiting the decoder to catch up
     volatile bool isScreamerVASDAudio;
     volatile bool stopScreamerVASDAudio;
+    long startTicks, lastSpeedChangeTicks;
 
     bool BufferVASD()
     {
+        long aDeviceDelay   = 0;
+        bool gotAudio       = !Audio.IsOpened || Config.Player.MaxLatency != 0;
+        bool gotVideo       = false;
+        bool shouldStop     = false;
+        bool showOneFrame   = true;
+        int  audioRetries   = 4;
+        int  loops          = 0;
+
         if (CanTrace) Log.Trace("Buffering");
 
         while (isVideoSwitch && IsPlaying) Thread.Sleep(10);
@@ -23,7 +32,7 @@ unsafe partial class Player
 
         if (Audio.isOpened && Config.Audio.Enabled)
         {
-            curAudioDeviceDelay = Audio.GetDeviceDelay();
+            aDeviceDelay = Audio.GetDeviceDelay();
 
             if (AudioDecoder.OnVideoDemuxer)
                 AudioDecoder.Start();
@@ -69,21 +78,12 @@ unsafe partial class Player
             }
         }
 
-        VideoDecoder.DisposeFrame(vFrame);
-        vFrame = null;
-        aFrame = null;
+        VideoDecoder.DisposeFrame(vFrame); // TBR: Should never be not null (check with LastFrame?)
+        vFrame = null; aFrame = null; dFrame = null;
         for (int i = 0; i < subNum; i++)
         {
             sFrames[i] = null;
         }
-        dFrame = null;
-
-        bool gotAudio       = !Audio.IsOpened || Config.Player.MaxLatency != 0;
-        bool gotVideo       = false;
-        bool shouldStop     = false;
-        bool showOneFrame   = true;
-        int  audioRetries   = 4;
-        int  loops          = 0;
 
         if (Config.Player.MaxLatency != 0)
         {
@@ -99,7 +99,6 @@ unsafe partial class Player
             if (showOneFrame && !VideoDecoder.Frames.IsEmpty)
             {
                 ShowOneFrame();
-                showOneFrameTicks = DateTime.UtcNow.Ticks;
                 showOneFrame = false;
             }
 
@@ -126,7 +125,7 @@ unsafe partial class Player
                     for (int i = 0; i < Math.Min(20, AudioDecoder.Frames.Count); i++)
                     {
                         if (aFrame == null
-                            || aFrame.timestamp - curAudioDeviceDelay > vFrame.timestamp
+                            || aFrame.timestamp - aDeviceDelay > vFrame.timestamp
                             || vFrame.timestamp > duration)
                         {
                             gotAudio = true;
@@ -220,6 +219,9 @@ unsafe partial class Player
 
         bool secondField = false; // To be transfered in renderer
         int dequeueRetries;
+        int vDistanceMs, dDistanceMs;
+        int[] sDistanceMss = new int[subNum];
+        long elapsedTicks;
 
         while (status == Status.Playing)
         {
@@ -688,13 +690,13 @@ unsafe partial class Player
     }
     private void CheckLatency()
     {
-        curLatency = GetBufferedDuration();
+        long curLatency = GetBufferedDuration();
 
         if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Frames: {VideoDecoder.Frames.Count} Packets: {VideoDemuxer.VideoPackets.Count} Speed: {speed}");
 
         if (curLatency <= Config.Player.MinLatency) // We've reached the down limit (back to speed x1)
         {
-            ChangeSpeedWithoutBuffering(1);
+            ChangeSpeedWithoutBuffering(1, curLatency);
             return;
         }
         else if (curLatency < Config.Player.MaxLatency)
@@ -711,9 +713,9 @@ unsafe partial class Player
             return;
         }
 
-        ChangeSpeedWithoutBuffering(newSpeed);
+        ChangeSpeedWithoutBuffering(newSpeed, curLatency);
     }
-    void ChangeSpeedWithoutBuffering(double newSpeed)
+    void ChangeSpeedWithoutBuffering(double newSpeed, long curLatency)
     {
         if (speed == newSpeed)
             return;
@@ -740,10 +742,7 @@ unsafe partial class Player
 
     void ScreamerVASDAudio()
     {
-        long bufferTicks    = 0;
-        long delayTicks     = 0;
-        long elapsedTicks   = 0;
-        long waitTicks      = 0;
+        long bufferTicks, delayTicks, elapsedTicks, waitTicks;
         long desyncMs       = 0;    // use Ms to avoid rescale inaccuracy
         long expectingPts   = NoTs; // Will be set on resync
         bool shouldResync   = true;

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -96,7 +96,7 @@ unsafe partial class Player
         {
             loops++;
 
-            if (showOneFrame && !VideoDecoder.Frames.IsEmpty)
+            if (showOneFrame && !vFrames.IsEmpty)
             {
                 ShowOneFrame();
                 showOneFrame = false;
@@ -106,11 +106,8 @@ unsafe partial class Player
             if ((!showOneFrame || loops > 8) && !seeks.IsEmpty)
                 return false;
 
-            if (!gotVideo && !showOneFrame && !VideoDecoder.Frames.IsEmpty)
-            {
-                VideoDecoder.Frames.TryDequeue(out vFrame);
-                if (vFrame != null) gotVideo = true;
-            }
+            if (!gotVideo && !showOneFrame && vFrames.TryDequeue(out vFrame))
+                gotVideo = true;
 
             if (!gotAudio && aFrame == null && !AudioDecoder.Frames.IsEmpty)
                 AudioDecoder.Frames.TryDequeue(out aFrame);
@@ -388,7 +385,7 @@ unsafe partial class Player
                 dequeueRetries = MAX_DEQUEUE_RETRIES;
                 do
                 {
-                    while (!isVideoSwitch && !VideoDecoder.Frames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
+                    while (!isVideoSwitch && !vFrames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
                         Thread.Sleep(1);
 
                     if (vFrame == null)
@@ -433,7 +430,7 @@ unsafe partial class Player
 
             // Present Current | Render Next
             if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}{(secondField ? " | SF" : "")}");
-            if (decoder.VideoDecoder.Renderer.PresentPlay())
+            if (renderer.PresentPlay())
             {
                 framesDisplayed++;
                 UpdateCurTime(vFrame.timestamp, false);
@@ -459,7 +456,7 @@ unsafe partial class Player
                 vFrame          = null; // don't dispose (LastFrame)
                 secondField     = false;
                 dequeueRetries  = MAX_DEQUEUE_RETRIES;
-                while (!isVideoSwitch && !VideoDecoder.Frames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
+                while (!isVideoSwitch && !vFrames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
                     Thread.Sleep(1);
 
                 if (vFrame != null && !renderer.RenderPlay(vFrame, secondField))
@@ -692,7 +689,7 @@ unsafe partial class Player
     {
         long curLatency = GetBufferedDuration();
 
-        if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Frames: {VideoDecoder.Frames.Count} Packets: {VideoDemuxer.VideoPackets.Count} Speed: {speed}");
+        if (CanDebug) Log.Debug($"[Latency {curLatency/10000}ms] Frames: {vFrames.Count} Packets: {vPackets.Count} Speed: {speed}");
 
         if (curLatency <= Config.Player.MinLatency) // We've reached the down limit (back to speed x1)
         {
@@ -737,8 +734,8 @@ unsafe partial class Player
 
     long GetBufferedDuration() // No speed aware
         => renderer.FieldType != VideoFrameFormat.Progressive && Config.Video.DoubleRate ?
-        (VideoDecoder.Frames.Count + VideoDemuxer.VideoPackets.Count) * renderer.VideoStream.FrameDuration2 :
-        (VideoDecoder.Frames.Count + VideoDemuxer.VideoPackets.Count) * renderer.VideoStream.FrameDuration;
+        (vFrames.Count + vPackets.Count) * renderer.VideoStream.FrameDuration2 :
+        (vFrames.Count + vPackets.Count) * renderer.VideoStream.FrameDuration;
 
     void ScreamerVASDAudio()
     {

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -51,22 +51,6 @@ unsafe partial class Player
     long    onBufferingStarted;
     long    onBufferingCompleted;
 
-    int     vDistanceMs;
-    int     aDistanceMs;
-    int[]   sDistanceMss;
-    int     dDistanceMs;
-    int     sleepMs;
-
-    long    elapsedTicks;
-    long    startTicks;
-    long    showOneFrameTicks;
-
-    long    lastSpeedChangeTicks;
-    long    curLatency;
-    internal long curAudioDeviceDelay;
-
-    public int subNum => Config.Subtitles.Max;
-
     Stopwatch sw = new();
 
     private void ShowOneFrame()
@@ -237,6 +221,10 @@ unsafe partial class Player
 
     private void ScreamerReverse()
     {   // TBR: Timings / Rebuffer
+
+        int vDistanceMs, sleepMs;
+        long elapsedTicks, startTicks = 0;
+
         while (status == Status.Playing)
         {
             if (seeks.TryPop(out var seekData))

--- a/FlyleafLib/MediaPlayer/Player.Screamers.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.cs
@@ -59,7 +59,7 @@ unsafe partial class Player
         {
             sFrames[i] = null;
         }
-        if (!VideoDecoder.Frames.TryDequeue(out vFrame))
+        if (!vFrames.TryDequeue(out vFrame))
             return;
 
         renderer.RenderRequest(vFrame);
@@ -255,9 +255,9 @@ unsafe partial class Player
                 VideoDecoder.Start();
 
                 // Recoding*
-                while (VideoDecoder.Frames.IsEmpty && status == Status.Playing && VideoDecoder.IsRunning) Thread.Sleep(15);
+                while (vFrames.IsEmpty && status == Status.Playing && VideoDecoder.IsRunning) Thread.Sleep(15);
                 OnBufferingCompleted();
-                if (!VideoDecoder.Frames.TryDequeue(out vFrame))
+                if (!vFrames.TryDequeue(out vFrame))
                     { Log.Warn("No video frame"); break; }
 
                 startTicks = vFrame.timestamp;
@@ -298,7 +298,7 @@ unsafe partial class Player
 
             vFrame = null;
             int dequeueRetries  = MAX_DEQUEUE_RETRIES;
-            while (!isVideoSwitch && !VideoDecoder.Frames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
+            while (!isVideoSwitch && !vFrames.TryDequeue(out vFrame) && dequeueRetries-- > 0)
                 Thread.Sleep(1);
         }
         if (vFrame != null)

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -72,6 +72,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     /// (Normally you should not access this directly)
     /// </summary>
     public VideoDecoder         VideoDecoder;
+    ConcurrentQueue<VideoFrame> vFrames;
 
     /// <summary>
     /// Player's Renderer
@@ -125,6 +126,7 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     /// (Normally you should not access this directly)
     /// </summary>
     public Demuxer              VideoDemuxer;
+    PacketQueue vPackets;
 
     /// <summary>
     /// Subtitles Demuxer
@@ -211,9 +213,24 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
                         Chapters            => VideoDemuxer?.Chapters;
 
     /// <summary>
-    /// Player's current time or user's current seek time (uses backward direction or accurate seek based on Config.Player.SeekAccurate)
+    /// Player's current time or user's current seek time (useful for two-way slide bar binding)
     /// </summary>
-    public long         CurTime             { get => curTime;           set { if (Config.Player.SeekAccurate) SeekAccurate((int) (value/10000)); else Seek((int) (value/10000), false); } } // Note: forward seeking casues issues to some formats and can have serious delays (eg. dash with h264, dash with vp9 works fine)
+    public long         CurTime
+    {
+        get => curTime;
+        set
+        {
+            if (Config.Player.SeekAccurate)
+                SeekAccurate((int) (value/10000));
+            else
+                // Note: forward seeking casues issues to some formats and can have serious delays (eg. dash with h264, dash with vp9 works fine)
+                //  Seek forward only when not local file and we have a chance to find it in cache (we consider this comes from slide bars)
+                Seek((int)(value / 10000),
+                    Playlist.InputType != InputType.File && Video.isOpened &&
+                    value > VideoDemuxer.CurTime &&
+                    value < VideoDemuxer.CurTime + VideoDemuxer.BufferedDuration - TimeSpan.FromMilliseconds(300).Ticks);
+        }
+    }
     internal long _CurTime, curTime;
     internal void SetCurTime()
     {
@@ -554,7 +571,11 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         SubtitlesASR     = decoder.SubtitlesASR;
         DataDemuxer      = decoder.DataDemuxer;
         Playlist         = decoder.Playlist;
+
+        // We keep the same instance
         renderer         = VideoDecoder.Renderer;
+        vFrames          = VideoDecoder.Frames;
+        vPackets         = VideoDemuxer.VideoPackets;
 
         UpdateMainDemuxer();
         if (renderer != null)

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -504,6 +504,8 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
     volatile bool isAudioSwitch;
     volatile bool[] isSubsSwitches;
     volatile bool isDataSwitch;
+
+    public int subNum => Config.Subtitles.Max;
     #endregion
 
     public Player(Config config = null)
@@ -569,7 +571,6 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         decoder.OpenExternalVideoStreamCompleted       += Decoder_OpenExternalVideoStreamCompleted;
         decoder.OpenExternalSubtitlesStreamCompleted   += Decoder_OpenExternalSubtitlesStreamCompleted;
 
-        //AudioDecoder.CBufAlloc      = () => { if (aFrame != null) aFrame.dataPtr = IntPtr.Zero; aFrame = null; Audio.ClearBuffer(); aFrame = null; };
         AudioDecoder.CodecChanged   = Decoder_AudioCodecChanged;
         VideoDecoder.CodecChanged   = Decoder_VideoCodecChanged;
         decoder.RecordingCompleted += (o, e) => { IsRecording = false; };
@@ -578,7 +579,6 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
         // second subtitles
         sFrames = new SubtitlesFrame[subNum];
         sFramesPrev = new SubtitlesFrame[subNum];
-        sDistanceMss = new int[subNum];
         isSubsSwitches = new bool[subNum];
 
         status = Status.Stopped;

--- a/FlyleafLib/MediaPlayer/Video.cs
+++ b/FlyleafLib/MediaPlayer/Video.cs
@@ -146,10 +146,10 @@ public class Video : NotifyPropertyChanged
         pixelFormat = decoder.VideoStream.PixelFormatStr;
         framesTotal = decoder.VideoStream.TotalFrames;
         videoAcceleration
-                    = decoder.VideoDecoder.VideoAccelerated;
+                    = player.VideoDecoder.VideoAccelerated;
         hdrFormat   = decoder.VideoStream.HDRFormat;
         colorFormat = $"{decoder.VideoStream.ColorSpace}\r\n{decoder.VideoStream.ColorTransfer}\r\n{decoder.VideoStream.ColorRange}";
-        isOpened    =!decoder.VideoDecoder.Disposed;
+        isOpened    =!player.VideoDecoder.Disposed;
 
         player.ResetFrameStats();
         bitRate         = 0;

--- a/FlyleafLib/Utils/NativeMethods.cs
+++ b/FlyleafLib/Utils/NativeMethods.cs
@@ -7,6 +7,18 @@ public static partial class Utils
 {
     public static class NativeMethods
     {
+        public static WindowStyles SetWindowLong(nint hWnd, WindowStyles style)
+            => (WindowStyles)SetWindowLong(hWnd, (int)WindowLongFlags.GWL_STYLE, (nint)style);
+
+        public static WindowStylesEx SetWindowLong(nint hWnd, WindowStylesEx style)
+            => (WindowStylesEx)SetWindowLong(hWnd, (int)WindowLongFlags.GWL_EXSTYLE, (nint)style);
+
+        public static WindowStyles GetWindowLong(nint hWnd)
+            => (WindowStyles)GetWindowLong(hWnd, (int)WindowLongFlags.GWL_STYLE);
+
+        public static WindowStylesEx GetWindowLongEx(nint hWnd)
+            => (WindowStylesEx)GetWindowLong(hWnd, (int)WindowLongFlags.GWL_EXSTYLE);
+
         public static nint GetWindowLong(nint hWnd, int nIndex)
             => IntPtr.Size == 8 ? GetWindowLongPtr64(hWnd, nIndex) : GetWindowLongPtr32(hWnd, nIndex);
 
@@ -14,16 +26,16 @@ public static partial class Utils
             => IntPtr.Size == 8 ? SetWindowLongPtr64(hWnd, nIndex, dwNewLong) : SetWindowLongPtr32(hWnd, nIndex, dwNewLong);
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
-        public static extern nint GetWindowLongPtr32(nint hWnd, int nIndex);
+        static extern nint GetWindowLongPtr32(nint hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
-        public static extern nint GetWindowLongPtr64(nint hWnd, int nIndex);
+        static extern nint GetWindowLongPtr64(nint hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-        public static extern nint SetWindowLongPtr32(nint hWnd, int nIndex, nint dwNewLong);
+        static extern nint SetWindowLongPtr32(nint hWnd, int nIndex, nint dwNewLong);
 
         [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-        public static extern nint SetWindowLongPtr64(nint hWnd, int nIndex, nint dwNewLong);
+        static extern nint SetWindowLongPtr64(nint hWnd, int nIndex, nint dwNewLong);
 
         [DllImport("user32.dll")]
         public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);


### PR DESCRIPTION
Update FlyleafLib v3.9.3 from v3.9.2

## Changelog
- Config.Decoder: Introduces AudioCodec/VideoCodec/SubtitlesCodec to allow forcing the codec
- Config.Decoder: Introduces AllowDropFrames which handles decoder's skip_frame and AV_CODEC_FLAG_LOW_DELAY/AV_CODEC_FLAG2_FAST for low latency
- Config.Decoder: Introduces KeyFrameValidation which ensures no artifacts on some broken formats
- VideoDecoder: Fixes a possible issue with frame drops (with network streams) at decoder level
- Renderer.Present: Fixes an issue with ClearScreen when forced
- Renderer.PixelShader: Switching from OMSetBlendState to custom PixelShader alpha blending to avoid double blend with transparency
- Player.CurTime: Improves seeking forward when it has a chance to find it in cache
- FlyleafHost.Wpf: Adds full transparency support for media with alpha channel (through VideoBackground and Config.Video.BackgroundColor)
- FlyleafHost.Wpf: Introduces VideoBackground for Surface's Background color (deprecates Config.Video.BackgroundColor for this purpose)
- Updates Vortice

New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/08ed18b52e8d3b21255a2115b8798d9848e4bb1b...88bd869850f591cfe8764d4a862be8947aa22161