### PR TITLE
Update FlyleafLib v3.9.4

### DIFF
--- a/FlyleafLib/Controls/WPF/FlyleafHost.cs
+++ b/FlyleafLib/Controls/WPF/FlyleafHost.cs
@@ -79,6 +79,10 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
      */
 
     /* TODO
+     * 
+     * BUG: The initial detached when attached back it will create UI freezes
+     *  Generally fix SetWindowLongs and mix with direct access to ShowInTaskbar/WindowStyle etc..
+     * 
      * 1) The surface / overlay events code is repeated
      * 2) PassWheelToOwner (Related with LayoutUpdate performance / ScrollViewer) / ActivityRefresh
      * 3) Attach to different Owner (Load/Unload) and change Overlay?
@@ -835,6 +839,9 @@ public class FlyleafHost : ContentControl, IHostPlayer, IDisposable
             ResizeRatio();
             Surface.Show();
             Overlay?.Show();
+
+            if (curResizeRatio == 0 && Surface.ActualWidth > 10 && Surface.ActualHeight > 10)
+                curResizeRatio = Surface.ActualWidth / Surface.ActualHeight;
         }
     }
 

--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -614,7 +614,7 @@ public class Config : NotifyPropertyChanged
         /// <summary>
         /// Maximum audio frames to be decoded and processed for playback
         /// </summary>
-        public int              MaxAudioFrames      { get; set; } = 10;
+        public int              MaxAudioFrames      { get; set; } = 5;
 
         /// <summary>
         /// Maximum subtitle frames to be decoded

--- a/FlyleafLib/Engine/Engine.Audio.cs
+++ b/FlyleafLib/Engine/Engine.Audio.cs
@@ -57,6 +57,9 @@ public class AudioEngine : CallbackBase, IMMNotificationClient, INotifyPropertyC
         EnumerateDevices();
     }
 
+    /// <summary>
+    /// Enumerates Audio Capture Devices which can be retrieved from <see cref="CapDevices"/>
+    /// </summary>
     public void RefreshCapDevices()
     {
         lock (lockCapDevices)

--- a/FlyleafLib/Engine/Engine.Video.cs
+++ b/FlyleafLib/Engine/Engine.Video.cs
@@ -34,6 +34,9 @@ public class VideoEngine
         GPUAdapters = GetAdapters();
     }
 
+    /// <summary>
+    /// Enumerates Video Capture Devices which can be retrieved from <see cref="CapDevices"/>
+    /// </summary>
     public void RefreshCapDevices()
     {
         lock (lockCapDevices)

--- a/FlyleafLib/Engine/Engine.cs
+++ b/FlyleafLib/Engine/Engine.cs
@@ -199,13 +199,6 @@ public static class Engine
         FFmpeg  = new();
         Plugins = new();
         IsLoaded= true;
-
-        if (Config.FFmpegLoadProfile == LoadProfile.All)
-        {
-            Audio.RefreshCapDevices();
-            Video.RefreshCapDevices();
-        }
-
         Loaded?.Invoke(null, null);
 
         if (Config.UIRefresh)

--- a/FlyleafLib/FlyleafLib.csproj
+++ b/FlyleafLib/FlyleafLib.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <RepositoryUrl></RepositoryUrl>
     <Description>Media Player .NET Library for WinUI 3/WPF/WinForms (based on FFmpeg/DirectX)</Description>
-    <Version>3.9.3</Version>
+    <Version>3.9.4</Version>
     <Authors>SuRGeoNix</Authors>
     <Copyright>SuRGeoNix © 2025</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -787,6 +787,7 @@ public unsafe partial class DecoderContext : PluginHandler
                         }
 
                         // Accurate seek with +- half frame distance
+                        // TBR: Live streams should never been seeked at first place (maybe allow HLSLive?) * can cause infinite loop
                         if (timestamp != -1 && !VideoDemuxer.IsLive && (long)(frame->pts * VideoStream.Timebase) - VideoDemuxer.StartTime + (VideoStream.FrameDuration / 2) < timestamp)
                         {
                             av_frame_unref(frame);

--- a/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
+++ b/FlyleafLib/MediaFramework/MediaContext/DecoderContext.cs
@@ -787,7 +787,7 @@ public unsafe partial class DecoderContext : PluginHandler
                         }
 
                         // Accurate seek with +- half frame distance
-                        if (timestamp != -1 && (long)(frame->pts * VideoStream.Timebase) - VideoDemuxer.StartTime + (VideoStream.FrameDuration / 2) < timestamp)
+                        if (timestamp != -1 && !VideoDemuxer.IsLive && (long)(frame->pts * VideoStream.Timebase) - VideoDemuxer.StartTime + (VideoStream.FrameDuration / 2) < timestamp)
                         {
                             av_frame_unref(frame);
                             continue;

--- a/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
+++ b/FlyleafLib/MediaFramework/MediaDecoder/VideoDecoder.cs
@@ -71,7 +71,7 @@ public unsafe class VideoDecoder : DecoderBase
     {
         if (VideoStream == null) return;
         speed = value;
-        skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
+        skipSpeedFrames = speed * VideoStream.FPS / (Config.Video.MaxOutputFps + 1); // Give 1 fps breath as some streams can be 60.x fps instead - cp->framerate vs av_guess_frame_rate- which one is right?)
     }
 
     /// <summary>
@@ -656,7 +656,7 @@ public unsafe class VideoDecoder : DecoderBase
             VideoStream.Refresh(this, frame);
             codecChanged    = false;
             startPts        = VideoStream.StartTimePts;
-            skipSpeedFrames = speed * VideoStream.FPS / Config.Video.MaxOutputFps;
+            skipSpeedFrames = speed * VideoStream.FPS / (Config.Video.MaxOutputFps + 1);
             
             if (VideoStream.PixelFormat == AVPixelFormat.None || !Renderer.ConfigPlanes(frame))
             {

--- a/FlyleafLib/MediaFramework/MediaStream/AudioStream.cs
+++ b/FlyleafLib/MediaFramework/MediaStream/AudioStream.cs
@@ -61,7 +61,7 @@ public unsafe class AudioStream : StreamBase
         }
 
         if (frame->sample_rate > 0)
-            SampleRate = codecCtx->sample_rate;
+            SampleRate = frame->sample_rate;
         else if (codecCtx->sample_rate > 0)
             SampleRate = codecCtx->sample_rate;
 

--- a/FlyleafLib/MediaPlayer/Player.Open.cs
+++ b/FlyleafLib/MediaPlayer/Player.Open.cs
@@ -53,7 +53,7 @@ unsafe partial class Player
     #region Decoder Events
     private void Decoder_AudioCodecChanged(DecoderBase x)
     {
-        Audio.Refresh();
+        Audio.Refresh(true);
         UIAll();
     }
     private void Decoder_VideoCodecChanged(DecoderBase x)

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -15,7 +15,11 @@ unsafe partial class Player
 
     bool BufferVASD()
     {
-        long aDeviceDelay   = 0;
+        /* [Requires recoding]
+         * We have three different statuses during A/V opening: Closed/Failed, Opening, Opened (Opened means filled from codec / valid format after 'analyze')
+         *  we currently use isOpened only (as two statuses)
+         */
+
         bool gotAudio       = !Audio.IsOpened || Config.Player.MaxLatency != 0;
         bool gotVideo       = false;
         bool shouldStop     = false;
