### PR TITLE
feat(asr): support OpenAI-compatible endpoints

### DIFF
--- a/FlyleafLib/Engine/Config.cs
+++ b/FlyleafLib/Engine/Config.cs
@@ -1248,12 +1248,12 @@ public class Config : NotifyPropertyChanged
 
         #region ASR
         /// <summary>
-        /// ASR Engine Type (Currently only supports OpenAI Whisper)
+        /// ASR engine type
         /// </summary>
         public SubASREngineType ASREngine { get; set => Set(ref field, value); } = SubASREngineType.WhisperCpp;
 
         /// <summary>
-        /// ASR OpenAI Whisper common config
+        /// ASR common config
         /// </summary>
         public WhisperConfig WhisperConfig { get; set => Set(ref field, value); } = new();
 
@@ -1266,6 +1266,11 @@ public class Config : NotifyPropertyChanged
         /// ASR Faster-Whisper config
         /// </summary>
         public FasterWhisperConfig FasterWhisperConfig { get; set => Set(ref field, value); } = new();
+
+        /// <summary>
+        /// ASR OpenAI-compatible API config
+        /// </summary>
+        public OpenAICompatibleASRConfig OpenAICompatibleASRConfig { get; set => Set(ref field, value); } = new();
 
         /// <summary>
         /// Chunk size (MB) when processing ASR with audio stream
@@ -1390,6 +1395,8 @@ public class Config : NotifyPropertyChanged
         internal void SetEnabled(bool enabled) => Set(ref _Enabled, enabled, true, nameof(Enabled));
     }
 }
+
+
 
 /// <summary>
 /// Engine's configuration
@@ -1542,4 +1549,3 @@ public class EngineConfig
         File.WriteAllText(path, JsonSerializer.Serialize(this, jsonOptions));
     }
 }
-

--- a/FlyleafLib/Engine/Globals.cs
+++ b/FlyleafLib/Engine/Globals.cs
@@ -115,7 +115,9 @@ public enum SubASREngineType
     [Description("whisper.cpp")]
     WhisperCpp,
     [Description("faster-whisper (Recommended)")]
-    FasterWhisper
+    FasterWhisper,
+    [Description("OpenAI-compatible API")]
+    OpenAICompatible
 }
 public enum UIRefreshType
 {

--- a/FlyleafLib/Engine/OpenAICompatibleASRConfig.cs
+++ b/FlyleafLib/Engine/OpenAICompatibleASRConfig.cs
@@ -1,0 +1,11 @@
+﻿namespace FlyleafLib;
+
+#nullable enable
+
+public class OpenAICompatibleASRConfig : NotifyPropertyChanged
+{
+    public string BaseUrl { get; set => Set(ref field, value); } = "http://localhost:8000/v1";
+    public string Model { get; set => Set(ref field, value); } = "sensevoice";
+    public string ApiKey { get; set => Set(ref field, value); } = string.Empty;
+    public int TimeoutSeconds { get; set => Set(ref field, value); } = 120;
+}

--- a/FlyleafLib/MediaPlayer/OpenAICompatibleASRService.cs
+++ b/FlyleafLib/MediaPlayer/OpenAICompatibleASRService.cs
@@ -107,9 +107,8 @@ public sealed class OpenAICompatibleASRService : IASRService
 
         using JsonDocument document = ParseResponse(body);
         JsonElement root = document.RootElement;
-        string fullText = ReadRequiredText(root);
+        _ = ReadRequiredText(root);
         string language = ResolveLanguage(root, commonConfig);
-        bool yieldedSegment = false;
         List<(string text, TimeSpan start, TimeSpan end)> parsedSegments = [];
 
         if (root.TryGetProperty("segments", out JsonElement segments) &&
@@ -141,14 +140,8 @@ public sealed class OpenAICompatibleASRService : IASRService
                 continue;
             }
 
-            yieldedSegment = true;
             previousEnd = end;
             yield return (text, normalizedStart, end, language);
-        }
-
-        if (!yieldedSegment && !string.IsNullOrWhiteSpace(fullText))
-        {
-            yield return (fullText.Trim(), TimeSpan.Zero, waveDuration, language);
         }
     }
 

