### PR TITLE
Add option to auto-start ASR on media open

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -1131,6 +1131,12 @@ public class Config : NotifyPropertyChanged
         public bool OpenAutomaticSubs { get; set => Set(ref field, value); }
 
         /// <summary>
+        /// Whether to automatically start ASR (Whisper) on the primary subtitle when a media file is opened.
+        /// Skipped for live streams and when no ASR engine/model is available.
+        /// </summary>
+        public bool AutoStartASR { get; set => Set(ref field, value); }
+
+        /// <summary>
         /// Subtitle languages preference by priority
         /// </summary>
         public List<Language> Languages

--- a/LLPlayer/Controls/Settings/SettingsSubtitlesASR.xaml
+++ b/LLPlayer/Controls/Settings/SettingsSubtitlesASR.xaml
@@ -147,6 +147,27 @@
                         <ToggleButton
                             IsChecked="{Binding FL.PlayerConfig.Subtitles.WhisperConfig.Translate}" />
                     </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock
+                            Width="180">
+                            Auto Start on Open
+                            <InlineUIContainer BaselineAlignment="Center" Cursor="Help">
+                                <ToolTipService.ToolTip>
+                                    <TextBlock
+                                        Text="Automatically start ASR on the primary subtitle when a media file is opened, so AI subtitles begin without manual selection. Skipped for live streams and when the ASR engine/model is unavailable."
+                                        TextWrapping="Wrap"
+                                        MaxWidth="400" />
+                                </ToolTipService.ToolTip>
+                                <materialDesign:PackIcon
+                                    Kind="Information"
+                                    Width="16" Height="16"
+                                    Margin="4 0 0 0" />
+                            </InlineUIContainer>
+                        </TextBlock>
+                        <ToggleButton
+                            IsChecked="{Binding FL.PlayerConfig.Subtitles.AutoStartASR}" />
+                    </StackPanel>
                 </StackPanel>
             </GroupBox>
 

--- a/LLPlayer/ViewModels/MainWindowVM.cs
+++ b/LLPlayer/ViewModels/MainWindowVM.cs
@@ -155,6 +155,16 @@ public class MainWindowVM : Bindable
             Title = $"{name} - {App.Name}";
             TaskBarProgressValue = 0;
             TaskBarProgressState = TaskbarItemProgressState.Normal;
+
+            // Auto-start ASR on the primary subtitle when enabled.
+            // Pre-guarded (live / engine availability) so it silently no-ops instead of raising error dialogs.
+            if (FL.PlayerConfig.Subtitles.AutoStartASR
+                && !FL.Player.IsLive
+                && FL.Player.Audio.IsOpened
+                && FL.Player.SubtitlesASR.CanExecute(out _))
+            {
+                FL.Player.Commands.OpenSubtitlesASR.Execute("0");
+            }
         };
 
         if (App.CmdUrl != null)


### PR DESCRIPTION
## Summary

Adds an opt-in setting to automatically start ASR (Whisper) for the **primary** subtitle when a media file is opened, instead of selecting ASR manually from the primary CC menu every time.

## Motivation

ASR currently has to be triggered by hand for each file via the primary CC button. For users who use AI subtitles as their default subtitle source, this is a repeated manual step on every open. This adds a toggle so it can happen automatically.

## Changes

- **`FlyleafLib/Engine/Config.cs`** — new `SubtitlesConfig.AutoStartASR` bool, default `false` (preserves current behavior).
- **`LLPlayer/ViewModels/MainWindowVM.cs`** — in the existing `OpenCompleted` handler, when `AutoStartASR` is enabled, invoke the existing `OpenSubtitlesASR` command for the primary subtitle (`"0"`). Pre-guarded with `!IsLive`, `Audio.IsOpened`, and `SubtitlesASR.CanExecute(...)` so it silently no-ops (no error dialogs) when ASR isn't applicable — e.g. live streams or no model downloaded.
- **`LLPlayer/Controls/Settings/SettingsSubtitlesASR.xaml`** — "Auto Start on Open" toggle in the Whisper Common group, with an explanatory tooltip.

## Behavior

- Default **off** → no change for existing users.
- When **on**, opening a non-live media file with an available ASR engine/model starts ASR for the primary subtitle from the current position (so subtitles begin from the start on open).
- Reuses the existing command path, so all of its guards and error handling apply unchanged.

## Testing

- Builds clean and publishes via the existing `FolderProfile` (framework-dependent, single-file, ReadyToRun, win-x64).
- App launches; the new toggle appears under Settings → Subtitles → ASR.
- With the toggle enabled, ASR auto-starts on open via the existing `OpenSubtitlesASR` command; with it disabled, behavior is unchanged.