@@ -32,8 +36,6 @@ unsafe partial class Player
 
         if (Audio.isOpened && Config.Audio.Enabled)
         {
-            aDeviceDelay = Audio.GetDeviceDelay();
-
             if (AudioDecoder.OnVideoDemuxer)
                 AudioDecoder.Start();
             else if (!decoder.RequiresResync)
@@ -118,8 +120,10 @@ unsafe partial class Player
                 if (decoder.RequiresResync)
                     decoder.Resync(vFrame.timestamp);
 
-                if (!gotAudio && aFrame != null)
+                if (!gotAudio && aFrame != null && Audio.isOpened) // Could be closed from invalid sample rate
                 {
+                    long aDeviceDelay = Audio.GetDeviceDelay();
+
                     for (int i = 0; i < Math.Min(20, AudioDecoder.Frames.Count); i++)
                     {
                         if (aFrame == null
@@ -814,9 +818,10 @@ unsafe partial class Player
 
                 if (Math.Abs(waitTicks) > 5_000_0000) // Far away
                 {
+                    // TBR: Infinite loop with AllowFindStreamInfo = false on HLS Live (FirstTimestamp different between A/V)
                     Log.Warn($"[A] Late Frame ({TicksToTimeMini(waitTicks)})");
                     requiresBuffering = true;
-                    continue;
+                    break;
                 }
                 else if (waitTicks > 10_0000) // Not yet
                     continue;
@@ -867,7 +872,7 @@ unsafe partial class Player
                 //        Thread.Sleep(1);
                 Audio.ClearBuffer();
 
-                if (CanDebug) Log.Debug($"[A] Resynced at {TicksToTimeMini(aFrame.timestamp)} [Diff: {TicksToTimeMini((long)((aFrame.timestamp - startTicks) / speed) - delayTicks)} | {TicksToTimeMini((long)(sw.ElapsedTicks * SWFREQ_TO_TICKS))}]");
+                if (CanInfo) Log.Info($"[A] Resynced at {TicksToTimeMini(aFrame.timestamp)} [Diff: {TicksToTimeMini((long)((aFrame.timestamp - startTicks) / speed) - delayTicks)} | {TicksToTimeMini((long)(sw.ElapsedTicks * SWFREQ_TO_TICKS))}]");
 
                 // Fill Enough Samples
                 desyncMs = 0;
@@ -930,7 +935,7 @@ unsafe partial class Player
     uint showFrameCount, framesFailed, framesDisplayed, framesDisplayedDwm, framesDisplayedDwmStart, framesDisplayedDwmEnd;
     internal void ResetFrameStats()
     {
-        if (Config.Player.Stats && showFrameCount != 0)
+        if (Config.Player.Stats)
         {
             /*Video.fpsCurrent = */showFrameCount = framesFailed = framesDisplayed = framesDisplayedDwm = framesDisplayedDwmEnd = 0;
             UI(() => /*Video.FPSCurrent = */Video.FramesDropped = Video.FramesDisplayed = 0);

--- a/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
+++ b/FlyleafLib/MediaPlayer/Player.Screamers.VASD.cs
@@ -220,6 +220,7 @@ unsafe partial class Player
         int vDistanceMs, dDistanceMs;
         int[] sDistanceMss = new int[subNum];
         long elapsedTicks;
+        bool refreshed = false;
 
         while (status == Status.Playing)
         {
@@ -410,16 +411,30 @@ unsafe partial class Player
                 continue;
             }
 
-            // Thread Sleep in Parts | Restarts on Late Frame (2sec?)
+            // Thread Sleep in Parts | 60fps Idle Refresh | Restarts on Late Frame (2sec?)
             if (vDistanceMs > 2)
             {
                 if (vDistanceMs > 11)
                 {
-                    if (vDistanceMs > 2_000) // we might need to avoid disposing vFrame here (e.g. HLS wrapped and that's a keyframe?*)
+                    if (status != Status.Playing)
+                        break;
+
+                    // Late Frame (e.g. HLS wrapped and that's a keyframe?* -we might need to avoid disposing vFrame here)
+                    if (vDistanceMs > 2_000)
                     {
                         requiresBuffering = true;
                         Log.Warn($"[V] Late Frame ({vDistanceMs})");
                     }
+
+                    // Keep ~60fps Idle refresh | TBR: We could avoid preparing frame too early -for slow fps- (as we discard it here)
+                    else if (vDistanceMs > 16 && renderer.RefreshPlay(secondField))
+                    {
+                        if (CanTrace) Log.Trace($"[V] Refreshing {TicksToTime(vFrame.timestamp)}{(secondField ? " | SF" : "")}");
+                        framesDisplayed++;
+                        refreshed = true;
+                    }
+
+                    // Sleep 10ms and recalculate distance
                     else
                         Thread.Sleep(10);
 
@@ -430,14 +445,20 @@ unsafe partial class Player
             }
 
             // Present Current | Render Next
-            if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}{(secondField ? " | SF" : "")}");
-            if (renderer.PresentPlay())
+            if (!refreshed)
             {
-                framesDisplayed++;
-                UpdateCurTime(vFrame.timestamp, false);
+                if (CanTrace) Log.Trace($"[V] Presenting {TicksToTime(vFrame.timestamp)}{(secondField ? " | SF" : "")}");
+
+                if (renderer.PresentPlay())
+                {
+                    framesDisplayed++;
+                    UpdateCurTime(vFrame.timestamp, false);
+                }
+                else
+                    framesFailed++;
             }
             else
-                framesFailed++;
+                refreshed = false;
 
             if (Config.Player.MaxLatency != 0)
                 CheckLatency();
@@ -665,7 +686,8 @@ unsafe partial class Player
 
         if (vFrame != null && vFrame != renderer.LastFrame) // TBR: lock*?
             { VideoDecoder.DisposeFrame(vFrame); vFrame = null; }
-        renderer.RenderPlayStop();
+
+        renderer.RenderPlayStop();  // Calls RenderRequest which ensure present of the last rendered frame
         StopScreamerVASDAudio();
 
         if (Config.Player.Stats)

--- a/FlyleafLib/MediaPlayer/Player.cs
+++ b/FlyleafLib/MediaPlayer/Player.cs
@@ -195,8 +195,8 @@ public unsafe partial class Player : NotifyPropertyChanged, IDisposable
             }
         }
     }
-
-    internal Status _Status = Status.Stopped, status = Status.Stopped;
+    internal volatile Status status = Status.Stopped;
+    internal Status _Status = Status.Stopped;
     public bool         IsPlaying           => status == Status.Playing;
     public bool         IsOpening           => status == Status.Opening;
 

--- a/LLPlayer/ViewModels/MainWindowVM.cs
+++ b/LLPlayer/ViewModels/MainWindowVM.cs
@@ -161,6 +161,15 @@ public class MainWindowVM : Bindable
         {
             FL.Player.OpenAsync(App.CmdUrl);
         }
+
+        if (Engine.Config.FFmpegLoadProfile == Flyleaf.FFmpeg.LoadProfile.All)
+        {
+            Task.Run(() =>
+            {
+                Engine.Video.RefreshCapDevices();
+                Engine.Audio.RefreshCapDevices();
+            });
+        }
     });
 
     public DelegateCommand? CmdOnClosing => field ??= new(() =>


### PR DESCRIPTION
Update FlyleafLib v3.9.4 from v3.9.3

## Changelog
- Engine: Prevents enumeration of A/V capture devices during start to avoid delays
- VideoDecoder/VideoStream: Fixes an issue while FFmpeg announces 60.00x fps instead of 60fps that could cause video decoder to drop frames (based on Config.Video.MaxOutputFps limit)
- Player.ScreamerVASD: Adds an ~60 FPS idle renderer embedded during playback to provide smoother resize and filter updates when the source FPS or speed is low
- Player.Audio: Few stability improvements (mainly for non-analyzed inputs)

[Breaking Changes]
- Engine: A/V captures devices will require manual enumeration with Engine.Audio/Video.RefreshCapDevices() if needed
- Config.Decoder: Defaults MaxAudioFrames from 10 to 5 for better syncing, smooth speed changes and resolves possible issues with MaxLatency
New commits are cherry-picked from the following diff.

https://github.com/SuRGeoNix/Flyleaf/compare/88bd869850f591cfe8764d4a862be8947aa22161...262839d2230e0c21656be0b133384835d4fd10c1