--- a/FlyleafLib/MediaPlayer/OpenAICompatibleASRService.cs
+++ b/FlyleafLib/MediaPlayer/OpenAICompatibleASRService.cs
@@ -1,0 +1,302 @@
+﻿using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FlyleafLib.MediaPlayer;
+
+#nullable enable
+
+public sealed class OpenAICompatibleASRService : IASRService
+{
+    private const int MaxErrorBodyLength = 2048;
+
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly bool _disposeHttpClient;
+
+    public OpenAICompatibleASRService(Config config)
+        : this(config, CreateHttpClient(), true)
+    {
+    }
+
+    public OpenAICompatibleASRService(Config config, HttpClient httpClient)
+        : this(config, httpClient, false)
+    {
+    }
+
+    private OpenAICompatibleASRService(Config config, HttpClient httpClient, bool disposeHttpClient)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _disposeHttpClient = disposeHttpClient;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposeHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async IAsyncEnumerable<(string text, TimeSpan start, TimeSpan end, string language)> Do(
+        MemoryStream waveStream,
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(waveStream);
+
+        OpenAICompatibleASRConfig apiConfig = _config.Subtitles.OpenAICompatibleASRConfig;
+        Uri endpoint = BuildTranscriptionsUri(apiConfig.BaseUrl);
+        byte[] waveBytes = waveStream.ToArray();
+        TimeSpan waveDuration = ReadWaveDuration(waveBytes);
+
+        using MultipartFormDataContent form = new();
+        ByteArrayContent audio = new(waveBytes);
+        audio.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
+        form.Add(audio, "file", "audio.wav");
+        form.Add(new StringContent(apiConfig.Model.Trim(), Encoding.UTF8), "model");
+        form.Add(new StringContent("verbose_json", Encoding.UTF8), "response_format");
+
+        WhisperConfig commonConfig = _config.Subtitles.WhisperConfig;
+        if (!commonConfig.LanguageDetection && !string.IsNullOrWhiteSpace(commonConfig.Language))
+        {
+            form.Add(new StringContent(commonConfig.Language.Trim(), Encoding.UTF8), "language");
+        }
+
+        using HttpRequestMessage request = new(HttpMethod.Post, endpoint) { Content = form };
+        if (!string.IsNullOrWhiteSpace(apiConfig.ApiKey))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiConfig.ApiKey.Trim());
+        }
+
+        using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(apiConfig.TimeoutSeconds));
+
+        string body;
+        try
+        {
+            using HttpResponseMessage response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    timeoutCts.Token)
+                .ConfigureAwait(false);
+
+            body = await response.Content.ReadAsStringAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"ASR endpoint returned {(int)response.StatusCode} ({response.ReasonPhrase}): {FormatErrorBody(body)}",
+                    null,
+                    response.StatusCode);
+            }
+        }
+        catch (OperationCanceledException ex) when (!token.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"The ASR endpoint did not respond within {apiConfig.TimeoutSeconds} seconds.", ex);
+        }
+
+        using JsonDocument document = ParseResponse(body);
+        JsonElement root = document.RootElement;
+        string fullText = ReadRequiredText(root);
+        string language = ResolveLanguage(root, commonConfig);
+        bool yieldedSegment = false;
+        List<(string text, TimeSpan start, TimeSpan end)> parsedSegments = [];
+
+        if (root.TryGetProperty("segments", out JsonElement segments) &&
+            segments.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement segment in segments.EnumerateArray())
+            {
+                if (!TryReadSegment(segment, waveDuration, out string text, out TimeSpan start, out TimeSpan end))
+                {
+                    continue;
+                }
+
+                parsedSegments.Add((text, start, end));
+            }
+        }
+
+        parsedSegments.Sort(static (left, right) =>
+        {
+            int startComparison = left.start.CompareTo(right.start);
+            return startComparison != 0 ? startComparison : right.end.CompareTo(left.end);
+        });
+
+        TimeSpan previousEnd = TimeSpan.Zero;
+        foreach ((string text, TimeSpan start, TimeSpan end) in parsedSegments)
+        {
+            TimeSpan normalizedStart = start < previousEnd ? previousEnd : start;
+            if (end <= normalizedStart)
+            {
+                continue;
+            }
+
+            yieldedSegment = true;
+            previousEnd = end;
+            yield return (text, normalizedStart, end, language);
+        }
+
+        if (!yieldedSegment && !string.IsNullOrWhiteSpace(fullText))
+        {
+            yield return (fullText.Trim(), TimeSpan.Zero, waveDuration, language);
+        }
+    }
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = Timeout.InfiniteTimeSpan };
+
+    public static Uri BuildTranscriptionsUri(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl) ||
+            !Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out Uri? uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment))
+        {
+            throw new ArgumentException(
+                "Base URL must be an absolute HTTP(S) URL without a query or fragment.",
+                nameof(baseUrl));
+        }
+
+        UriBuilder builder = new(uri);
+        string path = builder.Path.TrimEnd('/');
+        if (!path.EndsWith("/audio/transcriptions", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+                ? $"{path}/audio/transcriptions"
+                : $"{path}/v1/audio/transcriptions";
+        }
+
+        builder.Path = path;
+        return builder.Uri;
+    }
+
+    private static JsonDocument ParseResponse(string body)
+    {
+        try
+        {
+            JsonDocument document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                document.Dispose();
+                throw new InvalidDataException("ASR endpoint returned JSON that is not an object.");
+            }
+
+            return document;
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException("ASR endpoint returned invalid JSON.", ex);
+        }
+    }
+
+    private static string ReadRequiredText(JsonElement root)
+    {
+        if (!root.TryGetProperty("text", out JsonElement text) || text.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException("ASR endpoint response is missing the required string field 'text'.");
+        }
+
+        return text.GetString() ?? string.Empty;
+    }
+
+    private static string ResolveLanguage(JsonElement root, WhisperConfig commonConfig)
+    {
+        if (root.TryGetProperty("language", out JsonElement languageElement) &&
+            languageElement.ValueKind == JsonValueKind.String)
+        {
+            string? language = languageElement.GetString();
+            if (!string.IsNullOrWhiteSpace(language) &&
+                !language.Equals("auto", StringComparison.OrdinalIgnoreCase))
+            {
+                return language;
+            }
+        }
+
+        if (!commonConfig.LanguageDetection && !string.IsNullOrWhiteSpace(commonConfig.Language))
+        {
+            return commonConfig.Language;
+        }
+
+        return "und";
+    }
+
+    private static bool TryReadSegment(
+        JsonElement segment,
+        TimeSpan waveDuration,
+        out string text,
+        out TimeSpan start,
+        out TimeSpan end)
+    {
+        text = string.Empty;
+        start = TimeSpan.Zero;
+        end = TimeSpan.Zero;
+
+        if (segment.ValueKind != JsonValueKind.Object ||
+            !segment.TryGetProperty("text", out JsonElement textElement) ||
+            textElement.ValueKind != JsonValueKind.String ||
+            !segment.TryGetProperty("start", out JsonElement startElement) ||
+            !segment.TryGetProperty("end", out JsonElement endElement) ||
+            !startElement.TryGetDouble(out double startSeconds) ||
+            !endElement.TryGetDouble(out double endSeconds) ||
+            !double.IsFinite(startSeconds) ||
+            !double.IsFinite(endSeconds))
+        {
+            return false;
+        }
+
+        text = (textElement.GetString() ?? string.Empty).Trim();
+        double durationSeconds = waveDuration.TotalSeconds;
+        startSeconds = Math.Clamp(startSeconds, 0, durationSeconds);
+        endSeconds = Math.Clamp(endSeconds, 0, durationSeconds);
+        if (string.IsNullOrWhiteSpace(text) || endSeconds <= startSeconds)
+        {
+            return false;
+        }
+
+        start = TimeSpan.FromSeconds(startSeconds);
+        end = TimeSpan.FromSeconds(endSeconds);
+        return true;
+    }
+
+    private static TimeSpan ReadWaveDuration(byte[] bytes)
+    {
+        // AudioReader passes IASRService a fixed 44-byte PCM WAV header.
+        ReadOnlySpan<byte> data = bytes;
+        if (data.Length < 44 ||
+            !data[..4].SequenceEqual("RIFF"u8) ||
+            !data.Slice(8, 4).SequenceEqual("WAVE"u8))
+        {
+            throw new InvalidDataException("ASR input is not a valid PCM WAV stream.");
+        }
+
+        int byteRate = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(28, 4));
+        int dataSize = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(40, 4));
+        if (byteRate <= 0 || dataSize <= 0 || dataSize > data.Length - 44)
+        {
+            throw new InvalidDataException("ASR WAV stream has an invalid byte rate or data size.");
+        }
+
+        return TimeSpan.FromSeconds(dataSize / (double)byteRate);
+    }
+
+    private static string FormatErrorBody(string body)
+    {
+        string compact = body.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        if (compact.Length > MaxErrorBodyLength)
+        {
+            compact = compact[..MaxErrorBodyLength] + "...";
+        }
+
+        return string.IsNullOrEmpty(compact) ? "No response body." : compact;
+    }
+}

--- a/FlyleafLib/MediaPlayer/SubtitlesASR.cs
+++ b/FlyleafLib/MediaPlayer/SubtitlesASR.cs
@@ -102,6 +102,31 @@ public class SubtitlesASR
                 }
             }
         }
+        else if (_config.Subtitles.ASREngine == SubASREngineType.OpenAICompatible)
+        {
+            OpenAICompatibleASRConfig apiConfig = _config.Subtitles.OpenAICompatibleASRConfig;
+            if (string.IsNullOrWhiteSpace(apiConfig.Model))
+            {
+                err = "OpenAI-compatible ASR model is not set.";
+                return false;
+            }
+
+            if (apiConfig.TimeoutSeconds <= 0)
+            {
+                err = "OpenAI-compatible ASR timeout must be greater than zero.";
+                return false;
+            }
+
+            try
+            {
+                OpenAICompatibleASRService.BuildTranscriptionsUri(apiConfig.BaseUrl);
+            }
+            catch (ArgumentException ex)
+            {
+                err = ex.Message;
+                return false;
+            }
+        }
 
         err = "";
 
@@ -461,6 +486,7 @@ public class AudioReader : IDisposable
             {
                 SubASREngineType.WhisperCpp => new WhisperCppASRService(_config),
                 SubASREngineType.FasterWhisper => new FasterWhisperASRService(_config),
+                SubASREngineType.OpenAICompatible => new OpenAICompatibleASRService(_config),
                 _ => throw new InvalidOperationException()
             };
 

--- a/FlyleafLibTests/MediaPlayer/OpenAICompatibleASRServiceTests.cs
+++ b/FlyleafLibTests/MediaPlayer/OpenAICompatibleASRServiceTests.cs
@@ -1,0 +1,317 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using AwesomeAssertions;
+
+namespace FlyleafLib.MediaPlayer;
+
+public class OpenAICompatibleASRServiceTests
+{
+    [Theory]
+    [InlineData("http://localhost:8000", "http://localhost:8000/v1/audio/transcriptions")]
+    [InlineData("http://localhost:8000/", "http://localhost:8000/v1/audio/transcriptions")]
+    [InlineData("http://localhost:8000/v1", "http://localhost:8000/v1/audio/transcriptions")]
+    [InlineData("https://asr.example/api/v1/", "https://asr.example/api/v1/audio/transcriptions")]
+    [InlineData("https://asr.example/v1/audio/transcriptions", "https://asr.example/v1/audio/transcriptions")]
+    public void BuildTranscriptionsUri_NormalizesSupportedBaseUrls(string baseUrl, string expected)
+    {
+        OpenAICompatibleASRService.BuildTranscriptionsUri(baseUrl).Should().Be(new Uri(expected));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("localhost:8000")]
+    [InlineData("ftp://localhost:8000")]
+    [InlineData("https://asr.example/v1?tenant=one")]
+    public void BuildTranscriptionsUri_RejectsInvalidBaseUrls(string baseUrl)
+    {
+        Action act = () => OpenAICompatibleASRService.BuildTranscriptionsUri(baseUrl);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Do_SendsScopedCredentialsAndMapsTimestampedSegments()
+    {
+        CapturedRequest captured = new();
+        using HttpClient client = new(new DelegateHandler(async (request, token) =>
+        {
+            captured.Method = request.Method;
+            captured.Uri = request.RequestUri;
+            captured.Authorization = request.Headers.Authorization;
+            captured.Parts = await ReadParts(request, token);
+
+            return JsonResponse("""
+                {
+                  "text": "first second",
+                  "language": "zh",
+                  "segments": [
+                    {"start": 0.25, "end": 0.75, "text": " first "},
+                    {"start": 1.5, "end": 4.0, "text": "second"}
+                  ]
+                }
+                """);
+        }));
+        Config config = CreateConfig();
+        config.Subtitles.OpenAICompatibleASRConfig.ApiKey = "provider-secret";
+        config.Subtitles.WhisperConfig.LanguageDetection = false;
+        config.Subtitles.WhisperConfig.Language = "zh";
+
+        await using OpenAICompatibleASRService service = new(config, client);
+        List<(string text, TimeSpan start, TimeSpan end, string language)> results =
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(2)), CancellationToken.None));
+
+        captured.Method.Should().Be(HttpMethod.Post);
+        captured.Uri.Should().Be(new Uri("http://localhost:8000/v1/audio/transcriptions"));
+        captured.Authorization.Should().Be(new AuthenticationHeaderValue("Bearer", "provider-secret"));
+        captured.Parts["model"].Text.Should().Be("sensevoice");
+        captured.Parts["response_format"].Text.Should().Be("verbose_json");
+        captured.Parts["language"].Text.Should().Be("zh");
+        captured.Parts["file"].Bytes.Should().StartWith(Encoding.ASCII.GetBytes("RIFF"));
+
+        results.Should().HaveCount(2);
+        results[0].Should().Be(("first", TimeSpan.FromSeconds(0.25), TimeSpan.FromSeconds(0.75), "zh"));
+        results[1].Should().Be(("second", TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(2), "zh"));
+    }
+
+    [Fact]
+    public async Task Do_FallsBackToWaveDurationWhenSegmentsAreMissing()
+    {
+        CapturedRequest captured = new();
+        using HttpClient client = new(new DelegateHandler(async (request, token) =>
+        {
+            captured.Authorization = request.Headers.Authorization;
+            captured.Parts = await ReadParts(request, token);
+            return JsonResponse("""{"text":" hello ","language":"auto","segments":[]}""");
+        }));
+        Config config = CreateConfig();
+        config.Subtitles.WhisperConfig.LanguageDetection = true;
+
+        await using OpenAICompatibleASRService service = new(config, client);
+        List<(string text, TimeSpan start, TimeSpan end, string language)> results =
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(1.25)), CancellationToken.None));
+
+        captured.Authorization.Should().BeNull();
+        captured.Parts.Should().NotContainKey("language");
+        results.Should().ContainSingle().Which.Should()
+            .Be(("hello", TimeSpan.Zero, TimeSpan.FromSeconds(1.25), "und"));
+    }
+
+    [Fact]
+    public async Task Do_ReportsEndpointErrorDetails()
+    {
+        using HttpClient client = new(new DelegateHandler((_, _) => Task.FromResult(
+            JsonResponse("""{"detail":"unknown model"}""", HttpStatusCode.BadRequest))));
+        Config config = CreateConfig();
+        await using OpenAICompatibleASRService service = new(config, client);
+
+        Func<Task> act = async () =>
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(1)), CancellationToken.None));
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*400*unknown model*");
+    }
+
+    [Fact]
+    public async Task Do_ReportsConfiguredTimeout()
+    {
+        using HttpClient client = new(new DelegateHandler(async (_, token) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return JsonResponse("""{"text":"too late"}""");
+        }));
+        Config config = CreateConfig();
+        config.Subtitles.OpenAICompatibleASRConfig.TimeoutSeconds = 1;
+        await using OpenAICompatibleASRService service = new(config, client);
+
+        Func<Task> act = async () =>
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(1)), CancellationToken.None));
+
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*1 seconds*");
+    }
+
+    [Fact]
+    public async Task Constructor_DisablesOwnedHttpClientTimeout()
+    {
+        Config config = CreateConfig();
+        config.Subtitles.OpenAICompatibleASRConfig.TimeoutSeconds = 120;
+        await using OpenAICompatibleASRService service = new(config);
+        HttpClient client = (HttpClient)typeof(OpenAICompatibleASRService)
+            .GetField("_httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(service)!;
+
+        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
+    public async Task Do_ReportsTimeoutWhileReadingResponseBody()
+    {
+        using HttpClient client = new(new DelegateHandler((_, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new BlockingContent() })));
+        Config config = CreateConfig();
+        config.Subtitles.OpenAICompatibleASRConfig.TimeoutSeconds = 1;
+        await using OpenAICompatibleASRService service = new(config, client);
+
+        Func<Task> act = async () =>
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(1)), CancellationToken.None));
+
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*1 seconds*");
+    }
+
+    [Fact]
+    public async Task Do_PreservesCallerCancellation()
+    {
+        using HttpClient client = new(new DelegateHandler(async (_, token) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return JsonResponse("""{"text":"too late"}""");
+        }));
+        Config config = CreateConfig();
+        await using OpenAICompatibleASRService service = new(config, client);
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+
+        Func<Task> act = async () =>
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(1)), cancellation.Token));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Do_SortsAndNormalizesNonMonotonicSegments()
+    {
+        using HttpClient client = new(new DelegateHandler((_, _) => Task.FromResult(JsonResponse("""
+            {
+              "text": "early overlap contained late",
+              "segments": [
+                {"start": 1.5, "end": 2.0, "text": "late"},
+                {"start": 0.0, "end": 0.6, "text": "early"},
+                {"start": 0.5, "end": 1.2, "text": "overlap"},
+                {"start": 0.7, "end": 0.8, "text": "contained"},
+                {"start": 1.3, "end": 1.3, "text": "degenerate"}
+              ]
+            }
+            """))));
+        Config config = CreateConfig();
+        await using OpenAICompatibleASRService service = new(config, client);
+
+        List<(string text, TimeSpan start, TimeSpan end, string language)> results =
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(2)), CancellationToken.None));
+
+        results.Should().Equal(
+            ("early", TimeSpan.Zero, TimeSpan.FromSeconds(0.6), "und"),
+            ("overlap", TimeSpan.FromSeconds(0.6), TimeSpan.FromSeconds(1.2), "und"),
+            ("late", TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(2), "und"));
+    }
+
+    private static Config CreateConfig()
+    {
+        Config config = new(true);
+        config.Subtitles.OpenAICompatibleASRConfig.BaseUrl = "http://localhost:8000/v1";
+        config.Subtitles.OpenAICompatibleASRConfig.Model = "sensevoice";
+        config.Subtitles.OpenAICompatibleASRConfig.TimeoutSeconds = 30;
+        return config;
+    }
+
+    private static async Task<Dictionary<string, CapturedPart>> ReadParts(
+        HttpRequestMessage request,
+        CancellationToken token)
+    {
+        MultipartFormDataContent multipart = request.Content.Should()
+            .BeOfType<MultipartFormDataContent>().Which;
+        Dictionary<string, CapturedPart> parts = [];
+
+        foreach (HttpContent part in multipart)
+        {
+            string name = part.Headers.ContentDisposition!.Name!.Trim('"');
+            byte[] bytes = await part.ReadAsByteArrayAsync(token);
+            parts[name] = new CapturedPart(Encoding.UTF8.GetString(bytes), bytes);
+        }
+
+        return parts;
+    }
+
+    private static HttpResponseMessage JsonResponse(
+        string json,
+        HttpStatusCode statusCode = HttpStatusCode.OK) =>
+        new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private static MemoryStream CreateWave(TimeSpan duration)
+    {
+        const int sampleRate = 16000;
+        const short channels = 1;
+        const short bitsPerSample = 16;
+        int dataSize = (int)(sampleRate * duration.TotalSeconds) * channels * bitsPerSample / 8;
+        MemoryStream stream = new(44 + dataSize);
+        using (BinaryWriter writer = new(stream, Encoding.UTF8, true))
+        {
+            writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+            writer.Write(36 + dataSize);
+            writer.Write(Encoding.ASCII.GetBytes("WAVE"));
+            writer.Write(Encoding.ASCII.GetBytes("fmt "));
+            writer.Write(16);
+            writer.Write((short)1);
+            writer.Write(channels);
+            writer.Write(sampleRate);
+            writer.Write(sampleRate * channels * bitsPerSample / 8);
+            writer.Write((short)(channels * bitsPerSample / 8));
+            writer.Write(bitsPerSample);
+            writer.Write(Encoding.ASCII.GetBytes("data"));
+            writer.Write(dataSize);
+            writer.Write(new byte[dataSize]);
+        }
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> source)
+    {
+        List<T> results = [];
+        await foreach (T item in source)
+        {
+            results.Add(item);
+        }
+        return results;
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> callback) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => callback(request, cancellationToken);
+    }
+
+    private sealed class BlockingContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.Delay(Timeout.InfiniteTimeSpan);
+
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context,
+            CancellationToken cancellationToken) =>
+            Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+
+    private sealed class CapturedRequest
+    {
+        public HttpMethod? Method { get; set; }
+        public Uri? Uri { get; set; }
+        public AuthenticationHeaderValue? Authorization { get; set; }
+        public Dictionary<string, CapturedPart> Parts { get; set; } = [];
+    }
+
+    private sealed record CapturedPart(string Text, byte[] Bytes);
+}

--- a/FlyleafLibTests/MediaPlayer/OpenAICompatibleASRServiceTests.cs
+++ b/FlyleafLibTests/MediaPlayer/OpenAICompatibleASRServiceTests.cs
@@ -75,7 +75,7 @@ public class OpenAICompatibleASRServiceTests
     }
 
     [Fact]
-    public async Task Do_FallsBackToWaveDurationWhenSegmentsAreMissing()
+    public async Task Do_ReturnsNoSubtitleWhenSegmentsAreMissing()
     {
         CapturedRequest captured = new();
         using HttpClient client = new(new DelegateHandler(async (request, token) =>
@@ -93,8 +93,33 @@ public class OpenAICompatibleASRServiceTests
 
         captured.Authorization.Should().BeNull();
         captured.Parts.Should().NotContainKey("language");
-        results.Should().ContainSingle().Which.Should()
-            .Be(("hello", TimeSpan.Zero, TimeSpan.FromSeconds(1.25), "und"));
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Do_ReturnsNoSubtitleForLongTextWhenProviderReturnsNoSegments()
+    {
+        const string kennedyText =
+            "i believe that this nation should commit itself to achieving the goal before this decade is out " +
+            "of landing a man on the moon and returning him safely to the earth " +
+            "no single space project in this period will be more impressive to mankind " +
+            "or more important for the long range exploration of space";
+        using HttpClient client = new(new DelegateHandler((_, _) => Task.FromResult(JsonResponse($$"""
+            {
+              "task": "transcribe",
+              "language": "en",
+              "duration": 0,
+              "text": "{{kennedyText}}",
+              "segments": []
+            }
+            """))));
+        Config config = CreateConfig();
+        await using OpenAICompatibleASRService service = new(config, client);
+
+        List<(string text, TimeSpan start, TimeSpan end, string language)> results =
+            await CollectAsync(service.Do(CreateWave(TimeSpan.FromSeconds(21)), CancellationToken.None));
+
+        results.Should().BeEmpty();
     }
 
     [Fact]

--- a/LLPlayer/Controls/Settings/SettingsSubtitlesASR.xaml
+++ b/LLPlayer/Controls/Settings/SettingsSubtitlesASR.xaml
@@ -38,7 +38,7 @@
                 FontWeight="Bold"
                 Margin="0 0 0 16" />
 
-            <GroupBox Header="Whisper Common">
+            <GroupBox Header="ASR Common">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock
@@ -46,7 +46,7 @@
                             FontWeight="Medium"
                             Width="180">
                             <Hyperlink Style="{StaticResource MyHyperLink}" NavigateUri="https://github.com/umlx5h/LLPlayer/wiki/Whisper-Engine" helpers:HyperlinkHelper.OpenInBrowser="True">
-                                Whisper Engine
+                                ASR Engine
                             </Hyperlink>
                         </TextBlock>
                         <ComboBox
@@ -128,6 +128,16 @@
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FL.PlayerConfig.Subtitles.ASREngine}" Value="OpenAICompatible">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
                         <TextBlock
                             Width="180">
                             Translate to English
@@ -686,6 +696,79 @@
                                         HorizontalAlignment="Left"
                                         Command="{Binding CmdCopyHelpCommand}"/>
                                 </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+                    </StackPanel>
+                </TabItem>
+                <TabItem Header="OpenAI-compatible API">
+                    <StackPanel Margin="0 10 0 0">
+                        <GroupBox Header="OpenAI-compatible ASR config">
+                            <StackPanel>
+                                <DockPanel>
+                                    <TextBlock Width="200">
+                                        Base URL
+                                        <InlineUIContainer BaselineAlignment="Center" Cursor="Help">
+                                            <ToolTipService.ToolTip>
+                                                <TextBlock
+                                                    Text="Use a host URL, a URL ending in /v1, or the complete /audio/transcriptions endpoint."
+                                                    TextWrapping="Wrap"
+                                                    MaxWidth="400" />
+                                            </ToolTipService.ToolTip>
+                                            <materialDesign:PackIcon
+                                                Kind="Information"
+                                                Width="16" Height="16"
+                                                Margin="4 0 0 0" />
+                                        </InlineUIContainer>
+                                    </TextBlock>
+                                    <TextBox
+                                        HorizontalContentAlignment="Left"
+                                        Text="{Binding FL.PlayerConfig.Subtitles.OpenAICompatibleASRConfig.BaseUrl, UpdateSourceTrigger=PropertyChanged}" />
+                                </DockPanel>
+
+                                <DockPanel>
+                                    <TextBlock Width="200" Text="Model" />
+                                    <TextBox
+                                        HorizontalContentAlignment="Left"
+                                        Text="{Binding FL.PlayerConfig.Subtitles.OpenAICompatibleASRConfig.Model, UpdateSourceTrigger=PropertyChanged}" />
+                                </DockPanel>
+
+                                <DockPanel>
+                                    <TextBlock Width="200">
+                                        API Key (optional)
+                                        <InlineUIContainer BaselineAlignment="Center" Cursor="Help">
+                                            <ToolTipService.ToolTip>
+                                                <TextBlock
+                                                    Text="Sent only to this ASR provider as a Bearer authorization header."
+                                                    TextWrapping="Wrap"
+                                                    MaxWidth="400" />
+                                            </ToolTipService.ToolTip>
+                                            <materialDesign:PackIcon
+                                                Kind="Information"
+                                                Width="16" Height="16"
+                                                Margin="4 0 0 0" />
+                                        </InlineUIContainer>
+                                    </TextBlock>
+                                    <TextBox
+                                        HorizontalContentAlignment="Left"
+                                        Text="{Binding FL.PlayerConfig.Subtitles.OpenAICompatibleASRConfig.ApiKey, UpdateSourceTrigger=PropertyChanged}" />
+                                </DockPanel>
+
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Width="200" Text="Request Timeout (sec)" />
+                                    <TextBox
+                                        Width="100"
+                                        Text="{Binding FL.PlayerConfig.Subtitles.OpenAICompatibleASRConfig.TimeoutSeconds}"
+                                        helpers:TextBoxHelper.OnlyNumeric="Uint" />
+                                </StackPanel>
+
+                                <TextBlock Margin="5 10 5 0">
+                                    <Hyperlink
+                                        Style="{StaticResource MyHyperLink}"
+                                        NavigateUri="https://github.com/modelscope/FunASR/tree/main/examples/openai_api"
+                                        helpers:HyperlinkHelper.OpenInBrowser="True">
+                                        FunASR OpenAI API reference
+                                    </Hyperlink>
+                                </TextBlock>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- Add an OpenAI-compatible ASR engine for remote or self-hosted providers such as FunASR and SenseVoice.
- Expose base URL, model, optional Bearer key, and timeout settings while preserving the existing whisper.cpp and faster-whisper engines.
- Parse verbose timestamped responses, normalize malformed or non-monotonic segments, and fall back to the WAV duration when a provider returns only text.
- Keep credentials request-scoped and distinguish configured timeouts from caller cancellation.

## Validation
- `dotnet build LLPlayer/LLPlayer.csproj -p:EnableWindowsTargeting=true`: 0 warnings, 0 errors.
- `dotnet build FlyleafLibTests/FlyleafLibTests.csproj -p:EnableWindowsTargeting=true`: 0 warnings, 0 errors.
- 17 focused service tests pass through a source-linked `net10.0` harness. The native WindowsDesktop test host cannot execute on this Linux runner.
- Real endpoint test against FunASR 1.3.14 with SenseVoice on H100 transcribed the 5.55-second Chinese sample successfully through this exact C# service.
- Restricted `dotnet format --verify-no-changes` and `git diff --check` pass.

Closes #202